### PR TITLE
Add check for nil query in FindCustom to prevent panics

### DIFF
--- a/storage/mongodb/readrepository_test.go
+++ b/storage/mongodb/readrepository_test.go
@@ -143,6 +143,31 @@ func TestReadRepository(t *testing.T) {
 		t.Error("the item should be correct:", model)
 	}
 
+	t.Log("FindCustom with no query")
+	result, err = repo.FindCustom(func(c *mgo.Collection) *mgo.Query {
+		return nil
+	})
+	if err == nil || err != ErrInvalidQuery {
+		t.Error("there should be a invalid query error:", err)
+	}
+
+	count := 0
+	t.Log("FindCustom with query execution in the callback")
+	_, err = repo.FindCustom(func(c *mgo.Collection) *mgo.Query {
+		if count, err = c.Count(); err != nil {
+			t.Error("there should be no error:", err)
+		}
+
+		// Be sure to return nil to not execute the query again in FindCustom.
+		return nil
+	})
+	if err == nil || err != ErrInvalidQuery {
+		t.Error("there should be a invalid query error:", err)
+	}
+	if count != 2 {
+		t.Error("the count should be correct:", count)
+	}
+
 	t.Log("Remove one item")
 	err = repo.Remove(model1Alt.ID)
 	if err != nil {


### PR DESCRIPTION
It also allows custom queries to be executed directly in the callback by
returning nil as a query and expecting a ErrInvalidQuery error, see the docs
for FindCustom.