### PR TITLE
Add EventHandlingStrategy to select the strategy to use, i.e. async

### DIFF
--- a/eventbus.go
+++ b/eventbus.go
@@ -28,6 +28,9 @@ type EventBus interface {
 	// AddObserver adds an observer.
 	// TODO: Add pattern for what to observe.
 	AddObserver(EventObserver)
+
+	// SetHandlingStrategy will set the strategy to use for handling events.
+	SetHandlingStrategy(EventHandlingStrategy)
 }
 
 // EventHandler is a handler of events.
@@ -50,3 +53,15 @@ type EventObserver interface {
 	// Notify is notifed about an event.
 	Notify(Event)
 }
+
+// EventHandlingStrategy is the strategy to use when handling events.
+type EventHandlingStrategy int
+
+const (
+	// SimpleEventHandlingStrategy will handle events in the same goroutine and
+	// wait for them to complete before handling the next.
+	SimpleEventHandlingStrategy EventHandlingStrategy = iota
+	// AsyncEventHandlingStrategy will handle events concurrently in their own
+	// goroutines and not wait for them to finish.
+	AsyncEventHandlingStrategy
+)

--- a/eventbus/local/eventbus.go
+++ b/eventbus/local/eventbus.go
@@ -21,7 +21,7 @@ import (
 )
 
 // EventBus is an event bus that notifies registered EventHandlers of
-// published events.
+// published events. It will use the SimpleEventHandlingStrategy by default.
 type EventBus struct {
 	handlers  map[eh.EventType]map[eh.EventHandler]bool
 	observers map[eh.EventObserver]bool
@@ -30,6 +30,10 @@ type EventBus struct {
 	// separate mutexes per map for this as AddHandler/AddObserven is often
 	// called at program init and not at run time.
 	handlerMu sync.RWMutex
+
+	// handlingStrategy is the strategy to use when handling event, for example
+	// to handle the asynchronously.
+	handlingStrategy eh.EventHandlingStrategy
 }
 
 // NewEventBus creates a EventBus.
@@ -39,6 +43,12 @@ func NewEventBus() *EventBus {
 		observers: make(map[eh.EventObserver]bool),
 	}
 	return b
+}
+
+// SetHandlingStrategy implements the SetHandlingStrategy method of the
+// eventhorizon.EventBus interface.
+func (b *EventBus) SetHandlingStrategy(strategy eh.EventHandlingStrategy) {
+	b.handlingStrategy = strategy
 }
 
 // PublishEvent publishes an event to all handlers capable of handling it.
@@ -51,17 +61,25 @@ func (b *EventBus) PublishEvent(event eh.Event) {
 	// Handle the event if there is a handler registered.
 	if handlers, ok := b.handlers[event.EventType()]; ok {
 		for h := range handlers {
-			go h.HandleEvent(event)
+			if b.handlingStrategy == eh.AsyncEventHandlingStrategy {
+				go h.HandleEvent(event)
+			} else {
+				h.HandleEvent(event)
+			}
 		}
 	}
 
 	// Notify all observers about the event.
 	for o := range b.observers {
-		go o.Notify(event)
+		if b.handlingStrategy == eh.AsyncEventHandlingStrategy {
+			go o.Notify(event)
+		} else {
+			o.Notify(event)
+		}
 	}
 }
 
-// AddHandler implements the AddHandler method of the EventHandler interface.
+// AddHandler implements the AddHandler method of the eventhorizon.EventBus interface.
 func (b *EventBus) AddHandler(handler eh.EventHandler, eventType eh.EventType) {
 	b.handlerMu.Lock()
 	defer b.handlerMu.Unlock()
@@ -75,7 +93,7 @@ func (b *EventBus) AddHandler(handler eh.EventHandler, eventType eh.EventType) {
 	b.handlers[eventType][handler] = true
 }
 
-// AddObserver implements the AddObserver method of the EventHandler interface.
+// AddObserver implements the AddObserver method of the eventhorizon.EventBus interface.
 func (b *EventBus) AddObserver(observer eh.EventObserver) {
 	b.handlerMu.Lock()
 	defer b.handlerMu.Unlock()

--- a/eventbus/redis/eventbus.go
+++ b/eventbus/redis/eventbus.go
@@ -35,7 +35,7 @@ var ErrCouldNotMarshalEvent = errors.New("could not marshal event")
 var ErrCouldNotUnmarshalEvent = errors.New("could not unmarshal event")
 
 // EventBus is an event bus that notifies registered EventHandlers of
-// published events.
+// published events. It will use the SimpleEventHandlingStrategy by default.
 type EventBus struct {
 	handlers  map[eh.EventType]map[eh.EventHandler]bool
 	observers map[eh.EventObserver]bool
@@ -44,6 +44,10 @@ type EventBus struct {
 	// separate mutexes per map for this as AddHandler/AddObserven is often
 	// called at program init and not at run time.
 	handlerMu sync.RWMutex
+
+	// handlingStrategy is the strategy to use when handling event, for example
+	// to handle the asynchronously.
+	handlingStrategy eh.EventHandlingStrategy
 
 	prefix string
 	pool   *redis.Pool
@@ -114,6 +118,12 @@ func NewEventBusWithPool(appID string, pool *redis.Pool) (*EventBus, error) {
 	return b, nil
 }
 
+// SetHandlingStrategy implements the SetHandlingStrategy method of the
+// eventhorizon.EventBus interface.
+func (b *EventBus) SetHandlingStrategy(strategy eh.EventHandlingStrategy) {
+	b.handlingStrategy = strategy
+}
+
 // PublishEvent publishes an event to all handlers capable of handling it.
 func (b *EventBus) PublishEvent(event eh.Event) {
 	b.handlerMu.RLock()
@@ -121,8 +131,12 @@ func (b *EventBus) PublishEvent(event eh.Event) {
 
 	// Handle the event if there is a handler registered.
 	if handlers, ok := b.handlers[event.EventType()]; ok {
-		for handler := range handlers {
-			go handler.HandleEvent(event)
+		for h := range handlers {
+			if b.handlingStrategy == eh.AsyncEventHandlingStrategy {
+				go h.HandleEvent(event)
+			} else {
+				h.HandleEvent(event)
+			}
 		}
 	}
 
@@ -132,7 +146,7 @@ func (b *EventBus) PublishEvent(event eh.Event) {
 	}
 }
 
-// AddHandler adds a handler for a specific local event.
+// AddHandler implements the AddHandler method of the eventhorizon.EventBus interface.
 func (b *EventBus) AddHandler(handler eh.EventHandler, eventType eh.EventType) {
 	b.handlerMu.Lock()
 	defer b.handlerMu.Unlock()
@@ -146,7 +160,7 @@ func (b *EventBus) AddHandler(handler eh.EventHandler, eventType eh.EventType) {
 	b.handlers[eventType][handler] = true
 }
 
-// AddObserver implements the AddObserver method of the EventHandler interface.
+// AddObserver implements the AddObserver method of the eventhorizon.EventBus interface.
 func (b *EventBus) AddObserver(observer eh.EventObserver) {
 	b.handlerMu.Lock()
 	defer b.handlerMu.Unlock()
@@ -233,7 +247,11 @@ func (b *EventBus) recv(delay *backoff.Backoff) error {
 
 			b.handlerMu.RLock()
 			for o := range b.observers {
-				go o.Notify(event)
+				if b.handlingStrategy == eh.AsyncEventHandlingStrategy {
+					go o.Notify(event)
+				} else {
+					o.Notify(event)
+				}
 			}
 			b.handlerMu.RUnlock()
 

--- a/eventbus/redis/eventbus_test.go
+++ b/eventbus/redis/eventbus_test.go
@@ -73,6 +73,87 @@ func TestEventBus(t *testing.T) {
 	handler := testutil.NewMockEventHandler("testHandler")
 	bus.AddHandler(handler, testutil.TestEventType)
 	bus.PublishEvent(event1)
+	if !reflect.DeepEqual(handler.Events, []eh.Event{event1}) {
+		t.Error("the handler events should be correct:", handler.Events)
+	}
+	observer.WaitForEvent(t)
+	if !reflect.DeepEqual(observer.Events, []eh.Event{event1, event1}) {
+		t.Error("the observed events should be correct:", observer.Events)
+	}
+	observer2.WaitForEvent(t)
+	if !reflect.DeepEqual(observer2.Events, []eh.Event{event1, event1}) {
+		t.Error("the second observed events should be correct:", observer2.Events)
+	}
+
+	t.Log("publish another event")
+	bus.AddHandler(handler, testutil.TestEventOtherType)
+	event2 := &testutil.TestEventOther{eh.NewUUID(), "event2"}
+	bus.PublishEvent(event2)
+	if !reflect.DeepEqual(handler.Events, []eh.Event{event1, event2}) {
+		t.Error("the handler events should be correct:", handler.Events)
+	}
+	observer.WaitForEvent(t)
+	if !reflect.DeepEqual(observer.Events, []eh.Event{event1, event1, event2}) {
+		t.Error("the observed events should be correct:", observer.Events)
+	}
+	observer2.WaitForEvent(t)
+	if !reflect.DeepEqual(observer2.Events, []eh.Event{event1, event1, event2}) {
+		t.Error("the second observed events should be correct:", observer2.Events)
+	}
+}
+
+func TestEventBusAsync(t *testing.T) {
+	// Support Wercker testing with MongoDB.
+	host := os.Getenv("REDIS_PORT_6379_TCP_ADDR")
+	port := os.Getenv("REDIS_PORT_6379_TCP_PORT")
+
+	url := ":6379"
+	if host != "" && port != "" {
+		url = host + ":" + port
+	}
+
+	bus, err := NewEventBus("test", url, "")
+	if err != nil {
+		t.Fatal("there should be no error:", err)
+	}
+	if bus == nil {
+		t.Fatal("there should be a bus")
+	}
+	defer bus.Close()
+	bus.SetHandlingStrategy(eh.AsyncEventHandlingStrategy)
+	observer := testutil.NewMockEventObserver()
+	bus.AddObserver(observer)
+
+	// Another bus to test the observer.
+	bus2, err := NewEventBus("test", url, "")
+	if err != nil {
+		t.Fatal("there should be no error:", err)
+	}
+	defer bus2.Close()
+	bus2.SetHandlingStrategy(eh.AsyncEventHandlingStrategy)
+	observer2 := testutil.NewMockEventObserver()
+	bus2.AddObserver(observer2)
+
+	// Wait for subscriptions to be ready.
+	<-bus.ready
+	<-bus2.ready
+
+	t.Log("publish event without handler")
+	event1 := &testutil.TestEvent{eh.NewUUID(), "event1"}
+	bus.PublishEvent(event1)
+	observer.WaitForEvent(t)
+	if !reflect.DeepEqual(observer.Events, []eh.Event{event1}) {
+		t.Error("the observed events should be correct:", observer.Events)
+	}
+	observer2.WaitForEvent(t)
+	if !reflect.DeepEqual(observer2.Events, []eh.Event{event1}) {
+		t.Error("the second observed events should be correct:", observer2.Events)
+	}
+
+	t.Log("publish event")
+	handler := testutil.NewMockEventHandler("testHandler")
+	bus.AddHandler(handler, testutil.TestEventType)
+	bus.PublishEvent(event1)
 	handler.WaitForEvent(t)
 	if !reflect.DeepEqual(handler.Events, []eh.Event{event1}) {
 		t.Error("the handler events should be correct:", handler.Events)

--- a/eventhorizon_test.go
+++ b/eventhorizon_test.go
@@ -206,3 +206,4 @@ func (m *MockEventBus) PublishEvent(event Event) {
 
 func (m *MockEventBus) AddHandler(handler EventHandler, eventType EventType) {}
 func (m *MockEventBus) AddObserver(observer EventObserver)                   {}
+func (m *MockEventBus) SetHandlingStrategy(strategy EventHandlingStrategy)   {}

--- a/examples/mongodb/mongodb_test.go
+++ b/examples/mongodb/mongodb_test.go
@@ -48,6 +48,7 @@ func Example() {
 
 	// Create the event bus that distributes events.
 	eventBus := eventbus.NewEventBus()
+	eventBus.SetHandlingStrategy(eh.AsyncEventHandlingStrategy)
 	eventBus.AddObserver(&domain.Logger{})
 
 	// Create the aggregate repository.

--- a/examples/simple/simple_test.go
+++ b/examples/simple/simple_test.go
@@ -35,6 +35,7 @@ func Example() {
 
 	// Create the event bus that distributes events.
 	eventBus := eventbus.NewEventBus()
+	eventBus.SetHandlingStrategy(eh.AsyncEventHandlingStrategy)
 	eventBus.AddObserver(&domain.Logger{})
 
 	// Create the aggregate repository.


### PR DESCRIPTION
This should be useful when a fully deterministic (like the old version) event bus is needed.