### PR TITLE
Factories for Aggregates and Events

### DIFF
--- a/aggregate.go
+++ b/aggregate.go
@@ -14,6 +14,12 @@
 
 package eventhorizon
 
+import (
+	"errors"
+	"fmt"
+	"sync"
+)
+
 // Aggregate is an interface representing a versioned data entity created from
 // events. It receives commands and generates evens that are stored.
 //
@@ -110,4 +116,48 @@ func (a *AggregateBase) GetUncommittedEvents() []Event {
 // ClearUncommittedEvents clears all uncommitted events after storing.
 func (a *AggregateBase) ClearUncommittedEvents() {
 	a.uncommittedEvents = []Event{}
+}
+
+var aggregates = make(map[AggregateType]func(UUID) Aggregate)
+var registerAggregateLock sync.RWMutex
+
+// ErrAggregateNotRegistered is when no aggregate factory was registered.
+var ErrAggregateNotRegistered = errors.New("aggregate not registered")
+
+// RegisterAggregate registers an aggregate factory for a type. The factory is
+// used to create concrete aggregate types when loading from the database.
+//
+// An example would be:
+//     RegisterAggregate(func(id UUID) Aggregate { return &MyAggregate{id} })
+func RegisterAggregate(factory func(UUID) Aggregate) {
+	// TODO: Explore the use of reflect/gob for creating concrete types without
+	// a factory func.
+
+	// Check that the created aggregate matches the type registered.
+	aggregate := factory(NewUUID())
+	if aggregate == nil {
+		panic("eventhorizon: created aggregate is nil")
+	}
+	aggregateType := aggregate.AggregateType()
+	if aggregateType == AggregateType("") {
+		panic("eventhorizon: attempt to register empty aggregate type")
+	}
+
+	registerAggregateLock.Lock()
+	defer registerAggregateLock.Unlock()
+	if _, ok := aggregates[aggregateType]; ok {
+		panic(fmt.Sprintf("eventhorizon: registering duplicate types for %q", aggregateType))
+	}
+	aggregates[aggregateType] = factory
+}
+
+// CreateAggregate creates an aggregate of a type with an ID using the factory
+// registered with RegisterAggregate.
+func CreateAggregate(aggregateType AggregateType, id UUID) (Aggregate, error) {
+	registerAggregateLock.RLock()
+	defer registerAggregateLock.RUnlock()
+	if factory, ok := aggregates[aggregateType]; ok {
+		return factory(id), nil
+	}
+	return nil, ErrAggregateNotRegistered
 }

--- a/commandbus/local/commandbus.go
+++ b/commandbus/local/commandbus.go
@@ -15,35 +15,35 @@
 package local
 
 import (
-	"github.com/looplab/eventhorizon"
+	eh "github.com/looplab/eventhorizon"
 )
 
 // CommandBus is a command bus that handles commands with the
 // registered CommandHandlers
 type CommandBus struct {
-	handlers map[eventhorizon.CommandType]eventhorizon.CommandHandler
+	handlers map[eh.CommandType]eh.CommandHandler
 }
 
 // NewCommandBus creates a CommandBus.
 func NewCommandBus() *CommandBus {
 	b := &CommandBus{
-		handlers: make(map[eventhorizon.CommandType]eventhorizon.CommandHandler),
+		handlers: make(map[eh.CommandType]eh.CommandHandler),
 	}
 	return b
 }
 
 // HandleCommand handles a command with a handler capable of handling it.
-func (b *CommandBus) HandleCommand(command eventhorizon.Command) error {
+func (b *CommandBus) HandleCommand(command eh.Command) error {
 	if handler, ok := b.handlers[command.CommandType()]; ok {
 		return handler.HandleCommand(command)
 	}
-	return eventhorizon.ErrHandlerNotFound
+	return eh.ErrHandlerNotFound
 }
 
 // SetHandler adds a handler for a specific command.
-func (b *CommandBus) SetHandler(handler eventhorizon.CommandHandler, commandType eventhorizon.CommandType) error {
+func (b *CommandBus) SetHandler(handler eh.CommandHandler, commandType eh.CommandType) error {
 	if _, ok := b.handlers[commandType]; ok {
-		return eventhorizon.ErrHandlerAlreadySet
+		return eh.ErrHandlerAlreadySet
 	}
 	b.handlers[commandType] = handler
 	return nil

--- a/commandbus/local/commandbus_test.go
+++ b/commandbus/local/commandbus_test.go
@@ -17,7 +17,7 @@ package local
 import (
 	"testing"
 
-	"github.com/looplab/eventhorizon"
+	eh "github.com/looplab/eventhorizon"
 	"github.com/looplab/eventhorizon/testutil"
 )
 
@@ -28,9 +28,9 @@ func TestCommandBus(t *testing.T) {
 	}
 
 	t.Log("handle with no handler")
-	command1 := &testutil.TestCommand{eventhorizon.NewUUID(), "command1"}
+	command1 := &testutil.TestCommand{eh.NewUUID(), "command1"}
 	err := bus.HandleCommand(command1)
-	if err != eventhorizon.ErrHandlerNotFound {
+	if err != eh.ErrHandlerNotFound {
 		t.Error("there should be a ErrHandlerNotFound error:", err)
 	}
 
@@ -51,16 +51,16 @@ func TestCommandBus(t *testing.T) {
 	}
 
 	err = bus.SetHandler(handler, testutil.TestCommandType)
-	if err != eventhorizon.ErrHandlerAlreadySet {
+	if err != eh.ErrHandlerAlreadySet {
 		t.Error("there should be a ErrHandlerAlreadySet error:", err)
 	}
 }
 
 type TestCommandHandler struct {
-	command eventhorizon.Command
+	command eh.Command
 }
 
-func (t *TestCommandHandler) HandleCommand(command eventhorizon.Command) error {
+func (t *TestCommandHandler) HandleCommand(command eh.Command) error {
 	t.command = command
 	return nil
 }

--- a/commandhandler_test.go
+++ b/commandhandler_test.go
@@ -210,9 +210,9 @@ type TestCommandStringValue struct {
 	Content string
 }
 
-func (t *TestCommandStringValue) AggregateID() UUID            { return t.TestID }
-func (t *TestCommandStringValue) AggregateType() AggregateType { return AggregateType("Test") }
-func (t *TestCommandStringValue) CommandType() CommandType {
+func (t TestCommandStringValue) AggregateID() UUID            { return t.TestID }
+func (t TestCommandStringValue) AggregateType() AggregateType { return AggregateType("Test") }
+func (t TestCommandStringValue) CommandType() CommandType {
 	return CommandType("TestCommandStringValue")
 }
 
@@ -221,45 +221,45 @@ type TestCommandIntValue struct {
 	Content int
 }
 
-func (t *TestCommandIntValue) AggregateID() UUID            { return t.TestID }
-func (t *TestCommandIntValue) AggregateType() AggregateType { return AggregateType("Test") }
-func (t *TestCommandIntValue) CommandType() CommandType     { return CommandType("TestCommandIntValue") }
+func (t TestCommandIntValue) AggregateID() UUID            { return t.TestID }
+func (t TestCommandIntValue) AggregateType() AggregateType { return AggregateType("Test") }
+func (t TestCommandIntValue) CommandType() CommandType     { return CommandType("TestCommandIntValue") }
 
 type TestCommandFloatValue struct {
 	TestID  UUID
 	Content float32
 }
 
-func (t *TestCommandFloatValue) AggregateID() UUID            { return t.TestID }
-func (t *TestCommandFloatValue) AggregateType() AggregateType { return AggregateType("Test") }
-func (t *TestCommandFloatValue) CommandType() CommandType     { return CommandType("TestCommandFloatValue") }
+func (t TestCommandFloatValue) AggregateID() UUID            { return t.TestID }
+func (t TestCommandFloatValue) AggregateType() AggregateType { return AggregateType("Test") }
+func (t TestCommandFloatValue) CommandType() CommandType     { return CommandType("TestCommandFloatValue") }
 
 type TestCommandBoolValue struct {
 	TestID  UUID
 	Content bool
 }
 
-func (t *TestCommandBoolValue) AggregateID() UUID            { return t.TestID }
-func (t *TestCommandBoolValue) AggregateType() AggregateType { return AggregateType("Test") }
-func (t *TestCommandBoolValue) CommandType() CommandType     { return CommandType("TestCommandBoolValue") }
+func (t TestCommandBoolValue) AggregateID() UUID            { return t.TestID }
+func (t TestCommandBoolValue) AggregateType() AggregateType { return AggregateType("Test") }
+func (t TestCommandBoolValue) CommandType() CommandType     { return CommandType("TestCommandBoolValue") }
 
 type TestCommandSlice struct {
 	TestID UUID
 	Slice  []string
 }
 
-func (t *TestCommandSlice) AggregateID() UUID            { return t.TestID }
-func (t *TestCommandSlice) AggregateType() AggregateType { return AggregateType("Test") }
-func (t *TestCommandSlice) CommandType() CommandType     { return CommandType("TestCommandSlice") }
+func (t TestCommandSlice) AggregateID() UUID            { return t.TestID }
+func (t TestCommandSlice) AggregateType() AggregateType { return AggregateType("Test") }
+func (t TestCommandSlice) CommandType() CommandType     { return CommandType("TestCommandSlice") }
 
 type TestCommandMap struct {
 	TestID UUID
 	Map    map[string]string
 }
 
-func (t *TestCommandMap) AggregateID() UUID            { return t.TestID }
-func (t *TestCommandMap) AggregateType() AggregateType { return AggregateType("Test") }
-func (t *TestCommandMap) CommandType() CommandType     { return CommandType("TestCommandMap") }
+func (t TestCommandMap) AggregateID() UUID            { return t.TestID }
+func (t TestCommandMap) AggregateType() AggregateType { return AggregateType("Test") }
+func (t TestCommandMap) CommandType() CommandType     { return CommandType("TestCommandMap") }
 
 type TestCommandStruct struct {
 	TestID UUID
@@ -268,33 +268,33 @@ type TestCommandStruct struct {
 	}
 }
 
-func (t *TestCommandStruct) AggregateID() UUID            { return t.TestID }
-func (t *TestCommandStruct) AggregateType() AggregateType { return AggregateType("Test") }
-func (t *TestCommandStruct) CommandType() CommandType     { return CommandType("TestCommandStruct") }
+func (t TestCommandStruct) AggregateID() UUID            { return t.TestID }
+func (t TestCommandStruct) AggregateType() AggregateType { return AggregateType("Test") }
+func (t TestCommandStruct) CommandType() CommandType     { return CommandType("TestCommandStruct") }
 
 type TestCommandTime struct {
 	TestID UUID
 	Time   time.Time
 }
 
-func (t *TestCommandTime) AggregateID() UUID            { return t.TestID }
-func (t *TestCommandTime) AggregateType() AggregateType { return AggregateType("Test") }
-func (t *TestCommandTime) CommandType() CommandType     { return CommandType("TestCommandTime") }
+func (t TestCommandTime) AggregateID() UUID            { return t.TestID }
+func (t TestCommandTime) AggregateType() AggregateType { return AggregateType("Test") }
+func (t TestCommandTime) CommandType() CommandType     { return CommandType("TestCommandTime") }
 
 type TestCommandOptional struct {
 	TestID  UUID
 	Content string `eh:"optional"`
 }
 
-func (t *TestCommandOptional) AggregateID() UUID            { return t.TestID }
-func (t *TestCommandOptional) AggregateType() AggregateType { return AggregateType("Test") }
-func (t *TestCommandOptional) CommandType() CommandType     { return CommandType("TestCommandOptional") }
+func (t TestCommandOptional) AggregateID() UUID            { return t.TestID }
+func (t TestCommandOptional) AggregateType() AggregateType { return AggregateType("Test") }
+func (t TestCommandOptional) CommandType() CommandType     { return CommandType("TestCommandOptional") }
 
 type TestCommandPrivate struct {
 	TestID  UUID
 	private string
 }
 
-func (t *TestCommandPrivate) AggregateID() UUID            { return t.TestID }
-func (t *TestCommandPrivate) AggregateType() AggregateType { return AggregateType("Test") }
-func (t *TestCommandPrivate) CommandType() CommandType     { return CommandType("TestCommandPrivate") }
+func (t TestCommandPrivate) AggregateID() UUID            { return t.TestID }
+func (t TestCommandPrivate) AggregateType() AggregateType { return AggregateType("Test") }
+func (t TestCommandPrivate) CommandType() CommandType     { return CommandType("TestCommandPrivate") }

--- a/event_test.go
+++ b/event_test.go
@@ -1,0 +1,88 @@
+// Copyright (c) 2016 - Max Ekman <max@looplab.se>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package eventhorizon
+
+import (
+	"testing"
+)
+
+func TestCreateEvent(t *testing.T) {
+	event, err := CreateEvent(TestEventRegisterType)
+	if err != ErrEventNotRegistered {
+		t.Error("there should be a event not registered error:", err)
+	}
+
+	RegisterEvent(func() Event { return &TestEventRegister{} })
+
+	event, err = CreateEvent(TestEventRegisterType)
+	if err != nil {
+		t.Error("there should be no error:", err)
+	}
+	if event.EventType() != TestEventRegisterType {
+		t.Error("the event type should be correct:", event.EventType())
+	}
+}
+
+func TestRegisterEventEmptyName(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil || r != "eventhorizon: attempt to register empty event type" {
+			t.Error("there should have been a panic:", r)
+		}
+	}()
+	RegisterEvent(func() Event { return &TestEventRegisterEmpty{} })
+}
+
+func TestRegisterEventNil(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil || r != "eventhorizon: created event is nil" {
+			t.Error("there should have been a panic:", r)
+		}
+	}()
+	RegisterEvent(func() Event { return nil })
+}
+
+func TestRegisterEventTwice(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil || r != "eventhorizon: registering duplicate types for \"TestEventRegisterTwice\"" {
+			t.Error("there should have been a panic:", r)
+		}
+	}()
+	RegisterEvent(func() Event { return &TestEventRegisterTwice{} })
+	RegisterEvent(func() Event { return &TestEventRegisterTwice{} })
+}
+
+const (
+	TestEventRegisterType      EventType = "TestEventRegister"
+	TestEventRegisterEmptyType EventType = ""
+	TestEventRegisterTwiceType EventType = "TestEventRegisterTwice"
+)
+
+type TestEventRegister struct{}
+
+func (a TestEventRegister) AggregateID() UUID            { return UUID("") }
+func (a TestEventRegister) AggregateType() AggregateType { return TestAggregateType }
+func (a TestEventRegister) EventType() EventType         { return TestEventRegisterType }
+
+type TestEventRegisterEmpty struct{}
+
+func (a TestEventRegisterEmpty) AggregateID() UUID            { return UUID("") }
+func (a TestEventRegisterEmpty) AggregateType() AggregateType { return TestAggregateType }
+func (a TestEventRegisterEmpty) EventType() EventType         { return TestEventRegisterEmptyType }
+
+type TestEventRegisterTwice struct{}
+
+func (a TestEventRegisterTwice) AggregateID() UUID            { return UUID("") }
+func (a TestEventRegisterTwice) AggregateType() AggregateType { return TestAggregateType }
+func (a TestEventRegisterTwice) EventType() EventType         { return TestEventRegisterTwiceType }

--- a/eventbus/local/eventbus.go
+++ b/eventbus/local/eventbus.go
@@ -15,21 +15,21 @@
 package local
 
 import (
-	"github.com/looplab/eventhorizon"
+	eh "github.com/looplab/eventhorizon"
 )
 
 // EventBus is an event bus that notifies registered EventHandlers of
 // published events.
 type EventBus struct {
-	handlers  map[eventhorizon.EventType]map[eventhorizon.EventHandler]bool
-	observers map[eventhorizon.EventObserver]bool
+	handlers  map[eh.EventType]map[eh.EventHandler]bool
+	observers map[eh.EventObserver]bool
 }
 
 // NewEventBus creates a EventBus.
 func NewEventBus() *EventBus {
 	b := &EventBus{
-		handlers:  make(map[eventhorizon.EventType]map[eventhorizon.EventHandler]bool),
-		observers: make(map[eventhorizon.EventObserver]bool),
+		handlers:  make(map[eh.EventType]map[eh.EventHandler]bool),
+		observers: make(map[eh.EventObserver]bool),
 	}
 	return b
 }
@@ -37,7 +37,7 @@ func NewEventBus() *EventBus {
 // PublishEvent publishes an event to all handlers capable of handling it.
 // TODO: Put the event in a buffered channel consumed by another goroutine
 // to simulate a distributed bus.
-func (b *EventBus) PublishEvent(event eventhorizon.Event) {
+func (b *EventBus) PublishEvent(event eh.Event) {
 	// Handle the event if there is a handler registered.
 	if handlers, ok := b.handlers[event.EventType()]; ok {
 		for h := range handlers {
@@ -52,10 +52,10 @@ func (b *EventBus) PublishEvent(event eventhorizon.Event) {
 }
 
 // AddHandler implements the AddHandler method of the EventHandler interface.
-func (b *EventBus) AddHandler(handler eventhorizon.EventHandler, eventType eventhorizon.EventType) {
+func (b *EventBus) AddHandler(handler eh.EventHandler, eventType eh.EventType) {
 	// Create list for new event types.
 	if _, ok := b.handlers[eventType]; !ok {
-		b.handlers[eventType] = make(map[eventhorizon.EventHandler]bool)
+		b.handlers[eventType] = make(map[eh.EventHandler]bool)
 	}
 
 	// Add the handler for the event type.
@@ -63,6 +63,6 @@ func (b *EventBus) AddHandler(handler eventhorizon.EventHandler, eventType event
 }
 
 // AddObserver implements the AddObserver method of the EventHandler interface.
-func (b *EventBus) AddObserver(observer eventhorizon.EventObserver) {
+func (b *EventBus) AddObserver(observer eh.EventObserver) {
 	b.observers[observer] = true
 }

--- a/eventbus/local/eventbus_test.go
+++ b/eventbus/local/eventbus_test.go
@@ -18,7 +18,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/looplab/eventhorizon"
+	eh "github.com/looplab/eventhorizon"
 	"github.com/looplab/eventhorizon/testutil"
 )
 
@@ -32,9 +32,9 @@ func TestEventBus(t *testing.T) {
 	bus.AddObserver(observer)
 
 	t.Log("publish event without handler")
-	event1 := &testutil.TestEvent{eventhorizon.NewUUID(), "event1"}
+	event1 := &testutil.TestEvent{eh.NewUUID(), "event1"}
 	bus.PublishEvent(event1)
-	if !reflect.DeepEqual(observer.Events, []eventhorizon.Event{event1}) {
+	if !reflect.DeepEqual(observer.Events, []eh.Event{event1}) {
 		t.Error("the observed events should be correct:", observer.Events)
 	}
 
@@ -42,21 +42,21 @@ func TestEventBus(t *testing.T) {
 	handler := testutil.NewMockEventHandler("testHandler")
 	bus.AddHandler(handler, testutil.TestEventType)
 	bus.PublishEvent(event1)
-	if !reflect.DeepEqual(handler.Events, []eventhorizon.Event{event1}) {
+	if !reflect.DeepEqual(handler.Events, []eh.Event{event1}) {
 		t.Error("the handler events should be correct:", handler.Events)
 	}
-	if !reflect.DeepEqual(observer.Events, []eventhorizon.Event{event1, event1}) {
+	if !reflect.DeepEqual(observer.Events, []eh.Event{event1, event1}) {
 		t.Error("the observed events should be correct:", observer.Events)
 	}
 
 	t.Log("publish another event")
 	bus.AddHandler(handler, testutil.TestEventOtherType)
-	event2 := &testutil.TestEventOther{eventhorizon.NewUUID(), "event2"}
+	event2 := &testutil.TestEventOther{eh.NewUUID(), "event2"}
 	bus.PublishEvent(event2)
-	if !reflect.DeepEqual(handler.Events, []eventhorizon.Event{event1, event2}) {
+	if !reflect.DeepEqual(handler.Events, []eh.Event{event1, event2}) {
 		t.Error("the handler events should be correct:", handler.Events)
 	}
-	if !reflect.DeepEqual(observer.Events, []eventhorizon.Event{event1, event1, event2}) {
+	if !reflect.DeepEqual(observer.Events, []eh.Event{event1, event1, event2}) {
 		t.Error("the observed events should be correct:", observer.Events)
 	}
 }

--- a/eventbus/redis/eventbus.go
+++ b/eventbus/redis/eventbus.go
@@ -23,7 +23,7 @@ import (
 	"github.com/garyburd/redigo/redis"
 	"gopkg.in/mgo.v2/bson"
 
-	"github.com/looplab/eventhorizon"
+	eh "github.com/looplab/eventhorizon"
 )
 
 // ErrCouldNotMarshalEvent is when an event could not be marshaled into BSON.
@@ -35,8 +35,8 @@ var ErrCouldNotUnmarshalEvent = errors.New("could not unmarshal event")
 // EventBus is an event bus that notifies registered EventHandlers of
 // published events.
 type EventBus struct {
-	handlers  map[eventhorizon.EventType]map[eventhorizon.EventHandler]bool
-	observers map[eventhorizon.EventObserver]bool
+	handlers  map[eh.EventType]map[eh.EventHandler]bool
+	observers map[eh.EventObserver]bool
 	prefix    string
 	pool      *redis.Pool
 	conn      *redis.PubSubConn
@@ -73,8 +73,8 @@ func NewEventBus(appID, server, password string) (*EventBus, error) {
 // NewEventBusWithPool creates a EventBus for remote events.
 func NewEventBusWithPool(appID string, pool *redis.Pool) (*EventBus, error) {
 	b := &EventBus{
-		handlers:  make(map[eventhorizon.EventType]map[eventhorizon.EventHandler]bool),
-		observers: make(map[eventhorizon.EventObserver]bool),
+		handlers:  make(map[eh.EventType]map[eh.EventHandler]bool),
+		observers: make(map[eh.EventObserver]bool),
 		prefix:    appID + ":events:",
 		pool:      pool,
 		exit:      make(chan struct{}),
@@ -95,7 +95,7 @@ func NewEventBusWithPool(appID string, pool *redis.Pool) (*EventBus, error) {
 }
 
 // PublishEvent publishes an event to all handlers capable of handling it.
-func (b *EventBus) PublishEvent(event eventhorizon.Event) {
+func (b *EventBus) PublishEvent(event eh.Event) {
 	// Handle the event if there is a handler registered.
 	if handlers, ok := b.handlers[event.EventType()]; ok {
 		for handler := range handlers {
@@ -108,10 +108,10 @@ func (b *EventBus) PublishEvent(event eventhorizon.Event) {
 }
 
 // AddHandler adds a handler for a specific local event.
-func (b *EventBus) AddHandler(handler eventhorizon.EventHandler, eventType eventhorizon.EventType) {
+func (b *EventBus) AddHandler(handler eh.EventHandler, eventType eh.EventType) {
 	// Create handler list for new event types.
 	if _, ok := b.handlers[eventType]; !ok {
-		b.handlers[eventType] = make(map[eventhorizon.EventHandler]bool)
+		b.handlers[eventType] = make(map[eh.EventHandler]bool)
 	}
 
 	// Add handler to event type.
@@ -119,7 +119,7 @@ func (b *EventBus) AddHandler(handler eventhorizon.EventHandler, eventType event
 }
 
 // AddObserver implements the AddObserver method of the EventHandler interface.
-func (b *EventBus) AddObserver(observer eventhorizon.EventObserver) {
+func (b *EventBus) AddObserver(observer eh.EventObserver) {
 	b.observers[observer] = true
 }
 
@@ -136,7 +136,7 @@ func (b *EventBus) Close() {
 	}
 }
 
-func (b *EventBus) notify(event eventhorizon.Event) {
+func (b *EventBus) notify(event eh.Event) {
 	conn := b.pool.Get()
 	defer conn.Close()
 	if err := conn.Err(); err != nil {
@@ -161,10 +161,10 @@ func (b *EventBus) recv(ready chan struct{}) {
 		switch n := b.conn.Receive().(type) {
 		case redis.PMessage:
 			// Extract the event type from the channel name.
-			eventType := eventhorizon.EventType(strings.TrimPrefix(n.Channel, b.prefix))
+			eventType := eh.EventType(strings.TrimPrefix(n.Channel, b.prefix))
 
 			// Create an event of the correct type.
-			event, err := eventhorizon.CreateEvent(eventType)
+			event, err := eh.CreateEvent(eventType)
 			if err != nil {
 				log.Printf("error: event bus receive: %v\n", err)
 				continue

--- a/eventbus/redis/eventbus_test.go
+++ b/eventbus/redis/eventbus_test.go
@@ -41,16 +41,6 @@ func TestEventBus(t *testing.T) {
 		t.Fatal("there should be a bus")
 	}
 	defer bus.Close()
-	if err = bus.RegisterEventType(testutil.TestEventType, func() eventhorizon.Event {
-		return &testutil.TestEvent{}
-	}); err != nil {
-		t.Error("there should be no error:", err)
-	}
-	if err = bus.RegisterEventType(testutil.TestEventOtherType, func() eventhorizon.Event {
-		return &testutil.TestEventOther{}
-	}); err != nil {
-		t.Error("there should be no error:", err)
-	}
 	observer := testutil.NewMockEventObserver()
 	bus.AddObserver(observer)
 
@@ -60,16 +50,6 @@ func TestEventBus(t *testing.T) {
 		t.Fatal("there should be no error:", err)
 	}
 	defer bus2.Close()
-	if err = bus2.RegisterEventType(testutil.TestEventType, func() eventhorizon.Event {
-		return &testutil.TestEvent{}
-	}); err != nil {
-		t.Error("there should be no error:", err)
-	}
-	if err = bus2.RegisterEventType(testutil.TestEventOtherType, func() eventhorizon.Event {
-		return &testutil.TestEventOther{}
-	}); err != nil {
-		t.Error("there should be no error:", err)
-	}
 	observer2 := testutil.NewMockEventObserver()
 	bus2.AddObserver(observer2)
 

--- a/eventbus/redis/eventbus_test.go
+++ b/eventbus/redis/eventbus_test.go
@@ -19,7 +19,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/looplab/eventhorizon"
+	eh "github.com/looplab/eventhorizon"
 	"github.com/looplab/eventhorizon/testutil"
 )
 
@@ -54,14 +54,14 @@ func TestEventBus(t *testing.T) {
 	bus2.AddObserver(observer2)
 
 	t.Log("publish event without handler")
-	event1 := &testutil.TestEvent{eventhorizon.NewUUID(), "event1"}
+	event1 := &testutil.TestEvent{eh.NewUUID(), "event1"}
 	bus.PublishEvent(event1)
 	<-observer.Recv
-	if !reflect.DeepEqual(observer.Events, []eventhorizon.Event{event1}) {
+	if !reflect.DeepEqual(observer.Events, []eh.Event{event1}) {
 		t.Error("the observed events should be correct:", observer.Events)
 	}
 	<-observer2.Recv
-	if !reflect.DeepEqual(observer2.Events, []eventhorizon.Event{event1}) {
+	if !reflect.DeepEqual(observer2.Events, []eh.Event{event1}) {
 		t.Error("the second observed events should be correct:", observer2.Events)
 	}
 
@@ -69,31 +69,31 @@ func TestEventBus(t *testing.T) {
 	handler := testutil.NewMockEventHandler("testHandler")
 	bus.AddHandler(handler, testutil.TestEventType)
 	bus.PublishEvent(event1)
-	if !reflect.DeepEqual(handler.Events, []eventhorizon.Event{event1}) {
+	if !reflect.DeepEqual(handler.Events, []eh.Event{event1}) {
 		t.Error("the handler events should be correct:", handler.Events)
 	}
 	<-observer.Recv
-	if !reflect.DeepEqual(observer.Events, []eventhorizon.Event{event1, event1}) {
+	if !reflect.DeepEqual(observer.Events, []eh.Event{event1, event1}) {
 		t.Error("the observed events should be correct:", observer.Events)
 	}
 	<-observer2.Recv
-	if !reflect.DeepEqual(observer2.Events, []eventhorizon.Event{event1, event1}) {
+	if !reflect.DeepEqual(observer2.Events, []eh.Event{event1, event1}) {
 		t.Error("the second observed events should be correct:", observer2.Events)
 	}
 
 	t.Log("publish another event")
 	bus.AddHandler(handler, testutil.TestEventOtherType)
-	event2 := &testutil.TestEventOther{eventhorizon.NewUUID(), "event2"}
+	event2 := &testutil.TestEventOther{eh.NewUUID(), "event2"}
 	bus.PublishEvent(event2)
-	if !reflect.DeepEqual(handler.Events, []eventhorizon.Event{event1, event2}) {
+	if !reflect.DeepEqual(handler.Events, []eh.Event{event1, event2}) {
 		t.Error("the handler events should be correct:", handler.Events)
 	}
 	<-observer.Recv
-	if !reflect.DeepEqual(observer.Events, []eventhorizon.Event{event1, event1, event2}) {
+	if !reflect.DeepEqual(observer.Events, []eh.Event{event1, event1, event2}) {
 		t.Error("the observed events should be correct:", observer.Events)
 	}
 	<-observer2.Recv
-	if !reflect.DeepEqual(observer2.Events, []eventhorizon.Event{event1, event1, event2}) {
+	if !reflect.DeepEqual(observer2.Events, []eh.Event{event1, event1, event2}) {
 		t.Error("the second observed events should be correct:", observer2.Events)
 	}
 }

--- a/eventhorizon_test.go
+++ b/eventhorizon_test.go
@@ -25,6 +25,9 @@ func init() {
 	RegisterAggregate(func(id UUID) Aggregate {
 		return &TestAggregate2{AggregateBase: NewAggregateBase(id)}
 	})
+
+	RegisterEvent(func() Event { return &TestEvent{} })
+	RegisterEvent(func() Event { return &TestEvent2{} })
 }
 
 const (

--- a/eventhorizon_test.go
+++ b/eventhorizon_test.go
@@ -94,36 +94,36 @@ type TestCommand struct {
 	Content string
 }
 
-func (t *TestCommand) AggregateID() UUID            { return t.TestID }
-func (t *TestCommand) AggregateType() AggregateType { return TestAggregateType }
-func (t *TestCommand) CommandType() CommandType     { return TestCommandType }
+func (t TestCommand) AggregateID() UUID            { return t.TestID }
+func (t TestCommand) AggregateType() AggregateType { return TestAggregateType }
+func (t TestCommand) CommandType() CommandType     { return TestCommandType }
 
 type TestCommand2 struct {
 	TestID  UUID
 	Content string
 }
 
-func (t *TestCommand2) AggregateID() UUID            { return t.TestID }
-func (t *TestCommand2) AggregateType() AggregateType { return TestAggregate2Type }
-func (t *TestCommand2) CommandType() CommandType     { return TestCommand2Type }
+func (t TestCommand2) AggregateID() UUID            { return t.TestID }
+func (t TestCommand2) AggregateType() AggregateType { return TestAggregate2Type }
+func (t TestCommand2) CommandType() CommandType     { return TestCommand2Type }
 
 type TestEvent struct {
 	TestID  UUID
 	Content string
 }
 
-func (t *TestEvent) AggregateID() UUID            { return t.TestID }
-func (t *TestEvent) AggregateType() AggregateType { return TestAggregateType }
-func (t *TestEvent) EventType() EventType         { return TestEventType }
+func (t TestEvent) AggregateID() UUID            { return t.TestID }
+func (t TestEvent) AggregateType() AggregateType { return TestAggregateType }
+func (t TestEvent) EventType() EventType         { return TestEventType }
 
 type TestEvent2 struct {
 	TestID  UUID
 	Content string
 }
 
-func (t *TestEvent2) AggregateID() UUID            { return t.TestID }
-func (t *TestEvent2) AggregateType() AggregateType { return TestAggregate2Type }
-func (t *TestEvent2) EventType() EventType         { return TestEvent2Type }
+func (t TestEvent2) AggregateID() UUID            { return t.TestID }
+func (t TestEvent2) AggregateType() AggregateType { return TestAggregate2Type }
+func (t TestEvent2) EventType() EventType         { return TestEvent2Type }
 
 type MockRepository struct {
 	Aggregates map[UUID]Aggregate

--- a/eventhorizon_test.go
+++ b/eventhorizon_test.go
@@ -18,6 +18,15 @@ import (
 	"errors"
 )
 
+func init() {
+	RegisterAggregate(func(id UUID) Aggregate {
+		return &TestAggregate{AggregateBase: NewAggregateBase(id)}
+	})
+	RegisterAggregate(func(id UUID) Aggregate {
+		return &TestAggregate2{AggregateBase: NewAggregateBase(id)}
+	})
+}
+
 const (
 	TestAggregateType  AggregateType = "TestAggregate"
 	TestAggregate2Type               = "TestAggregate2"

--- a/eventhorizon_test.go
+++ b/eventhorizon_test.go
@@ -32,13 +32,13 @@ func init() {
 
 const (
 	TestAggregateType  AggregateType = "TestAggregate"
-	TestAggregate2Type               = "TestAggregate2"
+	TestAggregate2Type AggregateType = "TestAggregate2"
 
 	TestEventType  EventType = "TestEvent"
-	TestEvent2Type           = "TestEvent2"
+	TestEvent2Type EventType = "TestEvent2"
 
 	TestCommandType  CommandType = "TestCommand"
-	TestCommand2Type             = "TestCommand2"
+	TestCommand2Type CommandType = "TestCommand2"
 )
 
 type TestAggregate struct {

--- a/eventstore/dynamodb/eventstore_test.go
+++ b/eventstore/dynamodb/eventstore_test.go
@@ -17,13 +17,13 @@ package mongodb
 import (
 	"testing"
 
-	"github.com/looplab/eventhorizon"
+	eh "github.com/looplab/eventhorizon"
 	"github.com/looplab/eventhorizon/testutil"
 )
 
 func TestEventStore(t *testing.T) {
 	config := &EventStoreConfig{
-		Table:  "eventhorizonTest-" + eventhorizon.NewUUID().String(),
+		Table:  "eventhorizonTest-" + eh.NewUUID().String(),
 		Region: "eu-west-1",
 	}
 	store, err := NewEventStore(config)
@@ -34,7 +34,7 @@ func TestEventStore(t *testing.T) {
 		t.Fatal("there should be a store")
 	}
 
-	if err = store.RegisterEventType(testutil.TestEventType, func() eventhorizon.Event {
+	if err = store.RegisterEventType(testutil.TestEventType, func() eh.Event {
 		return &testutil.TestEvent{}
 	}); err != nil {
 		t.Fatal("there should be no error:", err)

--- a/eventstore/memory/eventstore.go
+++ b/eventstore/memory/eventstore.go
@@ -17,24 +17,24 @@ package memory
 import (
 	"time"
 
-	"github.com/looplab/eventhorizon"
+	eh "github.com/looplab/eventhorizon"
 )
 
 // EventStore implements EventStore as an in memory structure.
 type EventStore struct {
-	aggregateRecords map[eventhorizon.UUID]*memoryAggregateRecord
+	aggregateRecords map[eh.UUID]*memoryAggregateRecord
 }
 
 // NewEventStore creates a new EventStore.
 func NewEventStore() *EventStore {
 	s := &EventStore{
-		aggregateRecords: make(map[eventhorizon.UUID]*memoryAggregateRecord),
+		aggregateRecords: make(map[eh.UUID]*memoryAggregateRecord),
 	}
 	return s
 }
 
 type memoryAggregateRecord struct {
-	aggregateID eventhorizon.UUID
+	aggregateID eh.UUID
 	version     int
 	events      []*memoryEventRecord
 }
@@ -42,14 +42,14 @@ type memoryAggregateRecord struct {
 type memoryEventRecord struct {
 	version   int
 	timestamp time.Time
-	eventType eventhorizon.EventType
-	event     eventhorizon.Event
+	eventType eh.EventType
+	event     eh.Event
 }
 
 // Save appends all events in the event stream to the memory store.
-func (s *EventStore) Save(events []eventhorizon.Event) error {
+func (s *EventStore) Save(events []eh.Event) error {
 	if len(events) == 0 {
-		return eventhorizon.ErrNoEventsToAppend
+		return eh.ErrNoEventsToAppend
 	}
 
 	for _, event := range events {
@@ -77,14 +77,14 @@ func (s *EventStore) Save(events []eventhorizon.Event) error {
 
 // Load loads all events for the aggregate id from the memory store.
 // Returns ErrNoEventsFound if no events can be found.
-func (s *EventStore) Load(id eventhorizon.UUID) ([]eventhorizon.Event, error) {
+func (s *EventStore) Load(id eh.UUID) ([]eh.Event, error) {
 	if a, ok := s.aggregateRecords[id]; ok {
-		events := make([]eventhorizon.Event, len(a.events))
+		events := make([]eh.Event, len(a.events))
 		for i, r := range a.events {
 			events[i] = r.event
 		}
 		return events, nil
 	}
 
-	return []eventhorizon.Event{}, nil
+	return []eh.Event{}, nil
 }

--- a/eventstore/mongodb/eventstore_test.go
+++ b/eventstore/mongodb/eventstore_test.go
@@ -18,7 +18,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/looplab/eventhorizon"
 	"github.com/looplab/eventhorizon/testutil"
 )
 
@@ -38,12 +37,6 @@ func TestEventStore(t *testing.T) {
 	}
 	if store == nil {
 		t.Fatal("there should be a store")
-	}
-
-	if err = store.RegisterEventType(testutil.TestEventType, func() eventhorizon.Event {
-		return &testutil.TestEvent{}
-	}); err != nil {
-		t.Fatal("there should be no error:", err)
 	}
 
 	defer store.Close()

--- a/eventstore/trace/eventstore.go
+++ b/eventstore/trace/eventstore.go
@@ -17,7 +17,7 @@ package trace
 import (
 	"errors"
 
-	"github.com/looplab/eventhorizon"
+	eh "github.com/looplab/eventhorizon"
 )
 
 // ErrNoEventStoreDefined is if no event store has been defined.
@@ -25,22 +25,22 @@ var ErrNoEventStoreDefined = errors.New("no event store defined")
 
 // EventStore wraps an EventStore and adds debug tracing.
 type EventStore struct {
-	eventStore eventhorizon.EventStore
+	eventStore eh.EventStore
 	tracing    bool
-	trace      []eventhorizon.Event
+	trace      []eh.Event
 }
 
 // NewEventStore creates a new EventStore.
-func NewEventStore(eventStore eventhorizon.EventStore) *EventStore {
+func NewEventStore(eventStore eh.EventStore) *EventStore {
 	s := &EventStore{
 		eventStore: eventStore,
-		trace:      make([]eventhorizon.Event, 0),
+		trace:      make([]eh.Event, 0),
 	}
 	return s
 }
 
 // Save appends all events to the base store and trace them if enabled.
-func (s *EventStore) Save(events []eventhorizon.Event) error {
+func (s *EventStore) Save(events []eh.Event) error {
 	if s.tracing {
 		s.trace = append(s.trace, events...)
 	}
@@ -54,7 +54,7 @@ func (s *EventStore) Save(events []eventhorizon.Event) error {
 
 // Load loads all events for the aggregate id from the base store.
 // Returns ErrNoEventStoreDefined if no event store could be found.
-func (s *EventStore) Load(id eventhorizon.UUID) ([]eventhorizon.Event, error) {
+func (s *EventStore) Load(id eh.UUID) ([]eh.Event, error) {
 	if s.eventStore != nil {
 		return s.eventStore.Load(id)
 	}
@@ -73,11 +73,11 @@ func (s *EventStore) StopTracing() {
 }
 
 // GetTrace returns the events that happened during the tracing.
-func (s *EventStore) GetTrace() []eventhorizon.Event {
+func (s *EventStore) GetTrace() []eh.Event {
 	return s.trace
 }
 
 // ResetTrace resets the trace.
 func (s *EventStore) ResetTrace() {
-	s.trace = make([]eventhorizon.Event, 0)
+	s.trace = make([]eh.Event, 0)
 }

--- a/eventstore/trace/eventstore_test.go
+++ b/eventstore/trace/eventstore_test.go
@@ -18,7 +18,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/looplab/eventhorizon"
+	eh "github.com/looplab/eventhorizon"
 	"github.com/looplab/eventhorizon/eventstore/memory"
 	"github.com/looplab/eventhorizon/testutil"
 )
@@ -49,7 +49,7 @@ func TestEventStore(t *testing.T) {
 	}
 
 	event1 := savedEvents[0]
-	aggregate1events := []eventhorizon.Event{}
+	aggregate1events := []eh.Event{}
 	for _, e := range savedEvents {
 		if e.AggregateID() == event1.AggregateID() {
 			aggregate1events = append(aggregate1events, e)
@@ -57,7 +57,7 @@ func TestEventStore(t *testing.T) {
 	}
 
 	t.Log("save event, version 4")
-	err := store.Save([]eventhorizon.Event{event1})
+	err := store.Save([]eh.Event{event1})
 	if err != nil {
 		t.Error("there should be no error:", err)
 	}

--- a/examples/domain/aggregate.go
+++ b/examples/domain/aggregate.go
@@ -37,6 +37,13 @@ type InvitationAggregate struct {
 	declined bool
 }
 
+// NewInvitationAggregate creates a new InvitationAggregate with an ID.
+func NewInvitationAggregate(id eventhorizon.UUID) *InvitationAggregate {
+	return &InvitationAggregate{
+		AggregateBase: eventhorizon.NewAggregateBase(id),
+	}
+}
+
 // AggregateType implements the AggregateType method of the Aggregate interface.
 func (i *InvitationAggregate) AggregateType() eventhorizon.AggregateType {
 	return InvitationAggregateType

--- a/examples/domain/aggregate.go
+++ b/examples/domain/aggregate.go
@@ -20,6 +20,12 @@ import (
 	"github.com/looplab/eventhorizon"
 )
 
+func init() {
+	eventhorizon.RegisterAggregate(func(id eventhorizon.UUID) eventhorizon.Aggregate {
+		return NewInvitationAggregate(id)
+	})
+}
+
 // InvitationAggregateType is the type name of the aggregate.
 const InvitationAggregateType eventhorizon.AggregateType = "Invitation"
 

--- a/examples/domain/aggregate.go
+++ b/examples/domain/aggregate.go
@@ -17,17 +17,17 @@ package domain
 import (
 	"fmt"
 
-	"github.com/looplab/eventhorizon"
+	eh "github.com/looplab/eventhorizon"
 )
 
 func init() {
-	eventhorizon.RegisterAggregate(func(id eventhorizon.UUID) eventhorizon.Aggregate {
+	eh.RegisterAggregate(func(id eh.UUID) eh.Aggregate {
 		return NewInvitationAggregate(id)
 	})
 }
 
 // InvitationAggregateType is the type name of the aggregate.
-const InvitationAggregateType eventhorizon.AggregateType = "Invitation"
+const InvitationAggregateType eh.AggregateType = "Invitation"
 
 // InvitationAggregate is the root aggregate.
 //
@@ -35,7 +35,7 @@ const InvitationAggregateType eventhorizon.AggregateType = "Invitation"
 // declined, but not both.
 type InvitationAggregate struct {
 	// AggregateBase implements most of the eventhorizon.Aggregate interface.
-	*eventhorizon.AggregateBase
+	*eh.AggregateBase
 
 	name     string
 	age      int
@@ -44,19 +44,19 @@ type InvitationAggregate struct {
 }
 
 // NewInvitationAggregate creates a new InvitationAggregate with an ID.
-func NewInvitationAggregate(id eventhorizon.UUID) *InvitationAggregate {
+func NewInvitationAggregate(id eh.UUID) *InvitationAggregate {
 	return &InvitationAggregate{
-		AggregateBase: eventhorizon.NewAggregateBase(id),
+		AggregateBase: eh.NewAggregateBase(id),
 	}
 }
 
 // AggregateType implements the AggregateType method of the Aggregate interface.
-func (i *InvitationAggregate) AggregateType() eventhorizon.AggregateType {
+func (i *InvitationAggregate) AggregateType() eh.AggregateType {
 	return InvitationAggregateType
 }
 
 // HandleCommand implements the HandleCommand method of the Aggregate interface.
-func (i *InvitationAggregate) HandleCommand(command eventhorizon.Command) error {
+func (i *InvitationAggregate) HandleCommand(command eh.Command) error {
 	switch command := command.(type) {
 	case *CreateInvite:
 		i.StoreEvent(&InviteCreated{command.InvitationID, command.Name, command.Age})
@@ -98,7 +98,7 @@ func (i *InvitationAggregate) HandleCommand(command eventhorizon.Command) error 
 }
 
 // ApplyEvent implements the ApplyEvent method of the Aggregate interface.
-func (i *InvitationAggregate) ApplyEvent(event eventhorizon.Event) {
+func (i *InvitationAggregate) ApplyEvent(event eh.Event) {
 	switch event := event.(type) {
 	case *InviteCreated:
 		i.name = event.Name

--- a/examples/domain/commands.go
+++ b/examples/domain/commands.go
@@ -20,8 +20,8 @@ import (
 
 const (
 	CreateInviteCommand  eventhorizon.CommandType = "CreateInvite"
-	AcceptInviteCommand                           = "AcceptInvite"
-	DeclineInviteCommand                          = "DeclineInvite"
+	AcceptInviteCommand  eventhorizon.CommandType = "AcceptInvite"
+	DeclineInviteCommand eventhorizon.CommandType = "DeclineInvite"
 )
 
 // CreateInvite is a command for creating invites.

--- a/examples/domain/commands.go
+++ b/examples/domain/commands.go
@@ -15,40 +15,40 @@
 package domain
 
 import (
-	"github.com/looplab/eventhorizon"
+	eh "github.com/looplab/eventhorizon"
 )
 
 const (
-	CreateInviteCommand  eventhorizon.CommandType = "CreateInvite"
-	AcceptInviteCommand  eventhorizon.CommandType = "AcceptInvite"
-	DeclineInviteCommand eventhorizon.CommandType = "DeclineInvite"
+	CreateInviteCommand  eh.CommandType = "CreateInvite"
+	AcceptInviteCommand  eh.CommandType = "AcceptInvite"
+	DeclineInviteCommand eh.CommandType = "DeclineInvite"
 )
 
 // CreateInvite is a command for creating invites.
 type CreateInvite struct {
-	InvitationID eventhorizon.UUID
+	InvitationID eh.UUID
 	Name         string
 	Age          int `eh:"optional"`
 }
 
-func (c CreateInvite) AggregateID() eventhorizon.UUID            { return c.InvitationID }
-func (c CreateInvite) AggregateType() eventhorizon.AggregateType { return InvitationAggregateType }
-func (c CreateInvite) CommandType() eventhorizon.CommandType     { return CreateInviteCommand }
+func (c CreateInvite) AggregateID() eh.UUID            { return c.InvitationID }
+func (c CreateInvite) AggregateType() eh.AggregateType { return InvitationAggregateType }
+func (c CreateInvite) CommandType() eh.CommandType     { return CreateInviteCommand }
 
 // AcceptInvite is a command for accepting invites.
 type AcceptInvite struct {
-	InvitationID eventhorizon.UUID
+	InvitationID eh.UUID
 }
 
-func (c AcceptInvite) AggregateID() eventhorizon.UUID            { return c.InvitationID }
-func (c AcceptInvite) AggregateType() eventhorizon.AggregateType { return InvitationAggregateType }
-func (c AcceptInvite) CommandType() eventhorizon.CommandType     { return AcceptInviteCommand }
+func (c AcceptInvite) AggregateID() eh.UUID            { return c.InvitationID }
+func (c AcceptInvite) AggregateType() eh.AggregateType { return InvitationAggregateType }
+func (c AcceptInvite) CommandType() eh.CommandType     { return AcceptInviteCommand }
 
 // DeclineInvite is a command for declining invites.
 type DeclineInvite struct {
-	InvitationID eventhorizon.UUID
+	InvitationID eh.UUID
 }
 
-func (c DeclineInvite) AggregateID() eventhorizon.UUID            { return c.InvitationID }
-func (c DeclineInvite) AggregateType() eventhorizon.AggregateType { return InvitationAggregateType }
-func (c DeclineInvite) CommandType() eventhorizon.CommandType     { return DeclineInviteCommand }
+func (c DeclineInvite) AggregateID() eh.UUID            { return c.InvitationID }
+func (c DeclineInvite) AggregateType() eh.AggregateType { return InvitationAggregateType }
+func (c DeclineInvite) CommandType() eh.CommandType     { return DeclineInviteCommand }

--- a/examples/domain/commands.go
+++ b/examples/domain/commands.go
@@ -31,24 +31,24 @@ type CreateInvite struct {
 	Age          int `eh:"optional"`
 }
 
-func (c *CreateInvite) AggregateID() eventhorizon.UUID            { return c.InvitationID }
-func (c *CreateInvite) AggregateType() eventhorizon.AggregateType { return InvitationAggregateType }
-func (c *CreateInvite) CommandType() eventhorizon.CommandType     { return CreateInviteCommand }
+func (c CreateInvite) AggregateID() eventhorizon.UUID            { return c.InvitationID }
+func (c CreateInvite) AggregateType() eventhorizon.AggregateType { return InvitationAggregateType }
+func (c CreateInvite) CommandType() eventhorizon.CommandType     { return CreateInviteCommand }
 
 // AcceptInvite is a command for accepting invites.
 type AcceptInvite struct {
 	InvitationID eventhorizon.UUID
 }
 
-func (c *AcceptInvite) AggregateID() eventhorizon.UUID            { return c.InvitationID }
-func (c *AcceptInvite) AggregateType() eventhorizon.AggregateType { return InvitationAggregateType }
-func (c *AcceptInvite) CommandType() eventhorizon.CommandType     { return AcceptInviteCommand }
+func (c AcceptInvite) AggregateID() eventhorizon.UUID            { return c.InvitationID }
+func (c AcceptInvite) AggregateType() eventhorizon.AggregateType { return InvitationAggregateType }
+func (c AcceptInvite) CommandType() eventhorizon.CommandType     { return AcceptInviteCommand }
 
 // DeclineInvite is a command for declining invites.
 type DeclineInvite struct {
 	InvitationID eventhorizon.UUID
 }
 
-func (c *DeclineInvite) AggregateID() eventhorizon.UUID            { return c.InvitationID }
-func (c *DeclineInvite) AggregateType() eventhorizon.AggregateType { return InvitationAggregateType }
-func (c *DeclineInvite) CommandType() eventhorizon.CommandType     { return DeclineInviteCommand }
+func (c DeclineInvite) AggregateID() eventhorizon.UUID            { return c.InvitationID }
+func (c DeclineInvite) AggregateType() eventhorizon.AggregateType { return InvitationAggregateType }
+func (c DeclineInvite) CommandType() eventhorizon.CommandType     { return DeclineInviteCommand }

--- a/examples/domain/events.go
+++ b/examples/domain/events.go
@@ -31,24 +31,24 @@ type InviteCreated struct {
 	Age          int               `bson:"age"`
 }
 
-func (c *InviteCreated) AggregateID() eventhorizon.UUID            { return c.InvitationID }
-func (c *InviteCreated) AggregateType() eventhorizon.AggregateType { return InvitationAggregateType }
-func (c *InviteCreated) EventType() eventhorizon.EventType         { return InviteCreatedEvent }
+func (c InviteCreated) AggregateID() eventhorizon.UUID            { return c.InvitationID }
+func (c InviteCreated) AggregateType() eventhorizon.AggregateType { return InvitationAggregateType }
+func (c InviteCreated) EventType() eventhorizon.EventType         { return InviteCreatedEvent }
 
 // InviteAccepted is an event for when an invite has been accepted.
 type InviteAccepted struct {
 	InvitationID eventhorizon.UUID `bson:"invitation_id"`
 }
 
-func (c *InviteAccepted) AggregateID() eventhorizon.UUID            { return c.InvitationID }
-func (c *InviteAccepted) AggregateType() eventhorizon.AggregateType { return InvitationAggregateType }
-func (c *InviteAccepted) EventType() eventhorizon.EventType         { return InviteAcceptedEvent }
+func (c InviteAccepted) AggregateID() eventhorizon.UUID            { return c.InvitationID }
+func (c InviteAccepted) AggregateType() eventhorizon.AggregateType { return InvitationAggregateType }
+func (c InviteAccepted) EventType() eventhorizon.EventType         { return InviteAcceptedEvent }
 
 // InviteDeclined is an event for when an invite has been declined.
 type InviteDeclined struct {
 	InvitationID eventhorizon.UUID `bson:"invitation_id"`
 }
 
-func (c *InviteDeclined) AggregateID() eventhorizon.UUID            { return c.InvitationID }
-func (c *InviteDeclined) AggregateType() eventhorizon.AggregateType { return InvitationAggregateType }
-func (c *InviteDeclined) EventType() eventhorizon.EventType         { return InviteDeclinedEvent }
+func (c InviteDeclined) AggregateID() eventhorizon.UUID            { return c.InvitationID }
+func (c InviteDeclined) AggregateType() eventhorizon.AggregateType { return InvitationAggregateType }
+func (c InviteDeclined) EventType() eventhorizon.EventType         { return InviteDeclinedEvent }

--- a/examples/domain/events.go
+++ b/examples/domain/events.go
@@ -18,6 +18,12 @@ import (
 	"github.com/looplab/eventhorizon"
 )
 
+func init() {
+	eventhorizon.RegisterEvent(func() eventhorizon.Event { return &InviteCreated{} })
+	eventhorizon.RegisterEvent(func() eventhorizon.Event { return &InviteAccepted{} })
+	eventhorizon.RegisterEvent(func() eventhorizon.Event { return &InviteDeclined{} })
+}
+
 const (
 	InviteCreatedEvent  eventhorizon.EventType = "InviteCreated"
 	InviteAcceptedEvent                        = "InviteAccepted"

--- a/examples/domain/events.go
+++ b/examples/domain/events.go
@@ -26,8 +26,8 @@ func init() {
 
 const (
 	InviteCreatedEvent  eventhorizon.EventType = "InviteCreated"
-	InviteAcceptedEvent                        = "InviteAccepted"
-	InviteDeclinedEvent                        = "InviteDeclined"
+	InviteAcceptedEvent eventhorizon.EventType = "InviteAccepted"
+	InviteDeclinedEvent eventhorizon.EventType = "InviteDeclined"
 )
 
 // InviteCreated is an event for when an invite has been created.

--- a/examples/domain/events.go
+++ b/examples/domain/events.go
@@ -15,46 +15,46 @@
 package domain
 
 import (
-	"github.com/looplab/eventhorizon"
+	eh "github.com/looplab/eventhorizon"
 )
 
 func init() {
-	eventhorizon.RegisterEvent(func() eventhorizon.Event { return &InviteCreated{} })
-	eventhorizon.RegisterEvent(func() eventhorizon.Event { return &InviteAccepted{} })
-	eventhorizon.RegisterEvent(func() eventhorizon.Event { return &InviteDeclined{} })
+	eh.RegisterEvent(func() eh.Event { return &InviteCreated{} })
+	eh.RegisterEvent(func() eh.Event { return &InviteAccepted{} })
+	eh.RegisterEvent(func() eh.Event { return &InviteDeclined{} })
 }
 
 const (
-	InviteCreatedEvent  eventhorizon.EventType = "InviteCreated"
-	InviteAcceptedEvent eventhorizon.EventType = "InviteAccepted"
-	InviteDeclinedEvent eventhorizon.EventType = "InviteDeclined"
+	InviteCreatedEvent  eh.EventType = "InviteCreated"
+	InviteAcceptedEvent eh.EventType = "InviteAccepted"
+	InviteDeclinedEvent eh.EventType = "InviteDeclined"
 )
 
 // InviteCreated is an event for when an invite has been created.
 type InviteCreated struct {
-	InvitationID eventhorizon.UUID `bson:"invitation_id"`
-	Name         string            `bson:"name"`
-	Age          int               `bson:"age"`
+	InvitationID eh.UUID `bson:"invitation_id"`
+	Name         string  `bson:"name"`
+	Age          int     `bson:"age"`
 }
 
-func (c InviteCreated) AggregateID() eventhorizon.UUID            { return c.InvitationID }
-func (c InviteCreated) AggregateType() eventhorizon.AggregateType { return InvitationAggregateType }
-func (c InviteCreated) EventType() eventhorizon.EventType         { return InviteCreatedEvent }
+func (c InviteCreated) AggregateID() eh.UUID            { return c.InvitationID }
+func (c InviteCreated) AggregateType() eh.AggregateType { return InvitationAggregateType }
+func (c InviteCreated) EventType() eh.EventType         { return InviteCreatedEvent }
 
 // InviteAccepted is an event for when an invite has been accepted.
 type InviteAccepted struct {
-	InvitationID eventhorizon.UUID `bson:"invitation_id"`
+	InvitationID eh.UUID `bson:"invitation_id"`
 }
 
-func (c InviteAccepted) AggregateID() eventhorizon.UUID            { return c.InvitationID }
-func (c InviteAccepted) AggregateType() eventhorizon.AggregateType { return InvitationAggregateType }
-func (c InviteAccepted) EventType() eventhorizon.EventType         { return InviteAcceptedEvent }
+func (c InviteAccepted) AggregateID() eh.UUID            { return c.InvitationID }
+func (c InviteAccepted) AggregateType() eh.AggregateType { return InvitationAggregateType }
+func (c InviteAccepted) EventType() eh.EventType         { return InviteAcceptedEvent }
 
 // InviteDeclined is an event for when an invite has been declined.
 type InviteDeclined struct {
-	InvitationID eventhorizon.UUID `bson:"invitation_id"`
+	InvitationID eh.UUID `bson:"invitation_id"`
 }
 
-func (c InviteDeclined) AggregateID() eventhorizon.UUID            { return c.InvitationID }
-func (c InviteDeclined) AggregateType() eventhorizon.AggregateType { return InvitationAggregateType }
-func (c InviteDeclined) EventType() eventhorizon.EventType         { return InviteDeclinedEvent }
+func (c InviteDeclined) AggregateID() eh.UUID            { return c.InvitationID }
+func (c InviteDeclined) AggregateType() eh.AggregateType { return InvitationAggregateType }
+func (c InviteDeclined) EventType() eh.EventType         { return InviteDeclinedEvent }

--- a/examples/domain/logger.go
+++ b/examples/domain/logger.go
@@ -17,13 +17,13 @@ package domain
 import (
 	"log"
 
-	"github.com/looplab/eventhorizon"
+	eh "github.com/looplab/eventhorizon"
 )
 
 // Logger is a simple event handler for logging all events.
 type Logger struct{}
 
 // Notify implements the HandleEvent method of the EventHandler interface.
-func (l *Logger) Notify(event eventhorizon.Event) {
+func (l *Logger) Notify(event eh.Event) {
 	log.Printf("event: %#v\n", event)
 }

--- a/examples/domain/projectors.go
+++ b/examples/domain/projectors.go
@@ -15,12 +15,12 @@
 package domain
 
 import (
-	"github.com/looplab/eventhorizon"
+	eh "github.com/looplab/eventhorizon"
 )
 
 // Invitation is a read model object for an invitation.
 type Invitation struct {
-	ID     eventhorizon.UUID  `json:"id"         bson:"_id"`
+	ID     eh.UUID
 	Name   string
 	Age    int
 	Status string
@@ -28,11 +28,11 @@ type Invitation struct {
 
 // InvitationProjector is a projector that updates the invitations.
 type InvitationProjector struct {
-	repository eventhorizon.ReadRepository
+	repository eh.ReadRepository
 }
 
 // NewInvitationProjector creates a new InvitationProjector.
-func NewInvitationProjector(repository eventhorizon.ReadRepository) *InvitationProjector {
+func NewInvitationProjector(repository eh.ReadRepository) *InvitationProjector {
 	p := &InvitationProjector{
 		repository: repository,
 	}
@@ -40,18 +40,18 @@ func NewInvitationProjector(repository eventhorizon.ReadRepository) *InvitationP
 }
 
 // HandlerType implements the HandlerType method of the EventHandler interface.
-func (p *InvitationProjector) HandlerType() eventhorizon.EventHandlerType {
-	return eventhorizon.EventHandlerType("InvitationProjector")
+func (p *InvitationProjector) HandlerType() eh.EventHandlerType {
+	return eh.EventHandlerType("InvitationProjector")
 }
 
 // HandleEvent implements the HandleEvent method of the EventHandler interface.
-func (p *InvitationProjector) HandleEvent(event eventhorizon.Event) {
+func (p *InvitationProjector) HandleEvent(event eh.Event) {
 	switch event := event.(type) {
 	case *InviteCreated:
 		i := &Invitation{
-			ID:   event.InvitationID,
-			Name: event.Name,
-			Age:  event.Age,
+			ID:     event.InvitationID,
+			Name:   event.Name,
+			Age:    event.Age,
 			Status: "created",
 		}
 		p.repository.Save(i.ID, i)
@@ -70,7 +70,7 @@ func (p *InvitationProjector) HandleEvent(event eventhorizon.Event) {
 
 // GuestList is a read model object for the guest list.
 type GuestList struct {
-	Id     	    eventhorizon.UUID  `json:"id"         bson:"_id"`
+	Id          eh.UUID `json:"id"         bson:"_id"`
 	NumGuests   int
 	NumAccepted int
 	NumDeclined int
@@ -78,12 +78,12 @@ type GuestList struct {
 
 // GuestListProjector is a projector that updates the guest list.
 type GuestListProjector struct {
-	repository eventhorizon.ReadRepository
-	eventID    eventhorizon.UUID
+	repository eh.ReadRepository
+	eventID    eh.UUID
 }
 
 // NewGuestListProjector creates a new GuestListProjector.
-func NewGuestListProjector(repository eventhorizon.ReadRepository, eventID eventhorizon.UUID) *GuestListProjector {
+func NewGuestListProjector(repository eh.ReadRepository, eventID eh.UUID) *GuestListProjector {
 	p := &GuestListProjector{
 		repository: repository,
 		eventID:    eventID,
@@ -92,12 +92,12 @@ func NewGuestListProjector(repository eventhorizon.ReadRepository, eventID event
 }
 
 // HandlerType implements the HandlerType method of the EventHandler interface.
-func (p *GuestListProjector) HandlerType() eventhorizon.EventHandlerType {
-	return eventhorizon.EventHandlerType("GuestListProjector")
+func (p *GuestListProjector) HandlerType() eh.EventHandlerType {
+	return eh.EventHandlerType("GuestListProjector")
 }
 
 // HandleEvent implements the HandleEvent method of the EventHandler interface.
-func (p *GuestListProjector) HandleEvent(event eventhorizon.Event) {
+func (p *GuestListProjector) HandleEvent(event eh.Event) {
 	switch event.(type) {
 	case *InviteCreated:
 		m, _ := p.repository.Find(p.eventID)

--- a/examples/mongodb/mongodb_test.go
+++ b/examples/mongodb/mongodb_test.go
@@ -51,9 +51,7 @@ func Example() {
 	// Register an aggregate factory.
 	repository.RegisterAggregate(domain.InvitationAggregateType,
 		func(id eventhorizon.UUID) eventhorizon.Aggregate {
-			return &domain.InvitationAggregate{
-				AggregateBase: eventhorizon.NewAggregateBase(id),
-			}
+			return domain.NewInvitationAggregate(id)
 		},
 	)
 

--- a/examples/mongodb/mongodb_test.go
+++ b/examples/mongodb/mongodb_test.go
@@ -43,7 +43,7 @@ func Example() {
 	eventBus.AddObserver(&domain.Logger{})
 
 	// Create the aggregate repository.
-	repository, err := eventhorizon.NewCallbackRepository(eventStore, eventBus)
+	repository, err := eventhorizon.NewEventSourcingRepository(eventStore, eventBus)
 	if err != nil {
 		log.Fatalf("could not create repository: %s", err)
 	}

--- a/examples/mongodb/mongodb_test.go
+++ b/examples/mongodb/mongodb_test.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/looplab/eventhorizon"
+	eh "github.com/looplab/eventhorizon"
 	commandbus "github.com/looplab/eventhorizon/commandbus/local"
 	eventbus "github.com/looplab/eventhorizon/eventbus/local"
 	eventstore "github.com/looplab/eventhorizon/eventstore/mongodb"
@@ -39,13 +39,13 @@ func Example() {
 	eventBus.AddObserver(&domain.Logger{})
 
 	// Create the aggregate repository.
-	repository, err := eventhorizon.NewEventSourcingRepository(eventStore, eventBus)
+	repository, err := eh.NewEventSourcingRepository(eventStore, eventBus)
 	if err != nil {
 		log.Fatalf("could not create repository: %s", err)
 	}
 
 	// Create the aggregate command handler.
-	handler, err := eventhorizon.NewAggregateCommandHandler(repository)
+	handler, err := eh.NewAggregateCommandHandler(repository)
 	if err != nil {
 		log.Fatalf("could not create command handler: %s", err)
 	}
@@ -74,7 +74,7 @@ func Example() {
 	eventBus.AddHandler(invitationProjector, domain.InviteDeclinedEvent)
 
 	// Create and register a read model for a guest list.
-	eventID := eventhorizon.NewUUID()
+	eventID := eh.NewUUID()
 	guestListRepository, err := readrepository.NewReadRepository("localhost", "demo", "guest_lists")
 	if err != nil {
 		log.Fatalf("could not create guest list repository: %s", err)
@@ -94,7 +94,7 @@ func Example() {
 	// Note that Athena tries to decline the event, but that is not allowed
 	// by the domain logic in InvitationAggregate. The result is that she is
 	// still accepted.
-	athenaID := eventhorizon.NewUUID()
+	athenaID := eh.NewUUID()
 	commandBus.HandleCommand(&domain.CreateInvite{InvitationID: athenaID, Name: "Athena", Age: 42})
 	commandBus.HandleCommand(&domain.AcceptInvite{InvitationID: athenaID})
 	err = commandBus.HandleCommand(&domain.DeclineInvite{InvitationID: athenaID})
@@ -102,11 +102,11 @@ func Example() {
 		log.Printf("error: %s\n", err)
 	}
 
-	hadesID := eventhorizon.NewUUID()
+	hadesID := eh.NewUUID()
 	commandBus.HandleCommand(&domain.CreateInvite{InvitationID: hadesID, Name: "Hades"})
 	commandBus.HandleCommand(&domain.AcceptInvite{InvitationID: hadesID})
 
-	zeusID := eventhorizon.NewUUID()
+	zeusID := eh.NewUUID()
 	commandBus.HandleCommand(&domain.CreateInvite{InvitationID: zeusID, Name: "Zeus"})
 	commandBus.HandleCommand(&domain.DeclineInvite{InvitationID: zeusID})
 

--- a/examples/mongodb/mongodb_test.go
+++ b/examples/mongodb/mongodb_test.go
@@ -48,13 +48,6 @@ func Example() {
 		log.Fatalf("could not create repository: %s", err)
 	}
 
-	// Register an aggregate factory.
-	repository.RegisterAggregate(domain.InvitationAggregateType,
-		func(id eventhorizon.UUID) eventhorizon.Aggregate {
-			return domain.NewInvitationAggregate(id)
-		},
-	)
-
 	// Create the aggregate command handler.
 	handler, err := eventhorizon.NewAggregateCommandHandler(repository)
 	if err != nil {

--- a/examples/mongodb/mongodb_test.go
+++ b/examples/mongodb/mongodb_test.go
@@ -34,10 +34,6 @@ func Example() {
 		log.Fatalf("could not create event store: %s", err)
 	}
 
-	eventStore.RegisterEventType(domain.InviteCreatedEvent, func() eventhorizon.Event { return &domain.InviteCreated{} })
-	eventStore.RegisterEventType(domain.InviteAcceptedEvent, func() eventhorizon.Event { return &domain.InviteAccepted{} })
-	eventStore.RegisterEventType(domain.InviteDeclinedEvent, func() eventhorizon.Event { return &domain.InviteDeclined{} })
-
 	// Create the event bus that distributes events.
 	eventBus := eventbus.NewEventBus()
 	eventBus.AddObserver(&domain.Logger{})

--- a/examples/simple/simple_test.go
+++ b/examples/simple/simple_test.go
@@ -44,9 +44,7 @@ func Example() {
 	// Register an aggregate factory.
 	repository.RegisterAggregate(domain.InvitationAggregateType,
 		func(id eventhorizon.UUID) eventhorizon.Aggregate {
-			return &domain.InvitationAggregate{
-				AggregateBase: eventhorizon.NewAggregateBase(id),
-			}
+			return domain.NewInvitationAggregate(id)
 		},
 	)
 

--- a/examples/simple/simple_test.go
+++ b/examples/simple/simple_test.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/looplab/eventhorizon"
+	eh "github.com/looplab/eventhorizon"
 	commandbus "github.com/looplab/eventhorizon/commandbus/local"
 	eventbus "github.com/looplab/eventhorizon/eventbus/local"
 	eventstore "github.com/looplab/eventhorizon/eventstore/memory"
@@ -36,13 +36,13 @@ func Example() {
 	eventBus.AddObserver(&domain.Logger{})
 
 	// Create the aggregate repository.
-	repository, err := eventhorizon.NewEventSourcingRepository(eventStore, eventBus)
+	repository, err := eh.NewEventSourcingRepository(eventStore, eventBus)
 	if err != nil {
 		log.Fatalf("could not create repository: %s", err)
 	}
 
 	// Create the aggregate command handler.
-	handler, err := eventhorizon.NewAggregateCommandHandler(repository)
+	handler, err := eh.NewAggregateCommandHandler(repository)
 	if err != nil {
 		log.Fatalf("could not create command handler: %s", err)
 	}
@@ -67,7 +67,7 @@ func Example() {
 	eventBus.AddHandler(invitationProjector, domain.InviteDeclinedEvent)
 
 	// Create and register a read model for a guest list.
-	eventID := eventhorizon.NewUUID()
+	eventID := eh.NewUUID()
 	guestListRepository := readrepository.NewReadRepository()
 	guestListProjector := domain.NewGuestListProjector(guestListRepository, eventID)
 	eventBus.AddHandler(guestListProjector, domain.InviteCreatedEvent)
@@ -78,7 +78,7 @@ func Example() {
 	// Note that Athena tries to decline the event, but that is not allowed
 	// by the domain logic in InvitationAggregate. The result is that she is
 	// still accepted.
-	athenaID := eventhorizon.NewUUID()
+	athenaID := eh.NewUUID()
 	commandBus.HandleCommand(&domain.CreateInvite{InvitationID: athenaID, Name: "Athena", Age: 42})
 	commandBus.HandleCommand(&domain.AcceptInvite{InvitationID: athenaID})
 	err = commandBus.HandleCommand(&domain.DeclineInvite{InvitationID: athenaID})
@@ -86,11 +86,11 @@ func Example() {
 		log.Printf("error: %s\n", err)
 	}
 
-	hadesID := eventhorizon.NewUUID()
+	hadesID := eh.NewUUID()
 	commandBus.HandleCommand(&domain.CreateInvite{InvitationID: hadesID, Name: "Hades"})
 	commandBus.HandleCommand(&domain.AcceptInvite{InvitationID: hadesID})
 
-	zeusID := eventhorizon.NewUUID()
+	zeusID := eh.NewUUID()
 	commandBus.HandleCommand(&domain.CreateInvite{InvitationID: zeusID, Name: "Zeus"})
 	commandBus.HandleCommand(&domain.DeclineInvite{InvitationID: zeusID})
 

--- a/examples/simple/simple_test.go
+++ b/examples/simple/simple_test.go
@@ -36,7 +36,7 @@ func Example() {
 	eventBus.AddObserver(&domain.Logger{})
 
 	// Create the aggregate repository.
-	repository, err := eventhorizon.NewCallbackRepository(eventStore, eventBus)
+	repository, err := eventhorizon.NewEventSourcingRepository(eventStore, eventBus)
 	if err != nil {
 		log.Fatalf("could not create repository: %s", err)
 	}

--- a/examples/simple/simple_test.go
+++ b/examples/simple/simple_test.go
@@ -41,13 +41,6 @@ func Example() {
 		log.Fatalf("could not create repository: %s", err)
 	}
 
-	// Register an aggregate factory.
-	repository.RegisterAggregate(domain.InvitationAggregateType,
-		func(id eventhorizon.UUID) eventhorizon.Aggregate {
-			return domain.NewInvitationAggregate(id)
-		},
-	)
-
 	// Create the aggregate command handler.
 	handler, err := eventhorizon.NewAggregateCommandHandler(repository)
 	if err != nil {

--- a/readrepository/memory/readrepository.go
+++ b/readrepository/memory/readrepository.go
@@ -15,36 +15,36 @@
 package memory
 
 import (
-	"github.com/looplab/eventhorizon"
+	eh "github.com/looplab/eventhorizon"
 )
 
 // ReadRepository implements an in memory repository of read models.
 type ReadRepository struct {
-	data map[eventhorizon.UUID]interface{}
+	data map[eh.UUID]interface{}
 }
 
 // NewReadRepository creates a new ReadRepository.
 func NewReadRepository() *ReadRepository {
 	r := &ReadRepository{
-		data: make(map[eventhorizon.UUID]interface{}),
+		data: make(map[eh.UUID]interface{}),
 	}
 	return r
 }
 
 // Save saves a read model with id to the repository.
-func (r *ReadRepository) Save(id eventhorizon.UUID, model interface{}) error {
+func (r *ReadRepository) Save(id eh.UUID, model interface{}) error {
 	r.data[id] = model
 	return nil
 }
 
 // Find returns one read model with using an id. Returns
 // ErrModelNotFound if no model could be found.
-func (r *ReadRepository) Find(id eventhorizon.UUID) (interface{}, error) {
+func (r *ReadRepository) Find(id eh.UUID) (interface{}, error) {
 	if model, ok := r.data[id]; ok {
 		return model, nil
 	}
 
-	return nil, eventhorizon.ErrModelNotFound
+	return nil, eh.ErrModelNotFound
 }
 
 // FindAll returns all read models in the repository.
@@ -58,11 +58,11 @@ func (r *ReadRepository) FindAll() ([]interface{}, error) {
 
 // Remove removes a read model with id from the repository. Returns
 // ErrModelNotFound if no model could be found.
-func (r *ReadRepository) Remove(id eventhorizon.UUID) error {
+func (r *ReadRepository) Remove(id eh.UUID) error {
 	if _, ok := r.data[id]; ok {
 		delete(r.data, id)
 		return nil
 	}
 
-	return eventhorizon.ErrModelNotFound
+	return eh.ErrModelNotFound
 }

--- a/readrepository/memory/readrepository_test.go
+++ b/readrepository/memory/readrepository_test.go
@@ -19,7 +19,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/looplab/eventhorizon"
+	eh "github.com/looplab/eventhorizon"
 	"github.com/looplab/eventhorizon/testutil"
 )
 
@@ -41,7 +41,7 @@ func TestReadRepository(t *testing.T) {
 	}
 
 	t.Log("Save one item")
-	model1 := &testutil.TestModel{eventhorizon.NewUUID(), "model1", time.Now().Round(time.Millisecond)}
+	model1 := &testutil.TestModel{eh.NewUUID(), "model1", time.Now().Round(time.Millisecond)}
 	if err = repo.Save(model1.ID, model1); err != nil {
 		t.Error("there should be no error:", err)
 	}
@@ -79,7 +79,7 @@ func TestReadRepository(t *testing.T) {
 	}
 
 	t.Log("Save with another ID")
-	model2 := &testutil.TestModel{eventhorizon.NewUUID(), "model2", time.Now().Round(time.Millisecond)}
+	model2 := &testutil.TestModel{eh.NewUUID(), "model2", time.Now().Round(time.Millisecond)}
 	if err = repo.Save(model2.ID, model2); err != nil {
 		t.Error("there should be no error:", err)
 	}
@@ -122,7 +122,7 @@ func TestReadRepository(t *testing.T) {
 
 	t.Log("Remove non-existing item")
 	err = repo.Remove(model1Alt.ID)
-	if err != eventhorizon.ErrModelNotFound {
+	if err != eh.ErrModelNotFound {
 		t.Error("there should be a ErrModelNotFound error:", err)
 	}
 }

--- a/readrepository/mongodb/readrepository.go
+++ b/readrepository/mongodb/readrepository.go
@@ -19,7 +19,7 @@ import (
 
 	"gopkg.in/mgo.v2"
 
-	"github.com/looplab/eventhorizon"
+	eh "github.com/looplab/eventhorizon"
 )
 
 // ErrCouldNotDialDB is when the database could not be dialed.
@@ -74,19 +74,19 @@ func NewReadRepositoryWithSession(session *mgo.Session, database, collection str
 }
 
 // Save saves a read model with id to the repository.
-func (r *ReadRepository) Save(id eventhorizon.UUID, model interface{}) error {
+func (r *ReadRepository) Save(id eh.UUID, model interface{}) error {
 	sess := r.session.Copy()
 	defer sess.Close()
 
 	if _, err := sess.DB(r.db).C(r.collection).UpsertId(id, model); err != nil {
-		return eventhorizon.ErrCouldNotSaveModel
+		return eh.ErrCouldNotSaveModel
 	}
 	return nil
 }
 
 // Find returns one read model with using an id. Returns
 // ErrModelNotFound if no model could be found.
-func (r *ReadRepository) Find(id eventhorizon.UUID) (interface{}, error) {
+func (r *ReadRepository) Find(id eh.UUID) (interface{}, error) {
 	sess := r.session.Copy()
 	defer sess.Close()
 
@@ -97,7 +97,7 @@ func (r *ReadRepository) Find(id eventhorizon.UUID) (interface{}, error) {
 	model := r.factory()
 	err := sess.DB(r.db).C(r.collection).FindId(id).One(model)
 	if err != nil {
-		return nil, eventhorizon.ErrModelNotFound
+		return nil, eh.ErrModelNotFound
 	}
 
 	return model, nil
@@ -161,13 +161,13 @@ func (r *ReadRepository) FindAll() ([]interface{}, error) {
 
 // Remove removes a read model with id from the repository. Returns
 // ErrModelNotFound if no model could be found.
-func (r *ReadRepository) Remove(id eventhorizon.UUID) error {
+func (r *ReadRepository) Remove(id eh.UUID) error {
 	sess := r.session.Copy()
 	defer sess.Close()
 
 	err := sess.DB(r.db).C(r.collection).RemoveId(id)
 	if err != nil {
-		return eventhorizon.ErrModelNotFound
+		return eh.ErrModelNotFound
 	}
 
 	return nil

--- a/readrepository/mongodb/readrepository_test.go
+++ b/readrepository/mongodb/readrepository_test.go
@@ -23,7 +23,7 @@ import (
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 
-	"github.com/looplab/eventhorizon"
+	eh "github.com/looplab/eventhorizon"
 	"github.com/looplab/eventhorizon/testutil"
 )
 
@@ -69,7 +69,7 @@ func TestReadRepository(t *testing.T) {
 	}
 
 	t.Log("Save one item")
-	model1 := &testutil.TestModel{eventhorizon.NewUUID(), "model1", time.Now().Round(time.Millisecond)}
+	model1 := &testutil.TestModel{eh.NewUUID(), "model1", time.Now().Round(time.Millisecond)}
 	if err = repo.Save(model1.ID, model1); err != nil {
 		t.Error("there should be no error:", err)
 	}
@@ -107,7 +107,7 @@ func TestReadRepository(t *testing.T) {
 	}
 
 	t.Log("Save with another ID")
-	model2 := &testutil.TestModel{eventhorizon.NewUUID(), "model2", time.Now().Round(time.Millisecond)}
+	model2 := &testutil.TestModel{eh.NewUUID(), "model2", time.Now().Round(time.Millisecond)}
 	if err = repo.Save(model2.ID, model2); err != nil {
 		t.Error("there should be no error:", err)
 	}
@@ -186,7 +186,7 @@ func TestReadRepository(t *testing.T) {
 
 	t.Log("Remove non-existing item")
 	err = repo.Remove(model1Alt.ID)
-	if err != eventhorizon.ErrModelNotFound {
+	if err != eh.ErrModelNotFound {
 		t.Error("there should be a ErrModelNotFound error:", err)
 	}
 }

--- a/repository_test.go
+++ b/repository_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 )
 
-func TestNewRepository(t *testing.T) {
+func TestNewEventSourcingRepository(t *testing.T) {
 	store := &MockEventStore{
 		Events: make([]Event, 0),
 	}
@@ -28,7 +28,7 @@ func TestNewRepository(t *testing.T) {
 		Events: make([]Event, 0),
 	}
 
-	repo, err := NewCallbackRepository(nil, bus)
+	repo, err := NewEventSourcingRepository(nil, bus)
 	if err != ErrInvalidEventStore {
 		t.Error("there should be a ErrInvalidEventStore error:", err)
 	}
@@ -36,7 +36,7 @@ func TestNewRepository(t *testing.T) {
 		t.Error("there should be no repository:", repo)
 	}
 
-	repo, err = NewCallbackRepository(store, nil)
+	repo, err = NewEventSourcingRepository(store, nil)
 	if err != ErrInvalidEventBus {
 		t.Error("there should be a ErrInvalidEventBus error:", err)
 	}
@@ -44,7 +44,7 @@ func TestNewRepository(t *testing.T) {
 		t.Error("there should be no repository:", repo)
 	}
 
-	repo, err = NewCallbackRepository(store, bus)
+	repo, err = NewEventSourcingRepository(store, bus)
 	if err != nil {
 		t.Error("there should be no error:", err)
 	}
@@ -53,7 +53,7 @@ func TestNewRepository(t *testing.T) {
 	}
 }
 
-func TestRepositoryLoadNoEvents(t *testing.T) {
+func TestEventSourcingRepositoryLoadNoEvents(t *testing.T) {
 	repo, _, _ := createRepoAndStore(t)
 	err := repo.RegisterAggregate(TestAggregateType,
 		func(id UUID) Aggregate {
@@ -79,7 +79,7 @@ func TestRepositoryLoadNoEvents(t *testing.T) {
 	}
 }
 
-func TestRepositoryLoadEvents(t *testing.T) {
+func TestEventSourcingRepositoryLoadEvents(t *testing.T) {
 	repo, store, _ := createRepoAndStore(t)
 
 	err := repo.RegisterAggregate(TestAggregateType,
@@ -116,7 +116,7 @@ func TestRepositoryLoadEvents(t *testing.T) {
 	}
 }
 
-func TestRepositoryLoadEventsMismatchedEventType(t *testing.T) {
+func TestEventSourcingRepositoryLoadEventsMismatchedEventType(t *testing.T) {
 	repo, store, _ := createRepoAndStore(t)
 
 	err := repo.RegisterAggregate(TestAggregateType,
@@ -157,7 +157,7 @@ func TestRepositoryLoadEventsMismatchedEventType(t *testing.T) {
 	}
 }
 
-func TestRepositorySaveEvents(t *testing.T) {
+func TestEventSourcingRepositorySaveEvents(t *testing.T) {
 	repo, store, bus := createRepoAndStore(t)
 
 	id := NewUUID()
@@ -200,7 +200,7 @@ func TestRepositorySaveEvents(t *testing.T) {
 	}
 }
 
-func TestRepositoryAggregateNotRegistered(t *testing.T) {
+func TestEventSourcingRepositoryAggregateNotRegistered(t *testing.T) {
 	repo, _, _ := createRepoAndStore(t)
 
 	id := NewUUID()
@@ -239,14 +239,14 @@ func TestRepositoryRegisterAggregateTwice(t *testing.T) {
 	}
 }
 
-func createRepoAndStore(t *testing.T) (*CallbackRepository, *MockEventStore, *MockEventBus) {
+func createRepoAndStore(t *testing.T) (*EventSourcingRepository, *MockEventStore, *MockEventBus) {
 	store := &MockEventStore{
 		Events: make([]Event, 0),
 	}
 	bus := &MockEventBus{
 		Events: make([]Event, 0),
 	}
-	repo, err := NewCallbackRepository(store, bus)
+	repo, err := NewEventSourcingRepository(store, bus)
 	if err != nil {
 		t.Fatal("there should be no error:", err)
 	}

--- a/repository_test.go
+++ b/repository_test.go
@@ -55,16 +55,6 @@ func TestNewEventSourcingRepository(t *testing.T) {
 
 func TestEventSourcingRepositoryLoadNoEvents(t *testing.T) {
 	repo, _, _ := createRepoAndStore(t)
-	err := repo.RegisterAggregate(TestAggregateType,
-		func(id UUID) Aggregate {
-			return &TestAggregate{
-				AggregateBase: NewAggregateBase(id),
-			}
-		},
-	)
-	if err != nil {
-		t.Error("there should be no error:", err)
-	}
 
 	id := NewUUID()
 	agg, err := repo.Load("TestAggregate", id)
@@ -81,17 +71,6 @@ func TestEventSourcingRepositoryLoadNoEvents(t *testing.T) {
 
 func TestEventSourcingRepositoryLoadEvents(t *testing.T) {
 	repo, store, _ := createRepoAndStore(t)
-
-	err := repo.RegisterAggregate(TestAggregateType,
-		func(id UUID) Aggregate {
-			return &TestAggregate{
-				AggregateBase: NewAggregateBase(id),
-			}
-		},
-	)
-	if err != nil {
-		t.Error("there should be no error:", err)
-	}
 
 	id := NewUUID()
 	event1 := &TestEvent{id, "event"}
@@ -118,27 +97,6 @@ func TestEventSourcingRepositoryLoadEvents(t *testing.T) {
 
 func TestEventSourcingRepositoryLoadEventsMismatchedEventType(t *testing.T) {
 	repo, store, _ := createRepoAndStore(t)
-
-	err := repo.RegisterAggregate(TestAggregateType,
-		func(id UUID) Aggregate {
-			return &TestAggregate{
-				AggregateBase: NewAggregateBase(id),
-			}
-		},
-	)
-	if err != nil {
-		t.Error("there should be no error:", err)
-	}
-	err = repo.RegisterAggregate(TestAggregate2Type,
-		func(id UUID) Aggregate {
-			return &TestAggregate2{
-				AggregateBase: NewAggregateBase(id),
-			}
-		},
-	)
-	if err != nil {
-		t.Error("there should be no error:", err)
-	}
 
 	id := NewUUID()
 	event1 := &TestEvent{id, "event"}
@@ -204,38 +162,12 @@ func TestEventSourcingRepositoryAggregateNotRegistered(t *testing.T) {
 	repo, _, _ := createRepoAndStore(t)
 
 	id := NewUUID()
-	agg, err := repo.Load("TestAggregate", id)
+	agg, err := repo.Load("TestAggregate3", id)
 	if err != ErrAggregateNotRegistered {
 		t.Error("there should be a ErrAggregateNotRegistered error:", err)
 	}
 	if agg != nil {
 		t.Fatal("there should be no aggregate")
-	}
-}
-
-func TestRepositoryRegisterAggregateTwice(t *testing.T) {
-	repo, _, _ := createRepoAndStore(t)
-
-	err := repo.RegisterAggregate(TestAggregateType,
-		func(id UUID) Aggregate {
-			return &TestAggregate{
-				AggregateBase: NewAggregateBase(id),
-			}
-		},
-	)
-	if err != nil {
-		t.Error("there should be no error:", err)
-	}
-
-	err = repo.RegisterAggregate(TestAggregateType,
-		func(id UUID) Aggregate {
-			return &TestAggregate{
-				AggregateBase: NewAggregateBase(id),
-			}
-		},
-	)
-	if err != ErrAggregateAlreadyRegistered {
-		t.Error("there should be a ErrAggregateAlreadyRegistered error:", err)
 	}
 }
 

--- a/testutil/eventstore.go
+++ b/testutil/eventstore.go
@@ -19,29 +19,29 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/looplab/eventhorizon"
+	eh "github.com/looplab/eventhorizon"
 )
 
-func EventStoreCommonTests(t *testing.T, store eventhorizon.EventStore) []eventhorizon.Event {
-	savedEvents := []eventhorizon.Event{}
+func EventStoreCommonTests(t *testing.T, store eh.EventStore) []eh.Event {
+	savedEvents := []eh.Event{}
 
 	t.Log("save no events")
-	err := store.Save([]eventhorizon.Event{})
-	if err != eventhorizon.ErrNoEventsToAppend {
+	err := store.Save([]eh.Event{})
+	if err != eh.ErrNoEventsToAppend {
 		t.Error("there shoud be a ErrNoEventsToAppend error:", err)
 	}
 
 	t.Log("save event, version 1")
-	id, _ := eventhorizon.ParseUUID("c1138e5f-f6fb-4dd0-8e79-255c6c8d3756")
+	id, _ := eh.ParseUUID("c1138e5f-f6fb-4dd0-8e79-255c6c8d3756")
 	event1 := &TestEvent{id, "event1"}
-	err = store.Save([]eventhorizon.Event{event1})
+	err = store.Save([]eh.Event{event1})
 	if err != nil {
 		t.Error("there should be no error:", err)
 	}
 	savedEvents = append(savedEvents, event1)
 
 	t.Log("save event, version 2")
-	err = store.Save([]eventhorizon.Event{event1})
+	err = store.Save([]eh.Event{event1})
 	if err != nil {
 		t.Error("there should be no error:", err)
 	}
@@ -49,23 +49,23 @@ func EventStoreCommonTests(t *testing.T, store eventhorizon.EventStore) []eventh
 
 	t.Log("save event, version 3")
 	event2 := &TestEvent{id, "event2"}
-	err = store.Save([]eventhorizon.Event{event2})
+	err = store.Save([]eh.Event{event2})
 	if err != nil {
 		t.Error("there should be no error:", err)
 	}
 	savedEvents = append(savedEvents, event2)
 
 	t.Log("save event for another aggregate")
-	id2, _ := eventhorizon.ParseUUID("c1138e5e-f6fb-4dd0-8e79-255c6c8d3756")
+	id2, _ := eh.ParseUUID("c1138e5e-f6fb-4dd0-8e79-255c6c8d3756")
 	event3 := &TestEvent{id2, "event3"}
-	err = store.Save([]eventhorizon.Event{event3})
+	err = store.Save([]eh.Event{event3})
 	if err != nil {
 		t.Error("there should be no error:", err)
 	}
 	savedEvents = append(savedEvents, event3)
 
 	t.Log("load events for non-existing aggregate")
-	events, err := store.Load(eventhorizon.NewUUID())
+	events, err := store.Load(eh.NewUUID())
 	if err != nil {
 		t.Error("there should be no error:", err)
 	}
@@ -78,7 +78,7 @@ func EventStoreCommonTests(t *testing.T, store eventhorizon.EventStore) []eventh
 	if err != nil {
 		t.Error("there should be no error:", err)
 	}
-	if !reflect.DeepEqual(events, []eventhorizon.Event{event1, event1, event2}) {
+	if !reflect.DeepEqual(events, []eh.Event{event1, event1, event2}) {
 		t.Error("the loaded events should be correct:", eventsToString(events))
 	}
 
@@ -87,14 +87,14 @@ func EventStoreCommonTests(t *testing.T, store eventhorizon.EventStore) []eventh
 	if err != nil {
 		t.Error("there should be no error:", err)
 	}
-	if !reflect.DeepEqual(events, []eventhorizon.Event{event3}) {
+	if !reflect.DeepEqual(events, []eh.Event{event3}) {
 		t.Error("the loaded events should be correct:", eventsToString(events))
 	}
 
 	return savedEvents
 }
 
-func eventsToString(events []eventhorizon.Event) string {
+func eventsToString(events []eh.Event) string {
 	parts := make([]string, len(events))
 	for i, e := range events {
 		parts[i] = string(e.AggregateType()) +

--- a/testutil/mocks.go
+++ b/testutil/mocks.go
@@ -33,11 +33,11 @@ const (
 	TestAggregateType eventhorizon.AggregateType = "TestAggregate"
 
 	TestEventType      eventhorizon.EventType = "TestEvent"
-	TestEventOtherType                        = "TestEventOther"
+	TestEventOtherType eventhorizon.EventType = "TestEventOther"
 
 	TestCommandType       eventhorizon.CommandType = "TestCommand"
-	TestCommandOtherType                           = "TestCommandOther"
-	TestCommandOther2Type                          = "TestCommandOther2"
+	TestCommandOtherType  eventhorizon.CommandType = "TestCommandOther"
+	TestCommandOther2Type eventhorizon.CommandType = "TestCommandOther2"
 )
 
 type EmptyAggregate struct {

--- a/testutil/mocks.go
+++ b/testutil/mocks.go
@@ -52,45 +52,45 @@ type TestEvent struct {
 	Content string
 }
 
-func (t *TestEvent) AggregateID() eventhorizon.UUID            { return t.TestID }
-func (t *TestEvent) AggregateType() eventhorizon.AggregateType { return TestAggregateType }
-func (t *TestEvent) EventType() eventhorizon.EventType         { return TestEventType }
+func (t TestEvent) AggregateID() eventhorizon.UUID            { return t.TestID }
+func (t TestEvent) AggregateType() eventhorizon.AggregateType { return TestAggregateType }
+func (t TestEvent) EventType() eventhorizon.EventType         { return TestEventType }
 
 type TestEventOther struct {
 	TestID  eventhorizon.UUID
 	Content string
 }
 
-func (t *TestEventOther) AggregateID() eventhorizon.UUID            { return t.TestID }
-func (t *TestEventOther) AggregateType() eventhorizon.AggregateType { return TestAggregateType }
-func (t *TestEventOther) EventType() eventhorizon.EventType         { return TestEventOtherType }
+func (t TestEventOther) AggregateID() eventhorizon.UUID            { return t.TestID }
+func (t TestEventOther) AggregateType() eventhorizon.AggregateType { return TestAggregateType }
+func (t TestEventOther) EventType() eventhorizon.EventType         { return TestEventOtherType }
 
 type TestCommand struct {
 	TestID  eventhorizon.UUID
 	Content string
 }
 
-func (t *TestCommand) AggregateID() eventhorizon.UUID            { return t.TestID }
-func (t *TestCommand) AggregateType() eventhorizon.AggregateType { return TestAggregateType }
-func (t *TestCommand) CommandType() eventhorizon.CommandType     { return TestCommandType }
+func (t TestCommand) AggregateID() eventhorizon.UUID            { return t.TestID }
+func (t TestCommand) AggregateType() eventhorizon.AggregateType { return TestAggregateType }
+func (t TestCommand) CommandType() eventhorizon.CommandType     { return TestCommandType }
 
 type TestCommandOther struct {
 	TestID  eventhorizon.UUID
 	Content string
 }
 
-func (t *TestCommandOther) AggregateID() eventhorizon.UUID            { return t.TestID }
-func (t *TestCommandOther) AggregateType() eventhorizon.AggregateType { return TestAggregateType }
-func (t *TestCommandOther) CommandType() eventhorizon.CommandType     { return TestCommandOtherType }
+func (t TestCommandOther) AggregateID() eventhorizon.UUID            { return t.TestID }
+func (t TestCommandOther) AggregateType() eventhorizon.AggregateType { return TestAggregateType }
+func (t TestCommandOther) CommandType() eventhorizon.CommandType     { return TestCommandOtherType }
 
 type TestCommandOther2 struct {
 	TestID  eventhorizon.UUID
 	Content string
 }
 
-func (t *TestCommandOther2) AggregateID() eventhorizon.UUID            { return t.TestID }
-func (t *TestCommandOther2) AggregateType() eventhorizon.AggregateType { return TestAggregateType }
-func (t *TestCommandOther2) CommandType() eventhorizon.CommandType     { return TestCommandOther2Type }
+func (t TestCommandOther2) AggregateID() eventhorizon.UUID            { return t.TestID }
+func (t TestCommandOther2) AggregateType() eventhorizon.AggregateType { return TestAggregateType }
+func (t TestCommandOther2) CommandType() eventhorizon.CommandType     { return TestCommandOther2Type }
 
 type TestModel struct {
 	ID        eventhorizon.UUID `json:"id"         bson:"_id"`

--- a/testutil/mocks.go
+++ b/testutil/mocks.go
@@ -24,6 +24,9 @@ func init() {
 	eventhorizon.RegisterAggregate(func(id eventhorizon.UUID) eventhorizon.Aggregate {
 		return &TestAggregate{AggregateBase: eventhorizon.NewAggregateBase(id)}
 	})
+
+	eventhorizon.RegisterEvent(func() eventhorizon.Event { return &TestEvent{} })
+	eventhorizon.RegisterEvent(func() eventhorizon.Event { return &TestEventOther{} })
 }
 
 const (

--- a/testutil/mocks.go
+++ b/testutil/mocks.go
@@ -20,6 +20,12 @@ import (
 	"github.com/looplab/eventhorizon"
 )
 
+func init() {
+	eventhorizon.RegisterAggregate(func(id eventhorizon.UUID) eventhorizon.Aggregate {
+		return &TestAggregate{AggregateBase: eventhorizon.NewAggregateBase(id)}
+	})
+}
+
 const (
 	TestAggregateType eventhorizon.AggregateType = "TestAggregate"
 
@@ -37,6 +43,10 @@ type EmptyAggregate struct {
 type TestAggregate struct {
 	*eventhorizon.AggregateBase
 	Events []eventhorizon.Event
+}
+
+func (t *TestAggregate) HandleCommand(command eventhorizon.Command) error {
+	return nil
 }
 
 func (t *TestAggregate) AggregateType() eventhorizon.AggregateType {

--- a/testutil/mocks.go
+++ b/testutil/mocks.go
@@ -17,175 +17,175 @@ package testutil
 import (
 	"time"
 
-	"github.com/looplab/eventhorizon"
+	eh "github.com/looplab/eventhorizon"
 )
 
 func init() {
-	eventhorizon.RegisterAggregate(func(id eventhorizon.UUID) eventhorizon.Aggregate {
-		return &TestAggregate{AggregateBase: eventhorizon.NewAggregateBase(id)}
+	eh.RegisterAggregate(func(id eh.UUID) eh.Aggregate {
+		return &TestAggregate{AggregateBase: eh.NewAggregateBase(id)}
 	})
 
-	eventhorizon.RegisterEvent(func() eventhorizon.Event { return &TestEvent{} })
-	eventhorizon.RegisterEvent(func() eventhorizon.Event { return &TestEventOther{} })
+	eh.RegisterEvent(func() eh.Event { return &TestEvent{} })
+	eh.RegisterEvent(func() eh.Event { return &TestEventOther{} })
 }
 
 const (
-	TestAggregateType eventhorizon.AggregateType = "TestAggregate"
+	TestAggregateType eh.AggregateType = "TestAggregate"
 
-	TestEventType      eventhorizon.EventType = "TestEvent"
-	TestEventOtherType eventhorizon.EventType = "TestEventOther"
+	TestEventType      eh.EventType = "TestEvent"
+	TestEventOtherType eh.EventType = "TestEventOther"
 
-	TestCommandType       eventhorizon.CommandType = "TestCommand"
-	TestCommandOtherType  eventhorizon.CommandType = "TestCommandOther"
-	TestCommandOther2Type eventhorizon.CommandType = "TestCommandOther2"
+	TestCommandType       eh.CommandType = "TestCommand"
+	TestCommandOtherType  eh.CommandType = "TestCommandOther"
+	TestCommandOther2Type eh.CommandType = "TestCommandOther2"
 )
 
 type EmptyAggregate struct {
 }
 
 type TestAggregate struct {
-	*eventhorizon.AggregateBase
-	Events []eventhorizon.Event
+	*eh.AggregateBase
+	Events []eh.Event
 }
 
-func (t *TestAggregate) HandleCommand(command eventhorizon.Command) error {
+func (t *TestAggregate) HandleCommand(command eh.Command) error {
 	return nil
 }
 
-func (t *TestAggregate) AggregateType() eventhorizon.AggregateType {
+func (t *TestAggregate) AggregateType() eh.AggregateType {
 	return TestAggregateType
 }
 
-func (t *TestAggregate) ApplyEvent(event eventhorizon.Event) {
+func (t *TestAggregate) ApplyEvent(event eh.Event) {
 	t.Events = append(t.Events, event)
 }
 
 type TestEvent struct {
-	TestID  eventhorizon.UUID
+	TestID  eh.UUID
 	Content string
 }
 
-func (t TestEvent) AggregateID() eventhorizon.UUID            { return t.TestID }
-func (t TestEvent) AggregateType() eventhorizon.AggregateType { return TestAggregateType }
-func (t TestEvent) EventType() eventhorizon.EventType         { return TestEventType }
+func (t TestEvent) AggregateID() eh.UUID            { return t.TestID }
+func (t TestEvent) AggregateType() eh.AggregateType { return TestAggregateType }
+func (t TestEvent) EventType() eh.EventType         { return TestEventType }
 
 type TestEventOther struct {
-	TestID  eventhorizon.UUID
+	TestID  eh.UUID
 	Content string
 }
 
-func (t TestEventOther) AggregateID() eventhorizon.UUID            { return t.TestID }
-func (t TestEventOther) AggregateType() eventhorizon.AggregateType { return TestAggregateType }
-func (t TestEventOther) EventType() eventhorizon.EventType         { return TestEventOtherType }
+func (t TestEventOther) AggregateID() eh.UUID            { return t.TestID }
+func (t TestEventOther) AggregateType() eh.AggregateType { return TestAggregateType }
+func (t TestEventOther) EventType() eh.EventType         { return TestEventOtherType }
 
 type TestCommand struct {
-	TestID  eventhorizon.UUID
+	TestID  eh.UUID
 	Content string
 }
 
-func (t TestCommand) AggregateID() eventhorizon.UUID            { return t.TestID }
-func (t TestCommand) AggregateType() eventhorizon.AggregateType { return TestAggregateType }
-func (t TestCommand) CommandType() eventhorizon.CommandType     { return TestCommandType }
+func (t TestCommand) AggregateID() eh.UUID            { return t.TestID }
+func (t TestCommand) AggregateType() eh.AggregateType { return TestAggregateType }
+func (t TestCommand) CommandType() eh.CommandType     { return TestCommandType }
 
 type TestCommandOther struct {
-	TestID  eventhorizon.UUID
+	TestID  eh.UUID
 	Content string
 }
 
-func (t TestCommandOther) AggregateID() eventhorizon.UUID            { return t.TestID }
-func (t TestCommandOther) AggregateType() eventhorizon.AggregateType { return TestAggregateType }
-func (t TestCommandOther) CommandType() eventhorizon.CommandType     { return TestCommandOtherType }
+func (t TestCommandOther) AggregateID() eh.UUID            { return t.TestID }
+func (t TestCommandOther) AggregateType() eh.AggregateType { return TestAggregateType }
+func (t TestCommandOther) CommandType() eh.CommandType     { return TestCommandOtherType }
 
 type TestCommandOther2 struct {
-	TestID  eventhorizon.UUID
+	TestID  eh.UUID
 	Content string
 }
 
-func (t TestCommandOther2) AggregateID() eventhorizon.UUID            { return t.TestID }
-func (t TestCommandOther2) AggregateType() eventhorizon.AggregateType { return TestAggregateType }
-func (t TestCommandOther2) CommandType() eventhorizon.CommandType     { return TestCommandOther2Type }
+func (t TestCommandOther2) AggregateID() eh.UUID            { return t.TestID }
+func (t TestCommandOther2) AggregateType() eh.AggregateType { return TestAggregateType }
+func (t TestCommandOther2) CommandType() eh.CommandType     { return TestCommandOther2Type }
 
 type TestModel struct {
-	ID        eventhorizon.UUID `json:"id"         bson:"_id"`
-	Content   string            `json:"content"    bson:"content"`
-	CreatedAt time.Time         `json:"created_at" bson:"created_at"`
+	ID        eh.UUID   `json:"id"         bson:"_id"`
+	Content   string    `json:"content"    bson:"content"`
+	CreatedAt time.Time `json:"created_at" bson:"created_at"`
 }
 
 type MockEventHandler struct {
-	Type   eventhorizon.EventHandlerType
-	Events []eventhorizon.Event
-	Recv   chan eventhorizon.Event
+	Type   eh.EventHandlerType
+	Events []eh.Event
+	Recv   chan eh.Event
 }
 
-func NewMockEventHandler(handlerType eventhorizon.EventHandlerType) *MockEventHandler {
+func NewMockEventHandler(handlerType eh.EventHandlerType) *MockEventHandler {
 	return &MockEventHandler{
 		handlerType,
-		make([]eventhorizon.Event, 0),
-		make(chan eventhorizon.Event, 10),
+		make([]eh.Event, 0),
+		make(chan eh.Event, 10),
 	}
 }
 
-func (m *MockEventHandler) HandlerType() eventhorizon.EventHandlerType {
+func (m *MockEventHandler) HandlerType() eh.EventHandlerType {
 	return m.Type
 }
 
-func (m *MockEventHandler) HandleEvent(event eventhorizon.Event) {
+func (m *MockEventHandler) HandleEvent(event eh.Event) {
 	m.Events = append(m.Events, event)
 	m.Recv <- event
 }
 
 type MockEventObserver struct {
-	Events []eventhorizon.Event
-	Recv   chan eventhorizon.Event
+	Events []eh.Event
+	Recv   chan eh.Event
 }
 
 func NewMockEventObserver() *MockEventObserver {
 	return &MockEventObserver{
-		make([]eventhorizon.Event, 0),
-		make(chan eventhorizon.Event, 10),
+		make([]eh.Event, 0),
+		make(chan eh.Event, 10),
 	}
 }
 
-func (m *MockEventObserver) Notify(event eventhorizon.Event) {
+func (m *MockEventObserver) Notify(event eh.Event) {
 	m.Events = append(m.Events, event)
 	m.Recv <- event
 }
 
 type MockRepository struct {
-	Aggregates map[eventhorizon.UUID]eventhorizon.Aggregate
+	Aggregates map[eh.UUID]eh.Aggregate
 }
 
-func (m *MockRepository) Load(aggregateType eventhorizon.AggregateType, id eventhorizon.UUID) (eventhorizon.Aggregate, error) {
+func (m *MockRepository) Load(aggregateType eh.AggregateType, id eh.UUID) (eh.Aggregate, error) {
 	return m.Aggregates[id], nil
 }
 
-func (m *MockRepository) Save(aggregate eventhorizon.Aggregate) error {
+func (m *MockRepository) Save(aggregate eh.Aggregate) error {
 	m.Aggregates[aggregate.AggregateID()] = aggregate
 	return nil
 }
 
 type MockEventStore struct {
-	Events []eventhorizon.Event
-	Loaded eventhorizon.UUID
+	Events []eh.Event
+	Loaded eh.UUID
 }
 
-func (m *MockEventStore) Save(events []eventhorizon.Event) error {
+func (m *MockEventStore) Save(events []eh.Event) error {
 	m.Events = append(m.Events, events...)
 	return nil
 }
 
-func (m *MockEventStore) Load(id eventhorizon.UUID) ([]eventhorizon.Event, error) {
+func (m *MockEventStore) Load(id eh.UUID) ([]eh.Event, error) {
 	m.Loaded = id
 	return m.Events, nil
 }
 
 type MockEventBus struct {
-	Events []eventhorizon.Event
+	Events []eh.Event
 }
 
-func (m *MockEventBus) PublishEvent(event eventhorizon.Event) {
+func (m *MockEventBus) PublishEvent(event eh.Event) {
 	m.Events = append(m.Events, event)
 }
 
-func (m *MockEventBus) AddHandler(handler eventhorizon.EventHandler, event eventhorizon.Event) {}
-func (m *MockEventBus) AddObserver(observer eventhorizon.EventObserver)                        {}
+func (m *MockEventBus) AddHandler(handler eh.EventHandler, event eh.Event) {}
+func (m *MockEventBus) AddObserver(observer eh.EventObserver)              {}


### PR DESCRIPTION
Add functions for register and create aggregates and events. Before this was done in each place where it was needed (mongodb event store, redis event bus etc), now it is taken care of by the core package. This removes code duplication.