### PR TITLE
Local DynamoDB for testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,12 @@
 test: docker
 	go test -v ./...
 
+test_integration: docker
+	go test -v -integration ./...
+
+test_wercker:
+	wercker build
+
 test_cover: clean docker
 	go list -f '{{if len .TestGoFiles}}"go test -v -covermode=count -coverprofile={{.Dir}}/.coverprofile {{.ImportPath}}"{{end}}' ./... | xargs -L 1 sh -c
 	gover
@@ -13,6 +19,7 @@ cover:
 docker:
 	-docker run -d --name mongo -p 27017:27017 mongo
 	-docker run -d --name redis -p 6379:6379 redis
+	-docker run -d --name dynamodb -p 8000:8000 peopleperhour/dynamodb
 
 clean:
 	-find . -name \.coverprofile -type f -delete

--- a/eventstore/dynamodb/eventstore.go
+++ b/eventstore/dynamodb/eventstore.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package mongodb
+package dynamodb
 
 import (
 	"errors"

--- a/eventstore/dynamodb/eventstore.go
+++ b/eventstore/dynamodb/eventstore.go
@@ -54,8 +54,9 @@ type EventStore struct {
 
 // EventStoreConfig is a config for the DynamoDB event store.
 type EventStoreConfig struct {
-	Table  string
-	Region string
+	Table    string
+	Region   string
+	Endpoint string
 }
 
 func (c *EventStoreConfig) provideDefaults() {
@@ -72,7 +73,8 @@ func NewEventStore(config *EventStoreConfig) (*EventStore, error) {
 	config.provideDefaults()
 
 	awsConfig := &aws.Config{
-		Region: aws.String(config.Region),
+		Region:   aws.String(config.Region),
+		Endpoint: aws.String(config.Endpoint),
 	}
 	service := dynamodb.New(session.New(), awsConfig)
 

--- a/eventstore/dynamodb/eventstore_test.go
+++ b/eventstore/dynamodb/eventstore_test.go
@@ -15,16 +15,38 @@
 package dynamodb
 
 import (
+	"flag"
+	"os"
 	"testing"
 
 	eh "github.com/looplab/eventhorizon"
 	"github.com/looplab/eventhorizon/testutil"
 )
 
+var (
+	integration = flag.Bool("integration", false, "run integration tests")
+)
+
 func TestEventStore(t *testing.T) {
+	// Run non-integration tests towards a local DynamoDB in Docker.
+	url := ""
+	if !*integration {
+		// Support Wercker testing with local DynamoDB.
+		// NOTE: Not yet working.
+		// host := os.Getenv("DYNAMODB_PORT_8000_TCP_ADDR")
+		// port := os.Getenv("DYNAMODB_PORT_8000_TCP_PORT")
+
+		// Local DynamoDB testing using Docker.
+		url = "http://localhost:8000"
+		if host != "" && port != "" {
+			url = host + ":" + port
+		}
+	}
+
 	config := &EventStoreConfig{
-		Table:  "eventhorizonTest-" + eh.NewUUID().String(),
-		Region: "eu-west-1",
+		Table:    "eventhorizonTest-" + eh.NewUUID().String(),
+		Region:   "eu-west-1",
+		Endpoint: url,
 	}
 	store, err := NewEventStore(config)
 	if err != nil {

--- a/eventstore/dynamodb/eventstore_test.go
+++ b/eventstore/dynamodb/eventstore_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package mongodb
+package dynamodb
 
 import (
 	"testing"

--- a/wercker.yml
+++ b/wercker.yml
@@ -3,6 +3,7 @@ box: golang
 services:
     - mongo
     - redis
+    # - peopleperhour/dynamodb
 
 dev:
   steps:
@@ -29,7 +30,7 @@ build:
           go build ./...
 
     - script:
-        name: go test
+        name: go test -v -integration ./...
         code: |
           go get -d golang.org/x/tools/cmd/cover
           go get github.com/modocache/gover


### PR DESCRIPTION
Run a local version of DynamoDB in Docker to speed up testing. The CI tests are still run as an integration test towards AWS.

Thanks to @dtravin for bringing up the idea!