### PR TITLE
Return full EventRecords from EventStore.Load() containing metadata

### DIFF
--- a/eventhorizon_test.go
+++ b/eventhorizon_test.go
@@ -16,6 +16,7 @@ package eventhorizon
 
 import (
 	"errors"
+	"time"
 )
 
 func init() {
@@ -150,8 +151,28 @@ func (m *MockRepository) Save(aggregate Aggregate) error {
 	return nil
 }
 
+type MockEventRecord struct {
+	event Event
+}
+
+func (e MockEventRecord) Version() int {
+	return 0
+}
+
+func (e MockEventRecord) Timestamp() time.Time {
+	return time.Time{}
+}
+
+func (e MockEventRecord) Event() Event {
+	return e.event
+}
+
+func (e MockEventRecord) String() string {
+	return string(e.event.EventType())
+}
+
 type MockEventStore struct {
-	Events []Event
+	Events []EventRecord
 	Loaded UUID
 	// Used to simulate errors in the store.
 	err error
@@ -161,11 +182,13 @@ func (m *MockEventStore) Save(events []Event, originalVersion int) error {
 	if m.err != nil {
 		return m.err
 	}
-	m.Events = append(m.Events, events...)
+	for _, event := range events {
+		m.Events = append(m.Events, MockEventRecord{event: event})
+	}
 	return nil
 }
 
-func (m *MockEventStore) Load(id UUID) ([]Event, error) {
+func (m *MockEventStore) Load(id UUID) ([]EventRecord, error) {
 	if m.err != nil {
 		return nil, m.err
 	}

--- a/eventstore.go
+++ b/eventstore.go
@@ -16,6 +16,7 @@ package eventhorizon
 
 import (
 	"errors"
+	"time"
 )
 
 // ErrNoEventsToAppend is when no events are available to append.
@@ -27,7 +28,7 @@ type EventStore interface {
 	Save(events []Event, originalVersion int) error
 
 	// Load loads all events for the aggregate id from the store.
-	Load(UUID) ([]Event, error)
+	Load(UUID) ([]EventRecord, error)
 }
 
 // AggregateRecord is a stored record of an aggregate in form of its events.
@@ -38,10 +39,14 @@ type AggregateRecord interface {
 	EventRecords() []EventRecord
 }
 
-// EventRecord is a single event record with timestamp
-// NOTE: Not currently used.
+// EventRecord is a single event with metadata such as the type and timestamp.
 type EventRecord interface {
-	Type() string
+	// Version of the aggregate for this event (after it has been applied).
 	Version() int
-	Events() []Event
+	// Timestamp of when the event was created.
+	Timestamp() time.Time
+	// The specific event and its data.
+	Event() Event
+	// A string representation of the event.
+	String() string
 }

--- a/eventstore/trace/eventstore.go
+++ b/eventstore/trace/eventstore.go
@@ -54,7 +54,7 @@ func (s *EventStore) Save(events []eh.Event, originalVersion int) error {
 
 // Load loads all events for the aggregate id from the base store.
 // Returns ErrNoEventStoreDefined if no event store could be found.
-func (s *EventStore) Load(id eh.UUID) ([]eh.Event, error) {
+func (s *EventStore) Load(id eh.UUID) ([]eh.EventRecord, error) {
 	if s.eventStore != nil {
 		return s.eventStore.Load(id)
 	}

--- a/eventstore/trace/eventstore_test.go
+++ b/eventstore/trace/eventstore_test.go
@@ -68,10 +68,11 @@ func TestEventStore(t *testing.T) {
 	aggregate1events = append(aggregate1events, event1)
 
 	t.Log("load events without tracing")
-	events, err := store.Load(event1.AggregateID())
+	eventRecords, err := store.Load(event1.AggregateID())
 	if err != nil {
 		t.Error("there should be no error:", err)
 	}
+	events := testutil.EventsFromRecord(eventRecords)
 	if !reflect.DeepEqual(events, aggregate1events) {
 		t.Error("the loaded events should be correct:", events)
 	}

--- a/repository.go
+++ b/repository.go
@@ -71,19 +71,19 @@ func (r *EventSourcingRepository) Load(aggregateType AggregateType, id UUID) (Ag
 		return nil, err
 	}
 
-	// Load aggregate events.
-	events, err := r.eventStore.Load(aggregate.AggregateID())
+	// Load aggregate eventRecords.
+	eventRecords, err := r.eventStore.Load(aggregate.AggregateID())
 	if err != nil {
 		return nil, err
 	}
 
 	// Apply the events.
-	for _, event := range events {
-		if event.AggregateType() != aggregateType {
+	for _, eventRecord := range eventRecords {
+		if eventRecord.Event().AggregateType() != aggregateType {
 			return nil, ErrMismatchedEventType
 		}
 
-		aggregate.ApplyEvent(event)
+		aggregate.ApplyEvent(eventRecord.Event())
 		aggregate.IncrementVersion()
 	}
 

--- a/repository_test.go
+++ b/repository_test.go
@@ -22,7 +22,7 @@ import (
 
 func TestNewEventSourcingRepository(t *testing.T) {
 	store := &MockEventStore{
-		Events: make([]Event, 0),
+		Events: make([]EventRecord, 0),
 	}
 	bus := &MockEventBus{
 		Events: make([]Event, 0),
@@ -137,7 +137,7 @@ func TestEventSourcingRepositorySaveEvents(t *testing.T) {
 	if len(events) != 1 {
 		t.Fatal("there should be one event stored:", len(events))
 	}
-	if events[0] != event1 {
+	if events[0].Event() != event1 {
 		t.Error("the stored event should be correct:", events[0])
 	}
 	if len(agg.GetUncommittedEvents()) != 0 {
@@ -173,7 +173,7 @@ func TestEventSourcingRepositoryAggregateNotRegistered(t *testing.T) {
 
 func createRepoAndStore(t *testing.T) (*EventSourcingRepository, *MockEventStore, *MockEventBus) {
 	store := &MockEventStore{
-		Events: make([]Event, 0),
+		Events: make([]EventRecord, 0),
 	}
 	bus := &MockEventBus{
 		Events: make([]Event, 0),


### PR DESCRIPTION
Exposes event metadata through the `EventRecord` type. More work will happen with this in #39, this is to expose metadata during a transition period before that is ready.