### PR TITLE
Pass the original aggregate version to EventStore.Save(), for issue #16

### DIFF
--- a/eventhorizon_test.go
+++ b/eventhorizon_test.go
@@ -157,7 +157,7 @@ type MockEventStore struct {
 	err error
 }
 
-func (m *MockEventStore) Save(events []Event) error {
+func (m *MockEventStore) Save(events []Event, originalVersion int) error {
 	if m.err != nil {
 		return m.err
 	}

--- a/eventstore.go
+++ b/eventstore.go
@@ -23,10 +23,8 @@ var ErrNoEventsToAppend = errors.New("no events to append")
 
 // EventStore is an interface for an event sourcing event store.
 type EventStore interface {
-	// Save appends all events in the event stream to the store. It must return
-	// an error if not all events could be saved, preferably with a rewind of
-	// any DB actions performed.
-	Save([]Event) error
+	// Save appends all events in the event stream to the store.
+	Save(events []Event, originalVersion int) error
 
 	// Load loads all events for the aggregate id from the store.
 	Load(UUID) ([]Event, error)

--- a/eventstore/dynamodb/eventstore_test.go
+++ b/eventstore/dynamodb/eventstore_test.go
@@ -34,12 +34,6 @@ func TestEventStore(t *testing.T) {
 		t.Fatal("there should be a store")
 	}
 
-	if err = store.RegisterEventType(testutil.TestEventType, func() eh.Event {
-		return &testutil.TestEvent{}
-	}); err != nil {
-		t.Fatal("there should be no error:", err)
-	}
-
 	t.Log("creating table:", config.Table)
 	if err := store.CreateTable(); err != nil {
 		t.Fatal("could not create table:", err)

--- a/eventstore/memory/eventstore.go
+++ b/eventstore/memory/eventstore.go
@@ -15,60 +15,90 @@
 package memory
 
 import (
+	"errors"
 	"time"
 
 	eh "github.com/looplab/eventhorizon"
 )
 
+// ErrCouldNotSaveAggregate is when an aggregate could not be saved.
+var ErrCouldNotSaveAggregate = errors.New("could not save aggregate")
+
+// ErrInvalidEvent is when an event does not implement the Event interface.
+var ErrInvalidEvent = errors.New("invalid event")
+
 // EventStore implements EventStore as an in memory structure.
 type EventStore struct {
-	aggregateRecords map[eh.UUID]*memoryAggregateRecord
+	aggregateRecords map[eh.UUID]aggregateRecord
 }
 
 // NewEventStore creates a new EventStore.
 func NewEventStore() *EventStore {
 	s := &EventStore{
-		aggregateRecords: make(map[eh.UUID]*memoryAggregateRecord),
+		aggregateRecords: make(map[eh.UUID]aggregateRecord),
 	}
 	return s
 }
 
-type memoryAggregateRecord struct {
-	aggregateID eh.UUID
-	version     int
-	events      []*memoryEventRecord
+type aggregateRecord struct {
+	AggregateID eh.UUID
+	Version     int
+	Events      []eventRecord
+	// Type        string        `bson:"type"`
+	// Snapshot    bson.Raw      `bson:"snapshot"`
 }
 
-type memoryEventRecord struct {
-	version   int
-	timestamp time.Time
-	eventType eh.EventType
-	event     eh.Event
+type eventRecord struct {
+	EventType eh.EventType
+	Version   int
+	Timestamp time.Time
+	Event     eh.Event
 }
 
 // Save appends all events in the event stream to the memory store.
-func (s *EventStore) Save(events []eh.Event) error {
+func (s *EventStore) Save(events []eh.Event, originalVersion int) error {
 	if len(events) == 0 {
 		return eh.ErrNoEventsToAppend
 	}
 
-	for _, event := range events {
-		r := &memoryEventRecord{
-			timestamp: time.Now(),
-			eventType: event.EventType(),
-			event:     event,
+	// Build all event records, with incrementing versions starting from the
+	// original aggregate version.
+	eventRecords := make([]eventRecord, len(events))
+	aggregateID := events[0].AggregateID()
+	for i, event := range events {
+		// Only accept events belonging to the same aggregate.
+		if event.AggregateID() != aggregateID {
+			return ErrInvalidEvent
 		}
 
-		if a, ok := s.aggregateRecords[event.AggregateID()]; ok {
-			a.version++
-			r.version = a.version
-			a.events = append(a.events, r)
-		} else {
-			s.aggregateRecords[event.AggregateID()] = &memoryAggregateRecord{
-				aggregateID: event.AggregateID(),
-				version:     0,
-				events:      []*memoryEventRecord{r},
+		// Create the event record with timestamp.
+		eventRecords[i] = eventRecord{
+			EventType: event.EventType(),
+			Version:   1 + originalVersion + i,
+			Timestamp: time.Now(),
+			Event:     event,
+		}
+	}
+
+	// Either insert a new aggregate or append to an existing.
+	if originalVersion == 0 {
+		aggregate := aggregateRecord{
+			AggregateID: aggregateID,
+			Version:     len(eventRecords),
+			Events:      eventRecords,
+		}
+		s.aggregateRecords[aggregateID] = aggregate
+	} else {
+		// Increment aggregate version on insert of new event record, and
+		// only insert if version of aggregate is matching (ie not changed
+		// since loading the aggregate).
+		if aggregate, ok := s.aggregateRecords[aggregateID]; ok {
+			if aggregate.Version != originalVersion {
+				return ErrCouldNotSaveAggregate
 			}
+			aggregate.Version += len(eventRecords)
+			aggregate.Events = append(aggregate.Events, eventRecords...)
+			s.aggregateRecords[aggregateID] = aggregate
 		}
 	}
 
@@ -78,10 +108,10 @@ func (s *EventStore) Save(events []eh.Event) error {
 // Load loads all events for the aggregate id from the memory store.
 // Returns ErrNoEventsFound if no events can be found.
 func (s *EventStore) Load(id eh.UUID) ([]eh.Event, error) {
-	if a, ok := s.aggregateRecords[id]; ok {
-		events := make([]eh.Event, len(a.events))
-		for i, r := range a.events {
-			events[i] = r.event
+	if aggregate, ok := s.aggregateRecords[id]; ok {
+		events := make([]eh.Event, len(aggregate.Events))
+		for i, r := range aggregate.Events {
+			events[i] = r.Event
 		}
 		return events, nil
 	}

--- a/eventstore/trace/eventstore.go
+++ b/eventstore/trace/eventstore.go
@@ -40,13 +40,13 @@ func NewEventStore(eventStore eh.EventStore) *EventStore {
 }
 
 // Save appends all events to the base store and trace them if enabled.
-func (s *EventStore) Save(events []eh.Event) error {
+func (s *EventStore) Save(events []eh.Event, originalVersion int) error {
 	if s.tracing {
 		s.trace = append(s.trace, events...)
 	}
 
 	if s.eventStore != nil {
-		return s.eventStore.Save(events)
+		return s.eventStore.Save(events, originalVersion)
 	}
 
 	return nil

--- a/eventstore/trace/eventstore_test.go
+++ b/eventstore/trace/eventstore_test.go
@@ -56,8 +56,8 @@ func TestEventStore(t *testing.T) {
 		}
 	}
 
-	t.Log("save event, version 4")
-	err := store.Save([]eh.Event{event1})
+	t.Log("save event, version 7")
+	err := store.Save([]eh.Event{event1}, 6)
 	if err != nil {
 		t.Error("there should be no error:", err)
 	}

--- a/examples/mongodb/mongodb_test.go
+++ b/examples/mongodb/mongodb_test.go
@@ -17,6 +17,7 @@ package mongodb
 import (
 	"fmt"
 	"log"
+	"os"
 
 	eh "github.com/looplab/eventhorizon"
 	commandbus "github.com/looplab/eventhorizon/commandbus/local"
@@ -28,8 +29,17 @@ import (
 )
 
 func Example() {
+	// Support Wercker testing with MongoDB.
+	host := os.Getenv("MONGO_PORT_27017_TCP_ADDR")
+	port := os.Getenv("MONGO_PORT_27017_TCP_PORT")
+
+	url := "localhost"
+	if host != "" && port != "" {
+		url = host + ":" + port
+	}
+
 	// Create the event store.
-	eventStore, err := eventstore.NewEventStore("localhost", "demo")
+	eventStore, err := eventstore.NewEventStore(url, "demo")
 	if err != nil {
 		log.Fatalf("could not create event store: %s", err)
 	}
@@ -63,7 +73,7 @@ func Example() {
 	commandBus.SetHandler(handler, domain.DeclineInviteCommand)
 
 	// Create and register a read model for individual invitations.
-	invitationRepository, err := readrepository.NewReadRepository("localhost", "demo", "invitations")
+	invitationRepository, err := readrepository.NewReadRepository(url, "demo", "invitations")
 	if err != nil {
 		log.Fatalf("could not create invitation repository: %s", err)
 	}
@@ -75,7 +85,7 @@ func Example() {
 
 	// Create and register a read model for a guest list.
 	eventID := eh.NewUUID()
-	guestListRepository, err := readrepository.NewReadRepository("localhost", "demo", "guest_lists")
+	guestListRepository, err := readrepository.NewReadRepository(url, "demo", "guest_lists")
 	if err != nil {
 		log.Fatalf("could not create guest list repository: %s", err)
 	}

--- a/repository_test.go
+++ b/repository_test.go
@@ -74,7 +74,7 @@ func TestEventSourcingRepositoryLoadEvents(t *testing.T) {
 
 	id := NewUUID()
 	event1 := &TestEvent{id, "event"}
-	store.Save([]Event{event1})
+	store.Save([]Event{event1}, 0)
 	agg, err := repo.Load("TestAggregate", id)
 	if err != nil {
 		t.Error("there should be no error:", err)
@@ -100,11 +100,11 @@ func TestEventSourcingRepositoryLoadEventsMismatchedEventType(t *testing.T) {
 
 	id := NewUUID()
 	event1 := &TestEvent{id, "event"}
-	store.Save([]Event{event1})
+	store.Save([]Event{event1}, 0)
 
 	otherAggregateID := NewUUID()
 	event2 := &TestEvent2{otherAggregateID, "event2"}
-	store.Save([]Event{event2})
+	store.Save([]Event{event2}, 0)
 
 	agg, err := repo.Load("TestAggregate", otherAggregateID)
 	if err != ErrMismatchedEventType {


### PR DESCRIPTION
The original aggregate version is used for checking that a save can only be done if the version of the
aggregate has not been changed since it was loaded.