### PR TITLE
Prevent rebuilding aggregate with events of another aggregate type as command

### DIFF
--- a/eventhorizon_test.go
+++ b/eventhorizon_test.go
@@ -66,6 +66,54 @@ func (t *TestCommand) AggregateID() UUID     { return t.TestID }
 func (t *TestCommand) AggregateType() string { return "TestAggregate" }
 func (t *TestCommand) CommandType() string   { return "TestCommand" }
 
+type TestAggregate2 struct {
+	*AggregateBase
+
+	dispatchedCommand Command
+	appliedEvent      Event
+	numHandled        int
+}
+
+func (a *TestAggregate2) AggregateType() string {
+	return "TestAggregate2"
+}
+
+func (a *TestAggregate2) HandleCommand(command Command) error {
+	a.dispatchedCommand = command
+	a.numHandled++
+	switch command := command.(type) {
+	case *TestCommand2:
+		if command.Content == "error" {
+			return errors.New("command error")
+		}
+		a.StoreEvent(&TestEvent2{command.TestID, command.Content})
+		return nil
+	}
+	return errors.New("couldn't handle command")
+}
+
+func (a *TestAggregate2) ApplyEvent(event Event) {
+	a.appliedEvent = event
+}
+
+type TestEvent2 struct {
+	TestID  UUID
+	Content string
+}
+
+func (t *TestEvent2) AggregateID() UUID     { return t.TestID }
+func (t *TestEvent2) AggregateType() string { return "TestAggregate2" }
+func (t *TestEvent2) EventType() string     { return "TestEvent2" }
+
+type TestCommand2 struct {
+	TestID  UUID
+	Content string
+}
+
+func (t *TestCommand2) AggregateID() UUID     { return t.TestID }
+func (t *TestCommand2) AggregateType() string { return "TestAggregate2" }
+func (t *TestCommand2) CommandType() string   { return "TestCommand2" }
+
 type MockRepository struct {
 	Aggregates map[UUID]Aggregate
 }

--- a/eventhorizon_test.go
+++ b/eventhorizon_test.go
@@ -54,7 +54,7 @@ type TestEvent struct {
 }
 
 func (t *TestEvent) AggregateID() UUID     { return t.TestID }
-func (t *TestEvent) AggregateType() string { return "Test" }
+func (t *TestEvent) AggregateType() string { return "TestAggregate" }
 func (t *TestEvent) EventType() string     { return "TestEvent" }
 
 type TestCommand struct {
@@ -63,7 +63,7 @@ type TestCommand struct {
 }
 
 func (t *TestCommand) AggregateID() UUID     { return t.TestID }
-func (t *TestCommand) AggregateType() string { return "Test" }
+func (t *TestCommand) AggregateType() string { return "TestAggregate" }
 func (t *TestCommand) CommandType() string   { return "TestCommand" }
 
 type MockRepository struct {

--- a/repository.go
+++ b/repository.go
@@ -86,8 +86,11 @@ func (r *CallbackRepository) Load(aggregateType string, id UUID) (Aggregate, err
 
 	// Apply the events.
 	for _, event := range events {
-		aggregate.ApplyEvent(event)
-		aggregate.IncrementVersion()
+		// Events must be of same aggregate type as the command
+		if event.AggregateType() == aggregateType {
+			aggregate.ApplyEvent(event)
+			aggregate.IncrementVersion()
+		}
 	}
 
 	return aggregate, nil

--- a/repository_test.go
+++ b/repository_test.go
@@ -43,7 +43,6 @@ func TestNewRepositoryNilEventStore(t *testing.T) {
 
 func TestRepositoryLoadNoEvents(t *testing.T) {
 	repo, _ := createRepoAndStore(t)
-
 	err := repo.RegisterAggregate(&TestAggregate{},
 		func(id UUID) Aggregate {
 			return &TestAggregate{


### PR DESCRIPTION
Fixed issue of mismatched aggregate types between command and loaded
events when rebuilding an aggregate from stored events. Issue surfaces
when a command is dispatched with an aggregate id that matches another
aggregate type.