### PR TITLE
Command factory

### DIFF
--- a/command_test.go
+++ b/command_test.go
@@ -1,0 +1,88 @@
+// Copyright (c) 2016 - Max Ekman <max@looplab.se>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package eventhorizon
+
+import (
+	"testing"
+)
+
+func TestCreateCommand(t *testing.T) {
+	command, err := CreateCommand(TestCommandRegisterType)
+	if err != ErrCommandNotRegistered {
+		t.Error("there should be a command not registered error:", err)
+	}
+
+	RegisterCommand(func() Command { return &TestCommandRegister{} })
+
+	command, err = CreateCommand(TestCommandRegisterType)
+	if err != nil {
+		t.Error("there should be no error:", err)
+	}
+	if command.CommandType() != TestCommandRegisterType {
+		t.Error("the command type should be correct:", command.CommandType())
+	}
+}
+
+func TestRegisterCommandEmptyName(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil || r != "eventhorizon: attempt to register empty command type" {
+			t.Error("there should have been a panic:", r)
+		}
+	}()
+	RegisterCommand(func() Command { return &TestCommandRegisterEmpty{} })
+}
+
+func TestRegisterCommandNil(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil || r != "eventhorizon: created command is nil" {
+			t.Error("there should have been a panic:", r)
+		}
+	}()
+	RegisterCommand(func() Command { return nil })
+}
+
+func TestRegisterCommandTwice(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil || r != "eventhorizon: registering duplicate types for \"TestCommandRegisterTwice\"" {
+			t.Error("there should have been a panic:", r)
+		}
+	}()
+	RegisterCommand(func() Command { return &TestCommandRegisterTwice{} })
+	RegisterCommand(func() Command { return &TestCommandRegisterTwice{} })
+}
+
+const (
+	TestCommandRegisterType      CommandType = "TestCommandRegister"
+	TestCommandRegisterEmptyType CommandType = ""
+	TestCommandRegisterTwiceType CommandType = "TestCommandRegisterTwice"
+)
+
+type TestCommandRegister struct{}
+
+func (a TestCommandRegister) AggregateID() UUID            { return UUID("") }
+func (a TestCommandRegister) AggregateType() AggregateType { return TestAggregateType }
+func (a TestCommandRegister) CommandType() CommandType     { return TestCommandRegisterType }
+
+type TestCommandRegisterEmpty struct{}
+
+func (a TestCommandRegisterEmpty) AggregateID() UUID            { return UUID("") }
+func (a TestCommandRegisterEmpty) AggregateType() AggregateType { return TestAggregateType }
+func (a TestCommandRegisterEmpty) CommandType() CommandType     { return TestCommandRegisterEmptyType }
+
+type TestCommandRegisterTwice struct{}
+
+func (a TestCommandRegisterTwice) AggregateID() UUID            { return UUID("") }
+func (a TestCommandRegisterTwice) AggregateType() AggregateType { return TestAggregateType }
+func (a TestCommandRegisterTwice) CommandType() CommandType     { return TestCommandRegisterTwiceType }

--- a/event.go
+++ b/event.go
@@ -35,11 +35,9 @@ type Event interface {
 
 	// AggregateType returns the type of the aggregate that the event can be
 	// applied to.
-	// AggregateType() string
 	AggregateType() AggregateType
 
 	// EventType returns the type of the event.
-	// EventType() string
 	EventType() EventType
 }
 

--- a/examples/domain/commands.go
+++ b/examples/domain/commands.go
@@ -18,6 +18,14 @@ import (
 	eh "github.com/looplab/eventhorizon"
 )
 
+func init() {
+	eh.RegisterCommand(func() eh.Command { return &CreateInviteCommand{} })
+	eh.RegisterCommand(func() eh.Command { return &AcceptInviteCommand{} })
+	eh.RegisterCommand(func() eh.Command { return &DeclineInviteCommand{} })
+	eh.RegisterCommand(func() eh.Command { return &ConfirmInviteCommand{} })
+	eh.RegisterCommand(func() eh.Command { return &DenyInviteCommand{} })
+}
+
 const (
 	CreateInviteCommand eh.CommandType = "CreateInvite"
 

--- a/examples/domain/events.go
+++ b/examples/domain/events.go
@@ -22,6 +22,8 @@ func init() {
 	eh.RegisterEvent(func() eh.Event { return &InviteCreated{} })
 	eh.RegisterEvent(func() eh.Event { return &InviteAccepted{} })
 	eh.RegisterEvent(func() eh.Event { return &InviteDeclined{} })
+	eh.RegisterEvent(func() eh.Event { return &InviteConfirmedEvent{} })
+	eh.RegisterEvent(func() eh.Event { return &InviteDeniedEvent{} })
 }
 
 const (


### PR DESCRIPTION
Similar to the event and aggregate factories. Not yet used internally but is handy for client apps wanting to create commands from their name (http handler for example).