### PR TITLE
Add DynamoDB event store

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ There are simple in memory implementations of all components in the toolkit (eve
 
 In addition there is MongoDB implementations of the event store and a simple read repository, and a Redis implementation of the event bus.
 
-There is also experimental support for AWS DynamoDB in the "dynamodb" branch (kept separately for now due to breaking changes to the UUID type). Support for a event bus using AWS SQS is also planned but not started.
+There is also experimental support for AWS DynamoDB as an event store. Support for a event bus using AWS SQS is also planned but not started.
 
 
 # License

--- a/storage/dynamodb/eventstore.go
+++ b/storage/dynamodb/eventstore.go
@@ -1,0 +1,335 @@
+// Copyright (c) 2016 - Max Ekman <max@looplab.se>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mongodb
+
+import (
+	"errors"
+	"reflect"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/dynamodb"
+	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbattribute"
+
+	"github.com/looplab/eventhorizon"
+)
+
+// ErrCouldNotDialDB is when the database could not be dialed.
+var ErrCouldNotDialDB = errors.New("could not dial database")
+
+// ErrNoDBSession is when no database session is set.
+var ErrNoDBSession = errors.New("no database session")
+
+// ErrCouldNotClearDB is when the database could not be cleared.
+var ErrCouldNotClearDB = errors.New("could not clear database")
+
+// ErrEventNotRegistered is when an event is not registered.
+var ErrEventNotRegistered = errors.New("event not registered")
+
+// ErrCouldNotMarshalEvent is when an event could not be marshaled into BSON.
+var ErrCouldNotMarshalEvent = errors.New("could not marshal event")
+
+// ErrCouldNotUnmarshalEvent is when an event could not be unmarshaled into a concrete type.
+var ErrCouldNotUnmarshalEvent = errors.New("could not unmarshal event")
+
+// ErrCouldNotLoadAggregate is when an aggregate could not be loaded.
+var ErrCouldNotLoadAggregate = errors.New("could not load aggregate")
+
+// ErrCouldNotSaveAggregate is when an aggregate could not be saved.
+var ErrCouldNotSaveAggregate = errors.New("could not save aggregate")
+
+// ErrInvalidEvent is when an event does not implement the Event interface.
+var ErrInvalidEvent = errors.New("invalid event")
+
+// EventStore implements an EventStore for MongoDB.
+type EventStore struct {
+	eventBus  eventhorizon.EventBus
+	service   *dynamodb.DynamoDB
+	config    *EventStoreConfig
+	factories map[string]func() eventhorizon.Event
+}
+
+// EventStoreConfig is a config for the DynamoDB event store.
+type EventStoreConfig struct {
+	Table  string
+	Region string
+}
+
+func (c *EventStoreConfig) provideDefaults() {
+	if c.Table == "" {
+		c.Table = "eventhorizonEvents"
+	}
+	if c.Region == "" {
+		c.Region = "us-east-1"
+	}
+}
+
+// NewEventStore creates a new EventStore.
+func NewEventStore(eventBus eventhorizon.EventBus, config *EventStoreConfig) (*EventStore, error) {
+	config.provideDefaults()
+
+	awsConfig := &aws.Config{
+		Region: aws.String(config.Region),
+	}
+	service := dynamodb.New(session.New(), awsConfig)
+
+	s := &EventStore{
+		eventBus:  eventBus,
+		service:   service,
+		config:    config,
+		factories: make(map[string]func() eventhorizon.Event),
+	}
+
+	return s, nil
+}
+
+// TODO: Implement as atomic counter.
+type aggregateRecord struct {
+	AggregateID string
+	Version     int
+	Events      []*eventRecord
+	// AggregateType        string
+	// Snapshot    bson.Raw
+}
+
+type eventRecord struct {
+	AggregateID string
+	Version     int
+	Timestamp   time.Time
+	EventType   string
+	Payload     map[string]*dynamodb.AttributeValue
+	// Event       eventhorizon.Event
+}
+
+// Save appends all events in the event stream to the database.
+func (s *EventStore) Save(events []eventhorizon.Event) error {
+	if len(events) == 0 {
+		return eventhorizon.ErrNoEventsToAppend
+	}
+
+	for _, event := range events {
+		// TODO: Implement as atomic counter.
+		// Get an existing aggregate, if any.
+		queryParams := &dynamodb.QueryInput{
+			TableName:              aws.String(s.config.Table),
+			ProjectionExpression:   aws.String("Version"),
+			KeyConditionExpression: aws.String("AggregateID = :id"),
+			ExpressionAttributeValues: map[string]*dynamodb.AttributeValue{
+				":id": {S: aws.String(event.AggregateID().String())},
+			},
+			Limit:            aws.Int64(1),
+			ScanIndexForward: aws.Bool(false),
+			ConsistentRead:   aws.Bool(true),
+		}
+		queryResp, err := s.service.Query(queryParams)
+		if err != nil {
+			return err
+		}
+
+		version := 1
+		if len(queryResp.Items) == 1 {
+			lastRecord := &eventRecord{}
+			if err := dynamodbattribute.UnmarshalMap(queryResp.Items[0], lastRecord); err != nil {
+				return err
+			}
+			version = lastRecord.Version + 1
+		}
+
+		// Marshal event payload.
+		payload, err := dynamodbattribute.MarshalMap(event)
+		if err != nil {
+			// return ErrCouldNotMarshalEvent
+			return err
+		}
+
+		// Create the event record with current version and timestamp.
+		record := &eventRecord{
+			AggregateID: event.AggregateID().String(),
+			Version:     version,
+			Timestamp:   time.Now(),
+			EventType:   event.EventType(),
+			Payload:     payload,
+		}
+
+		// Marshal and store the event record.
+		item, err := dynamodbattribute.MarshalMap(record)
+		if err != nil {
+			return err
+		}
+		putParams := &dynamodb.PutItemInput{
+			TableName:           aws.String(s.config.Table),
+			ConditionExpression: aws.String("attribute_not_exists(AggregateID) AND attribute_not_exists(Version)"),
+			Item:                item,
+		}
+		if _, err = s.service.PutItem(putParams); err != nil {
+			if err, ok := err.(awserr.RequestFailure); ok && err.Code() == "ConditionalCheckFailedException" {
+				return ErrCouldNotSaveAggregate
+			}
+			return err
+		}
+
+		// Publish event on the bus.
+		if s.eventBus != nil {
+			s.eventBus.PublishEvent(event)
+		}
+	}
+
+	return nil
+}
+
+// Load loads all events for the aggregate id from the database.
+// Returns ErrNoEventsFound if no events can be found.
+func (s *EventStore) Load(id eventhorizon.UUID) ([]eventhorizon.Event, error) {
+	params := &dynamodb.QueryInput{
+		TableName:              aws.String(s.config.Table),
+		KeyConditionExpression: aws.String("AggregateID = :id"),
+		ExpressionAttributeValues: map[string]*dynamodb.AttributeValue{
+			":id": {S: aws.String(id.String())},
+		},
+		ConsistentRead: aws.Bool(true),
+	}
+	resp, err := s.service.Query(params)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(resp.Items) == 0 {
+		return nil, eventhorizon.ErrNoEventsFound
+	}
+
+	eventRecords := make([]*eventRecord, len(resp.Items))
+	for i, item := range resp.Items {
+		record := &eventRecord{}
+		if err := dynamodbattribute.UnmarshalMap(item, record); err != nil {
+			return nil, err
+		}
+		eventRecords[i] = record
+	}
+
+	events := make([]eventhorizon.Event, len(eventRecords))
+	for i, record := range eventRecords {
+		f, ok := s.factories[record.EventType]
+		if !ok {
+			return nil, ErrEventNotRegistered
+		}
+		event := f()
+		if err := dynamodbattribute.UnmarshalMap(record.Payload, event); err != nil {
+			// 	return nil, ErrCouldNotUnmarshalEvent
+			return nil, err
+		}
+		events[i] = event
+	}
+
+	return events, nil
+}
+
+// RegisterEventType registers an event factory for a event type. The factory is
+// used to create concrete event types when loading from the database.
+//
+// An example would be:
+//     eventStore.RegisterEventType(&MyEvent{}, func() Event { return &MyEvent{} })
+func (s *EventStore) RegisterEventType(event eventhorizon.Event, factory func() eventhorizon.Event) error {
+	if _, ok := s.factories[event.EventType()]; ok {
+		return eventhorizon.ErrHandlerAlreadySet
+	}
+	s.factories[event.EventType()] = factory
+	return nil
+}
+
+// CreateTable creates the table if it is not allready existing and correct.
+func (s *EventStore) CreateTable() error {
+	attributeDefinitions := []*dynamodb.AttributeDefinition{{
+		AttributeName: aws.String("AggregateID"),
+		AttributeType: aws.String("S"),
+	}, {
+		AttributeName: aws.String("Version"),
+		AttributeType: aws.String("N"),
+	}}
+
+	keySchema := []*dynamodb.KeySchemaElement{{
+		AttributeName: aws.String("AggregateID"),
+		KeyType:       aws.String("HASH"),
+	}, {
+		AttributeName: aws.String("Version"),
+		KeyType:       aws.String("RANGE"),
+	}}
+
+	describeParams := &dynamodb.DescribeTableInput{
+		TableName: aws.String(s.config.Table),
+	}
+	if resp, err := s.service.DescribeTable(describeParams); err != nil {
+		if err, ok := err.(awserr.RequestFailure); !ok || err.Code() != "ResourceNotFoundException" {
+			return err
+		}
+		// Table does not exist, create below.
+	} else {
+		if aws.StringValue(resp.Table.TableStatus) != "ACTIVE" {
+			return errors.New("table is not active")
+		}
+		if !reflect.DeepEqual(resp.Table.AttributeDefinitions, attributeDefinitions) {
+			return errors.New("incorrect attribute definitions")
+		}
+		if !reflect.DeepEqual(resp.Table.KeySchema, keySchema) {
+			return errors.New("incorrect key schema")
+		}
+		// Table exists and is correct.
+		return nil
+	}
+
+	createParams := &dynamodb.CreateTableInput{
+		TableName:            aws.String(s.config.Table),
+		AttributeDefinitions: attributeDefinitions,
+		KeySchema:            keySchema,
+		ProvisionedThroughput: &dynamodb.ProvisionedThroughput{
+			ReadCapacityUnits:  aws.Int64(1),
+			WriteCapacityUnits: aws.Int64(1),
+		},
+	}
+	if _, err := s.service.CreateTable(createParams); err != nil {
+		return err
+	}
+
+	if err := s.service.WaitUntilTableExists(describeParams); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// DeleteTable deletes the event table.
+func (s *EventStore) DeleteTable() error {
+	params := &dynamodb.DeleteTableInput{
+		TableName: aws.String(s.config.Table),
+	}
+	_, err := s.service.DeleteTable(params)
+	if err != nil {
+		if err, ok := err.(awserr.RequestFailure); ok && err.Code() == "ResourceNotFoundException" {
+			return nil
+		}
+		// return ErrCouldNotClearDB
+		return err
+	}
+
+	describeParams := &dynamodb.DescribeTableInput{
+		TableName: aws.String(s.config.Table),
+	}
+	if err := s.service.WaitUntilTableNotExists(describeParams); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/storage/dynamodb/eventstore_test.go
+++ b/storage/dynamodb/eventstore_test.go
@@ -22,18 +22,6 @@ import (
 	"github.com/looplab/eventhorizon/testutil"
 )
 
-// func (s *EventStoreSuite) SetUpSuite(c *C) {
-// 	// Support Wercker testing with MongoDB.
-// 	host := os.Getenv("WERCKER_MONGODB_HOST")
-// 	port := os.Getenv("WERCKER_MONGODB_PORT")
-
-// 	if host != "" && port != "" {
-// 		s.url = host + ":" + port
-// 	} else {
-// 		s.url = "localhost"
-// 	}
-// }
-
 func TestEventStore(t *testing.T) {
 	bus := &testutil.MockEventBus{
 		Events: make([]eventhorizon.Event, 0),

--- a/storage/dynamodb/eventstore_test.go
+++ b/storage/dynamodb/eventstore_test.go
@@ -1,0 +1,143 @@
+// Copyright (c) 2016 - Max Ekman <max@looplab.se>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mongodb
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/looplab/eventhorizon"
+	"github.com/looplab/eventhorizon/testutil"
+)
+
+// func (s *EventStoreSuite) SetUpSuite(c *C) {
+// 	// Support Wercker testing with MongoDB.
+// 	host := os.Getenv("WERCKER_MONGODB_HOST")
+// 	port := os.Getenv("WERCKER_MONGODB_PORT")
+
+// 	if host != "" && port != "" {
+// 		s.url = host + ":" + port
+// 	} else {
+// 		s.url = "localhost"
+// 	}
+// }
+
+func TestEventStore(t *testing.T) {
+	bus := &testutil.MockEventBus{
+		Events: make([]eventhorizon.Event, 0),
+	}
+
+	config := &EventStoreConfig{
+		Table:  "eventhorizonTest-" + eventhorizon.NewUUID().String(),
+		Region: "eu-west-1",
+	}
+	store, err := NewEventStore(bus, config)
+	if err != nil {
+		t.Fatal("there should be no error:", err)
+	}
+	if store == nil {
+		t.Fatal("there should be a store")
+	}
+
+	if err = store.RegisterEventType(&testutil.TestEvent{}, func() eventhorizon.Event {
+		return &testutil.TestEvent{}
+	}); err != nil {
+		t.Fatal("there should be no error:", err)
+	}
+
+	t.Log("creating table:", config.Table)
+	if err := store.CreateTable(); err != nil {
+		t.Fatal("could not create table:", err)
+	}
+
+	defer func() {
+		t.Log("deleting table:", store.config.Table)
+		if err := store.DeleteTable(); err != nil {
+			t.Fatal("could not delete table: ", err)
+		}
+	}()
+
+	t.Log("save no events")
+	err = store.Save([]eventhorizon.Event{})
+	if err != eventhorizon.ErrNoEventsToAppend {
+		t.Error("there shoud be a ErrNoEventsToAppend error:", err)
+	}
+
+	t.Log("save event, version 1")
+	id, _ := eventhorizon.ParseUUID("c1138e5f-f6fb-4dd0-8e79-255c6c8d3756")
+	event1 := &testutil.TestEvent{id, "event1"}
+	err = store.Save([]eventhorizon.Event{event1})
+	if err != nil {
+		t.Error("there should be no error:", err)
+	}
+	if !reflect.DeepEqual(bus.Events, []eventhorizon.Event{event1}) {
+		t.Error("there should be an event on the bus:", bus.Events)
+	}
+
+	t.Log("save event, version 2")
+	err = store.Save([]eventhorizon.Event{event1})
+	if err != nil {
+		t.Error("there should be no error:", err)
+	}
+	if !reflect.DeepEqual(bus.Events, []eventhorizon.Event{event1, event1}) {
+		t.Error("there should be events on the bus:", bus.Events)
+	}
+
+	t.Log("save event, version 3")
+	event2 := &testutil.TestEvent{id, "event2"}
+	err = store.Save([]eventhorizon.Event{event2})
+	if err != nil {
+		t.Error("there should be no error:", err)
+	}
+
+	t.Log("save event for another aggregate")
+	id2, _ := eventhorizon.ParseUUID("c1138e5e-f6fb-4dd0-8e79-255c6c8d3756")
+	event3 := &testutil.TestEvent{id2, "event3"}
+	err = store.Save([]eventhorizon.Event{event3})
+	if err != nil {
+		t.Error("there should be no error:", err)
+	}
+
+	if !reflect.DeepEqual(bus.Events, []eventhorizon.Event{event1, event1, event2, event3}) {
+		t.Error("there should be events on the bus:", bus.Events)
+	}
+
+	t.Log("load events for non-existing aggregate")
+	events, err := store.Load(eventhorizon.NewUUID())
+	if err == nil || err.Error() != "could not find events" {
+		t.Error("there should be a 'could not find events' error:", err)
+	}
+	if !reflect.DeepEqual(events, []eventhorizon.Event(nil)) {
+		t.Error("there should be no loaded events:", events)
+	}
+
+	t.Log("load events")
+	events, err = store.Load(id)
+	if err != nil {
+		t.Error("there should be no error:", err)
+	}
+	if !reflect.DeepEqual(events, []eventhorizon.Event{event1, event1, event2}) {
+		t.Error("the loaded events should be correct:", events)
+	}
+
+	t.Log("load events for another aggregate")
+	events, err = store.Load(id2)
+	if err != nil {
+		t.Error("there should be no error:", err)
+	}
+	if !reflect.DeepEqual(events, []eventhorizon.Event{event3}) {
+		t.Error("the loaded events should be correct:", events)
+	}
+}

--- a/uuid.go
+++ b/uuid.go
@@ -16,20 +16,17 @@ package eventhorizon
 
 import (
 	"crypto/rand"
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"regexp"
-
-	"github.com/aws/aws-sdk-go/service/dynamodb"
 )
 
 // Pattern used to parse hex string representation of the UUID.
 // FIXME: do something to consider both brackets at one time,
 // current one allows to parse string with only one opening
 // or closing bracket.
-const hexPattern = "^(urn\\:uuid\\:)?\\{?([a-z0-9]{8})-([a-z0-9]{4})-" +
-	"([1-5][a-z0-9]{3})-([a-z0-9]{4})-([a-z0-9]{12})\\}?$"
+const hexPattern = "^(urn\\:uuid\\:)?\\{?([a-f0-9]{8})-([a-f0-9]{4})-" +
+	"([1-5][a-f0-9]{3})-([a-f0-9]{4})-([a-f0-9]{12})\\}?$"
 
 var re = regexp.MustCompile(hexPattern)
 
@@ -53,7 +50,7 @@ func NewUUID() UUID {
 	// Set the version to 4.
 	u[6] = (u[6] & 0xF) | 0x40
 
-	return UUID(u[:])
+	return UUID(fmt.Sprintf("%x-%x-%x-%x-%x", u[0:4], u[4:6], u[6:8], u[8:10], u[10:]))
 }
 
 // ParseUUID parses a UUID from a string representation.
@@ -69,27 +66,18 @@ func ParseUUID(s string) (UUID, error) {
 	if md == nil {
 		return "", errors.New("Invalid UUID string")
 	}
-	hash := md[2] + md[3] + md[4] + md[5] + md[6]
-	b, err := hex.DecodeString(hash)
-	if err != nil {
-		return "", err
-	}
-	return UUID(b), nil
+	return UUID(fmt.Sprintf("%s-%s-%s-%s-%s", md[2], md[3], md[4], md[5], md[6])), nil
 }
 
 // String implements the Stringer interface for UUID.
 func (id UUID) String() string {
-	if len(id) == 16 {
-		u := []byte(id)
-		return fmt.Sprintf("%x-%x-%x-%x-%x", u[0:4], u[4:6], u[6:8], u[8:10], u[10:])
-	}
-	return ""
+	return string(id)
 }
 
 // MarshalJSON turns UUID into a json.Marshaller.
 func (id UUID) MarshalJSON() ([]byte, error) {
 	// Pack the string representation in quotes
-	return []byte(fmt.Sprintf(`"%s"`, id.String())), nil
+	return []byte(fmt.Sprintf(`"%s"`, id)), nil
 }
 
 // UnmarshalJSON turns *UUID into a json.Unmarshaller.
@@ -104,29 +92,6 @@ func (id *UUID) UnmarshalJSON(data []byte) error {
 	parsed, err := ParseUUID(value)
 	if err != nil {
 		return fmt.Errorf("invalid UUID in JSON, %v: %v", value, err)
-	}
-
-	// Dereference pointer value and store parsed
-	*id = parsed
-	return nil
-}
-
-// MarshalDynamoDBAttributeValue marshals a UUID into a DynamoDB type.
-func (id UUID) MarshalDynamoDBAttributeValue(av *dynamodb.AttributeValue) error {
-	s := id.String()
-	av.S = &s
-	return nil
-}
-
-// UnmarshalDynamoDBAttributeValue unmarshals a DynamoDB type into a UUID.
-func (id *UUID) UnmarshalDynamoDBAttributeValue(av *dynamodb.AttributeValue) error {
-	if av.S == nil {
-		return errors.New("invalid UUID")
-	}
-
-	parsed, err := ParseUUID(*av.S)
-	if err != nil {
-		return fmt.Errorf("invalid UUID, %v: %v", *av.S, err)
 	}
 
 	// Dereference pointer value and store parsed


### PR DESCRIPTION
This PR adds a first version of a AWS DynamoDB event store. It may not be considered production stable yet!

It also changes the UUID type to be represented as a full string internally (including the -). This is not a perfect solution but it enables the use of human readable UUID values in DynamoDB.