### PR TITLE
Refactor the event type to contain more data

### DIFF
--- a/aggregate_test.go
+++ b/aggregate_test.go
@@ -15,14 +15,18 @@
 package eventhorizon
 
 import (
+	"reflect"
 	"testing"
 )
 
 func TestNewAggregateBase(t *testing.T) {
 	id := NewUUID()
-	agg := NewAggregateBase(id)
+	agg := NewAggregateBase(TestAggregateType, id)
 	if agg == nil {
 		t.Fatal("there should be an aggregate")
+	}
+	if agg.AggregateType() != TestAggregateType {
+		t.Error("the aggregate type should be correct: ", agg.AggregateType(), TestAggregateType)
 	}
 	if agg.AggregateID() != id {
 		t.Error("the aggregate ID should be correct: ", agg.AggregateID(), id)
@@ -33,7 +37,7 @@ func TestNewAggregateBase(t *testing.T) {
 }
 
 func TestAggregateIncrementVersion(t *testing.T) {
-	agg := NewAggregateBase(NewUUID())
+	agg := NewAggregateBase(TestAggregateType, NewUUID())
 	if agg.Version() != 0 {
 		t.Error("the version should be 0:", agg.Version())
 	}
@@ -44,9 +48,36 @@ func TestAggregateIncrementVersion(t *testing.T) {
 	}
 }
 
+func TestAggregateNewEvent(t *testing.T) {
+	id := NewUUID()
+	agg := NewTestAggregate(id)
+	event := agg.NewEvent(TestEventType, &TestEventData{"event1"})
+	if event.EventType() != TestEventType {
+		t.Error("the event type should be correct:", event.EventType())
+	}
+	if !reflect.DeepEqual(event.Data(), &TestEventData{"event1"}) {
+		t.Error("the data should be correct:", event.Data())
+	}
+	if event.Timestamp().IsZero() {
+		t.Error("the timestamp should not be zero:", event.Timestamp())
+	}
+	if event.Version() != 0 {
+		t.Error("the version should be zero:", event.Version())
+	}
+	if event.AggregateType() != TestAggregateType {
+		t.Error("the aggregate type should be correct:", event.AggregateType())
+	}
+	if event.AggregateID() != id {
+		t.Error("the aggregate id should be correct:", event.AggregateID())
+	}
+	if event.String() != "TestEvent@0" {
+		t.Error("the string representation should be correct:", event.String())
+	}
+}
+
 func TestAggregateStoreEvent(t *testing.T) {
-	agg := NewAggregateBase(NewUUID())
-	event1 := &TestEvent{NewUUID(), "event1"}
+	agg := NewTestAggregate(NewUUID())
+	event1 := agg.NewEvent(TestEventType, &TestEventData{"event1"})
 	agg.StoreEvent(event1)
 	events := agg.GetUncommittedEvents()
 	if len(events) != 1 {
@@ -56,9 +87,9 @@ func TestAggregateStoreEvent(t *testing.T) {
 		t.Error("the stored event should be correct:", events[0])
 	}
 
-	agg = NewAggregateBase(NewUUID())
-	event1 = &TestEvent{NewUUID(), "event1"}
-	event2 := &TestEvent{NewUUID(), "event2"}
+	agg = NewTestAggregate(NewUUID())
+	event1 = agg.NewEvent(TestEventType, &TestEventData{"event1"})
+	event2 := agg.NewEvent(TestEventType, &TestEventData{"event2"})
 	agg.StoreEvent(event1)
 	agg.StoreEvent(event2)
 	events = agg.GetUncommittedEvents()
@@ -74,8 +105,8 @@ func TestAggregateStoreEvent(t *testing.T) {
 }
 
 func TestAggregateClearUncommittedEvents(t *testing.T) {
-	agg := NewAggregateBase(NewUUID())
-	event1 := &TestEvent{NewUUID(), "event1"}
+	agg := NewTestAggregate(NewUUID())
+	event1 := agg.NewEvent(TestEventType, &TestEventData{"event1"})
 	agg.StoreEvent(event1)
 	events := agg.GetUncommittedEvents()
 	if len(events) != 1 {
@@ -100,7 +131,7 @@ func TestCreateAggregate(t *testing.T) {
 	}
 
 	RegisterAggregate(func(id UUID) Aggregate {
-		return &TestAggregateRegister{AggregateBase: NewAggregateBase(id)}
+		return &TestAggregateRegister{AggregateBase: NewAggregateBase(TestAggregateType, id)}
 	})
 
 	aggregate, err = CreateAggregate(TestAggregateRegisterType, id)
@@ -122,7 +153,11 @@ func TestRegisterAggregateEmptyName(t *testing.T) {
 			t.Error("there should have been a panic:", r)
 		}
 	}()
-	RegisterAggregate(func(id UUID) Aggregate { return &TestAggregateRegisterEmpty{AggregateBase: NewAggregateBase(id)} })
+	RegisterAggregate(func(id UUID) Aggregate {
+		return &TestAggregateRegisterEmpty{
+			AggregateBase: NewAggregateBase(TestAggregateRegisterType, id),
+		}
+	})
 }
 
 func TestRegisterAggregateNil(t *testing.T) {
@@ -141,10 +176,10 @@ func TestRegisterAggregateTwice(t *testing.T) {
 		}
 	}()
 	RegisterAggregate(func(id UUID) Aggregate {
-		return &TestAggregateRegisterTwice{AggregateBase: NewAggregateBase(id)}
+		return &TestAggregateRegisterTwice{AggregateBase: NewAggregateBase(TestAggregateType, id)}
 	})
 	RegisterAggregate(func(id UUID) Aggregate {
-		return &TestAggregateRegisterTwice{AggregateBase: NewAggregateBase(id)}
+		return &TestAggregateRegisterTwice{AggregateBase: NewAggregateBase(TestAggregateType, id)}
 	})
 }
 

--- a/commandhandler_test.go
+++ b/commandhandler_test.go
@@ -156,9 +156,7 @@ func TestCommandHandlerCheckCommand(t *testing.T) {
 }
 
 func BenchmarkCommandHandler(b *testing.B) {
-	aggregate := &TestAggregate{
-		AggregateBase: NewAggregateBase(NewUUID()),
-	}
+	aggregate := NewTestAggregate(NewUUID())
 	repo := &MockRepository{
 		Aggregates: map[UUID]Aggregate{
 			aggregate.AggregateID(): aggregate,
@@ -183,9 +181,7 @@ func BenchmarkCommandHandler(b *testing.B) {
 }
 
 func createAggregateAndHandler(t *testing.T) (*TestAggregate, *AggregateCommandHandler) {
-	aggregate := &TestAggregate{
-		AggregateBase: NewAggregateBase(NewUUID()),
-	}
+	aggregate := NewTestAggregate(NewUUID())
 	repo := &MockRepository{
 		Aggregates: map[UUID]Aggregate{
 			aggregate.AggregateID(): aggregate,

--- a/event.go
+++ b/event.go
@@ -19,7 +19,14 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"time"
 )
+
+// EventType is the type of an event, used as its unique identifier.
+type EventType string
+
+// EventData is any additional data for an event.
+type EventData interface{}
 
 // Event is a domain event describing a change that has happened to an aggregate.
 //
@@ -29,61 +36,116 @@ import (
 //
 // The event should contain all the data needed when applying/handling it.
 type Event interface {
-	// AggregateID returns the ID of the aggregate that the event should be
-	// applied to.
-	AggregateID() UUID
+	// EventType returns the type of the event.
+	EventType() EventType
+	// The data attached to the event.
+	Data() EventData
+	// Timestamp of when the event was created.
+	Timestamp() time.Time
 
 	// AggregateType returns the type of the aggregate that the event can be
 	// applied to.
 	AggregateType() AggregateType
+	// AggregateID returns the ID of the aggregate that the event should be
+	// applied to.
+	AggregateID() UUID
+	// Version of the aggregate for this event (after it has been applied).
+	Version() int
 
-	// EventType returns the type of the event.
-	EventType() EventType
+	// A string representation of the event.
+	String() string
 }
 
-// EventType is the type of an event, used as its unique identifier.
-type EventType string
+// NewEvent creates a new event with a type and data, setting its timestamp.
+func NewEvent(eventType EventType, data EventData) Event {
+	return event{
+		eventType: eventType,
+		data:      data,
+		timestamp: time.Now(),
+	}
+}
 
-var events = make(map[EventType]func() Event)
-var registerEventLock sync.RWMutex
+// event is an internal representation of an event, returned when the aggregate
+// uses NewEvent to create a new event. The events loaded from the db is
+// represented by each DBs internal event type, implementing Event.
+type event struct {
+	eventType     EventType
+	data          EventData
+	timestamp     time.Time
+	aggregateType AggregateType
+	aggregateID   UUID
+	version       int
+}
 
-// ErrEventNotRegistered is when no event factory was registered.
-var ErrEventNotRegistered = errors.New("event not registered")
+// EventType implements the EventType method of the Event interface.
+func (e event) EventType() EventType {
+	return e.eventType
+}
 
-// RegisterEvent registers an event factory for a type. The factory is
-// used to create concrete event types when loading from the database.
+// Data implements the Data method of the Event interface.
+func (e event) Data() EventData {
+	return e.data
+}
+
+// Timestamp implements the Timestamp method of the Event interface.
+func (e event) Timestamp() time.Time {
+	return e.timestamp
+}
+
+// AggregateType implements the AggregateType method of the Event interface.
+func (e event) AggregateType() AggregateType {
+	return e.aggregateType
+}
+
+// AggrgateID implements the AggrgateID method of the Event interface.
+func (e event) AggregateID() UUID {
+	return e.aggregateID
+}
+
+// Version implements the Version method of the Event interface.
+func (e event) Version() int {
+	return e.version
+}
+
+// String implements the String method of the Event interface.
+func (e event) String() string {
+	return fmt.Sprintf("%s@%d", e.eventType, e.version)
+}
+
+var eventDataFactories = make(map[EventType]func() EventData)
+var registerEventDataMu sync.RWMutex
+
+// ErrEventDataNotRegistered is when no event data factory was registered.
+var ErrEventDataNotRegistered = errors.New("event data not registered")
+
+// RegisterEventData registers an event data factory for a type. The factory is
+// used to create concrete event data structs when loading from the database.
 //
 // An example would be:
-//     RegisterEvent(func() Event { return &MyEvent{} })
-func RegisterEvent(factory func() Event) {
+//     RegisterEventData(MyEventType, func() Event { return &MyEventData{} })
+func RegisterEventData(eventType EventType, factory func() EventData) {
 	// TODO: Explore the use of reflect/gob for creating concrete types without
 	// a factory func.
 
-	// Check that the created event matches the type registered.
-	event := factory()
-	if event == nil {
-		panic("eventhorizon: created event is nil")
-	}
-	eventType := event.EventType()
 	if eventType == EventType("") {
 		panic("eventhorizon: attempt to register empty event type")
 	}
 
-	registerEventLock.Lock()
-	defer registerEventLock.Unlock()
-	if _, ok := events[eventType]; ok {
+	registerEventDataMu.Lock()
+	defer registerEventDataMu.Unlock()
+	if _, ok := eventDataFactories[eventType]; ok {
 		panic(fmt.Sprintf("eventhorizon: registering duplicate types for %q", eventType))
 	}
-	events[eventType] = factory
+	eventDataFactories[eventType] = factory
 }
 
-// CreateEvent creates an event of a type with an ID using the factory
-// registered with RegisterEvent.
-func CreateEvent(eventType EventType) (Event, error) {
-	registerEventLock.RLock()
-	defer registerEventLock.RUnlock()
-	if factory, ok := events[eventType]; ok {
+// CreateEventData creates an event data of a type using the factory registered
+// with RegisterEventData.
+func CreateEventData(eventType EventType) (EventData, error) {
+	registerEventDataMu.RLock()
+	defer registerEventDataMu.RUnlock()
+	if factory, ok := eventDataFactories[eventType]; ok {
 		return factory(), nil
 	}
-	return nil, ErrEventNotRegistered
+	return nil, ErrEventDataNotRegistered
 }

--- a/eventbus/local/eventbus_test.go
+++ b/eventbus/local/eventbus_test.go
@@ -15,11 +15,10 @@
 package local
 
 import (
-	"reflect"
 	"testing"
 
 	eh "github.com/looplab/eventhorizon"
-	"github.com/looplab/eventhorizon/mocks"
+	"github.com/looplab/eventhorizon/eventbus/testutil"
 )
 
 func TestEventBus(t *testing.T) {
@@ -28,37 +27,7 @@ func TestEventBus(t *testing.T) {
 		t.Fatal("there should be a bus")
 	}
 
-	observer := mocks.NewEventObserver()
-	bus.AddObserver(observer)
-
-	t.Log("publish event without handler")
-	event1 := &mocks.Event{eh.NewUUID(), "event1"}
-	bus.PublishEvent(event1)
-	if !reflect.DeepEqual(observer.Events, []eh.Event{event1}) {
-		t.Error("the observed events should be correct:", observer.Events)
-	}
-
-	t.Log("publish event")
-	handler := mocks.NewEventHandler("testHandler")
-	bus.AddHandler(handler, mocks.EventType)
-	bus.PublishEvent(event1)
-	if !reflect.DeepEqual(handler.Events, []eh.Event{event1}) {
-		t.Error("the handler events should be correct:", handler.Events)
-	}
-	if !reflect.DeepEqual(observer.Events, []eh.Event{event1, event1}) {
-		t.Error("the observed events should be correct:", observer.Events)
-	}
-
-	t.Log("publish another event")
-	bus.AddHandler(handler, mocks.EventOtherType)
-	event2 := &mocks.EventOther{eh.NewUUID(), "event2"}
-	bus.PublishEvent(event2)
-	if !reflect.DeepEqual(handler.Events, []eh.Event{event1, event2}) {
-		t.Error("the handler events should be correct:", handler.Events)
-	}
-	if !reflect.DeepEqual(observer.Events, []eh.Event{event1, event1, event2}) {
-		t.Error("the observed events should be correct:", observer.Events)
-	}
+	testutil.EventBusCommonTests(t, bus, bus)
 }
 
 func TestEventBusAsync(t *testing.T) {
@@ -68,40 +37,5 @@ func TestEventBusAsync(t *testing.T) {
 	}
 	bus.SetHandlingStrategy(eh.AsyncEventHandlingStrategy)
 
-	observer := mocks.NewEventObserver()
-	bus.AddObserver(observer)
-
-	t.Log("publish event without handler")
-	event1 := &mocks.Event{eh.NewUUID(), "event1"}
-	bus.PublishEvent(event1)
-	observer.WaitForEvent(t)
-	if !reflect.DeepEqual(observer.Events, []eh.Event{event1}) {
-		t.Error("the observed events should be correct:", observer.Events)
-	}
-
-	t.Log("publish event")
-	handler := mocks.NewEventHandler("testHandler")
-	bus.AddHandler(handler, mocks.EventType)
-	bus.PublishEvent(event1)
-	handler.WaitForEvent(t)
-	if !reflect.DeepEqual(handler.Events, []eh.Event{event1}) {
-		t.Error("the handler events should be correct:", handler.Events)
-	}
-	observer.WaitForEvent(t)
-	if !reflect.DeepEqual(observer.Events, []eh.Event{event1, event1}) {
-		t.Error("the observed events should be correct:", observer.Events)
-	}
-
-	t.Log("publish another event")
-	bus.AddHandler(handler, mocks.EventOtherType)
-	event2 := &mocks.EventOther{eh.NewUUID(), "event2"}
-	bus.PublishEvent(event2)
-	handler.WaitForEvent(t)
-	if !reflect.DeepEqual(handler.Events, []eh.Event{event1, event2}) {
-		t.Error("the handler events should be correct:", handler.Events)
-	}
-	observer.WaitForEvent(t)
-	if !reflect.DeepEqual(observer.Events, []eh.Event{event1, event1, event2}) {
-		t.Error("the observed events should be correct:", observer.Events)
-	}
+	testutil.EventBusCommonTests(t, bus, bus)
 }

--- a/eventbus/testutil/common_tests.go
+++ b/eventbus/testutil/common_tests.go
@@ -1,0 +1,99 @@
+// Copyright (c) 2016 - Max Ekman <max@looplab.se>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testutil
+
+import (
+	"testing"
+
+	eh "github.com/looplab/eventhorizon"
+	"github.com/looplab/eventhorizon/mocks"
+)
+
+// EventBusCommonTests are test cases that are common to all implementations
+// of event busses.
+func EventBusCommonTests(t *testing.T, bus1, bus2 eh.EventBus) {
+	observer1 := mocks.NewEventObserver()
+	bus1.AddObserver(observer1)
+
+	observer2 := mocks.NewEventObserver()
+	bus2.AddObserver(observer2)
+
+	t.Log("publish event without handler")
+	id, _ := eh.ParseUUID("c1138e5f-f6fb-4dd0-8e79-255c6c8d3756")
+	agg := mocks.NewAggregate(id)
+	event1 := agg.NewEvent(mocks.EventType, &mocks.EventData{"event1"})
+	bus1.PublishEvent(event1)
+	expectedEvents := []eh.Event{event1}
+	observer1.WaitForEvent(t)
+	for i, event := range observer1.Events {
+		if err := mocks.CompareEvents(event, expectedEvents[i]); err != nil {
+			t.Error("the event was incorrect:", err)
+		}
+	}
+	observer2.WaitForEvent(t)
+	for i, event := range observer2.Events {
+		if err := mocks.CompareEvents(event, expectedEvents[i]); err != nil {
+			t.Error("the event was incorrect:", err)
+		}
+	}
+
+	t.Log("publish event")
+	handler := mocks.NewEventHandler("testHandler")
+	bus1.AddHandler(handler, mocks.EventType)
+	bus1.PublishEvent(event1)
+	expectedEvents = []eh.Event{event1}
+	for i, event := range handler.Events {
+		if err := mocks.CompareEvents(event, expectedEvents[i]); err != nil {
+			t.Error("the event was incorrect:", err)
+		}
+	}
+	expectedEvents = []eh.Event{event1, event1}
+	observer1.WaitForEvent(t)
+	for i, event := range observer1.Events {
+		if err := mocks.CompareEvents(event, expectedEvents[i]); err != nil {
+			t.Error("the event was incorrect:", err)
+		}
+	}
+	observer2.WaitForEvent(t)
+	for i, event := range observer2.Events {
+		if err := mocks.CompareEvents(event, expectedEvents[i]); err != nil {
+			t.Error("the event was incorrect:", err)
+		}
+	}
+
+	t.Log("publish another event")
+	bus1.AddHandler(handler, mocks.EventOtherType)
+	event2 := agg.NewEvent(mocks.EventOtherType, nil)
+	bus1.PublishEvent(event2)
+	expectedEvents = []eh.Event{event1, event2}
+	for i, event := range handler.Events {
+		if err := mocks.CompareEvents(event, expectedEvents[i]); err != nil {
+			t.Error("the event was incorrect:", err)
+		}
+	}
+	expectedEvents = []eh.Event{event1, event1, event2}
+	observer1.WaitForEvent(t)
+	for i, event := range observer1.Events {
+		if err := mocks.CompareEvents(event, expectedEvents[i]); err != nil {
+			t.Error("the event was incorrect:", err)
+		}
+	}
+	observer2.WaitForEvent(t)
+	for i, event := range observer2.Events {
+		if err := mocks.CompareEvents(event, expectedEvents[i]); err != nil {
+			t.Error("the event was incorrect:", err)
+		}
+	}
+}

--- a/eventstore.go
+++ b/eventstore.go
@@ -14,10 +14,7 @@
 
 package eventhorizon
 
-import (
-	"errors"
-	"time"
-)
+import "errors"
 
 // ErrNoEventsToAppend is when no events are available to append.
 var ErrNoEventsToAppend = errors.New("no events to append")
@@ -28,25 +25,5 @@ type EventStore interface {
 	Save(events []Event, originalVersion int) error
 
 	// Load loads all events for the aggregate id from the store.
-	Load(AggregateType, UUID) ([]EventRecord, error)
-}
-
-// AggregateRecord is a stored record of an aggregate in form of its events.
-// NOTE: Not currently used.
-type AggregateRecord interface {
-	AggregateID() UUID
-	Version() int
-	EventRecords() []EventRecord
-}
-
-// EventRecord is a single event with metadata such as the type and timestamp.
-type EventRecord interface {
-	// Version of the aggregate for this event (after it has been applied).
-	Version() int
-	// Timestamp of when the event was created.
-	Timestamp() time.Time
-	// The specific event and its data.
-	Event() Event
-	// A string representation of the event.
-	String() string
+	Load(AggregateType, UUID) ([]Event, error)
 }

--- a/eventstore/trace/eventstore.go
+++ b/eventstore/trace/eventstore.go
@@ -59,7 +59,7 @@ func (s *EventStore) Save(events []eh.Event, originalVersion int) error {
 
 // Load loads all events for the aggregate id from the base store.
 // Returns ErrNoEventStoreDefined if no event store could be found.
-func (s *EventStore) Load(aggregateType eh.AggregateType, id eh.UUID) ([]eh.EventRecord, error) {
+func (s *EventStore) Load(aggregateType eh.AggregateType, id eh.UUID) ([]eh.Event, error) {
 	if s.eventStore != nil {
 		return s.eventStore.Load(aggregateType, id)
 	}

--- a/eventstore/trace/eventstore_test.go
+++ b/eventstore/trace/eventstore_test.go
@@ -21,6 +21,7 @@ import (
 	eh "github.com/looplab/eventhorizon"
 	"github.com/looplab/eventhorizon/eventstore/memory"
 	"github.com/looplab/eventhorizon/eventstore/testutil"
+	"github.com/looplab/eventhorizon/mocks"
 )
 
 func TestEventStore(t *testing.T) {
@@ -68,12 +69,16 @@ func TestEventStore(t *testing.T) {
 	aggregate1events = append(aggregate1events, event1)
 
 	t.Log("load events without tracing")
-	eventRecords, err := store.Load(event1.AggregateType(), event1.AggregateID())
+	events, err := store.Load(event1.AggregateType(), event1.AggregateID())
 	if err != nil {
 		t.Error("there should be no error:", err)
 	}
-	events := testutil.EventsFromRecord(eventRecords)
-	if !reflect.DeepEqual(events, aggregate1events) {
-		t.Error("the loaded events should be correct:", events)
+	for i, event := range events {
+		if err := mocks.CompareEvents(event, aggregate1events[i]); err != nil {
+			t.Error("the event was incorrect:", err)
+		}
+		if event.Version() != i+1 {
+			t.Error("the event version should be correct:", event, event.Version())
+		}
 	}
 }

--- a/examples/domain/events.go
+++ b/examples/domain/events.go
@@ -18,67 +18,30 @@ import (
 	eh "github.com/looplab/eventhorizon"
 )
 
-func init() {
-	eh.RegisterEvent(func() eh.Event { return &InviteCreated{} })
-	eh.RegisterEvent(func() eh.Event { return &InviteAccepted{} })
-	eh.RegisterEvent(func() eh.Event { return &InviteDeclined{} })
-	eh.RegisterEvent(func() eh.Event { return &InviteConfirmed{} })
-	eh.RegisterEvent(func() eh.Event { return &InviteDenied{} })
-}
-
 const (
+	// InviteCreatedEvent is when an invite is created.
 	InviteCreatedEvent eh.EventType = "InviteCreated"
 
+	// InviteAcceptedEvent is when an invite has been accepted by the guest.
 	InviteAcceptedEvent eh.EventType = "InviteAccepted"
+	// InviteDeclinedEvent is when an invite has been declined by the guest.
 	InviteDeclinedEvent eh.EventType = "InviteDeclined"
 
+	// InviteConfirmedEvent is when an invite has been cornfirmed as booked.
 	InviteConfirmedEvent eh.EventType = "InviteConfirmed"
-	InviteDeniedEvent    eh.EventType = "InviteDenied"
+	// InviteDeniedEvent is when an invite has been declined to be booked.
+	InviteDeniedEvent eh.EventType = "InviteDenied"
 )
 
-// InviteCreated is an event for when an invite has been created.
-type InviteCreated struct {
-	InvitationID eh.UUID `bson:"invitation_id"`
-	Name         string  `bson:"name"`
-	Age          int     `bson:"age"`
+func init() {
+	// Only the event for creating an invite has custom data.
+	eh.RegisterEventData(InviteCreatedEvent, func() eh.EventData {
+		return &InviteCreatedData{}
+	})
 }
 
-func (c InviteCreated) AggregateID() eh.UUID            { return c.InvitationID }
-func (c InviteCreated) AggregateType() eh.AggregateType { return InvitationAggregateType }
-func (c InviteCreated) EventType() eh.EventType         { return InviteCreatedEvent }
-
-// InviteAccepted is an event for when an invite has been accepted.
-type InviteAccepted struct {
-	InvitationID eh.UUID `bson:"invitation_id"`
+// InviteCreatedData is the event data for when an invite has been created.
+type InviteCreatedData struct {
+	Name string `bson:"name"`
+	Age  int    `bson:"age"`
 }
-
-func (c InviteAccepted) AggregateID() eh.UUID            { return c.InvitationID }
-func (c InviteAccepted) AggregateType() eh.AggregateType { return InvitationAggregateType }
-func (c InviteAccepted) EventType() eh.EventType         { return InviteAcceptedEvent }
-
-// InviteDeclined is an event for when an invite has been declined.
-type InviteDeclined struct {
-	InvitationID eh.UUID `bson:"invitation_id"`
-}
-
-func (c InviteDeclined) AggregateID() eh.UUID            { return c.InvitationID }
-func (c InviteDeclined) AggregateType() eh.AggregateType { return InvitationAggregateType }
-func (c InviteDeclined) EventType() eh.EventType         { return InviteDeclinedEvent }
-
-// InviteConfirmed is an event for when an invite has been confirmed as booked.
-type InviteConfirmed struct {
-	InvitationID eh.UUID `bson:"invitation_id"`
-}
-
-func (c InviteConfirmed) AggregateID() eh.UUID            { return c.InvitationID }
-func (c InviteConfirmed) AggregateType() eh.AggregateType { return InvitationAggregateType }
-func (c InviteConfirmed) EventType() eh.EventType         { return InviteConfirmedEvent }
-
-// InviteDenied is an event for when an invite has been denied to book.
-type InviteDenied struct {
-	InvitationID eh.UUID `bson:"invitation_id"`
-}
-
-func (c InviteDenied) AggregateID() eh.UUID            { return c.InvitationID }
-func (c InviteDenied) AggregateType() eh.AggregateType { return InvitationAggregateType }
-func (c InviteDenied) EventType() eh.EventType         { return InviteDeniedEvent }

--- a/examples/domain/logger.go
+++ b/examples/domain/logger.go
@@ -25,5 +25,5 @@ type Logger struct{}
 
 // Notify implements the HandleEvent method of the EventHandler interface.
 func (l *Logger) Notify(event eh.Event) {
-	log.Printf("event: %#v\n", event)
+	log.Println("event:", event)
 }

--- a/examples/domain/projectors.go
+++ b/examples/domain/projectors.go
@@ -65,23 +65,27 @@ func (p *InvitationProjector) HandleEvent(event eh.Event) {
 	}
 
 	// Apply the changes for the event.
-	switch e := event.(type) {
-	case *InviteCreated:
-		i.Name = e.Name
-		i.Age = e.Age
-	case *InviteAccepted:
+	switch event.EventType() {
+	case InviteCreatedEvent:
+		if data, ok := event.Data().(*InviteCreatedData); ok {
+			i.Name = data.Name
+			i.Age = data.Age
+		} else {
+			log.Println("invalid event data type:", event.Data())
+		}
+	case InviteAcceptedEvent:
 		// NOTE: Temp fix for events that arrive out of order.
 		if i.Status != "confirmed" && i.Status != "denied" {
 			i.Status = "accepted"
 		}
-	case *InviteDeclined:
+	case InviteDeclinedEvent:
 		// NOTE: Temp fix for events that arrive out of order.
 		if i.Status != "confirmed" && i.Status != "denied" {
 			i.Status = "declined"
 		}
-	case *InviteConfirmed:
+	case InviteConfirmedEvent:
 		i.Status = "confirmed"
-	case *InviteDenied:
+	case InviteDeniedEvent:
 		i.Status = "denied"
 	}
 
@@ -139,16 +143,16 @@ func (p *GuestListProjector) HandleEvent(event eh.Event) {
 	}
 
 	// Apply the count of the guests.
-	switch event.(type) {
-	case *InviteAccepted:
+	switch event.EventType() {
+	case InviteAcceptedEvent:
 		g.NumAccepted++
 		g.NumGuests++
-	case *InviteDeclined:
+	case InviteDeclinedEvent:
 		g.NumDeclined++
 		g.NumGuests++
-	case *InviteConfirmed:
+	case InviteConfirmedEvent:
 		g.NumConfirmed++
-	case *InviteDenied:
+	case InviteDeniedEvent:
 		g.NumDenied++
 	}
 

--- a/examples/domain/saga.go
+++ b/examples/domain/saga.go
@@ -51,8 +51,8 @@ func (s *ResponseSaga) SagaType() eh.SagaType {
 
 // RunSaga implements the Run saga method of the Saga interface.
 func (s *ResponseSaga) RunSaga(event eh.Event) []eh.Command {
-	switch event := event.(type) {
-	case *InviteAccepted:
+	switch event.EventType() {
+	case InviteAcceptedEvent:
 		// Do nothing for already accepted guests.
 		s.acceptedGuestsMu.RLock()
 		ok, _ := s.acceptedGuests[event.AggregateID()]

--- a/mocks/testutils.go
+++ b/mocks/testutils.go
@@ -1,0 +1,39 @@
+// Copyright (c) 2014 - Max Ekman <max@looplab.se>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mocks
+
+import (
+	"fmt"
+	"reflect"
+
+	eh "github.com/looplab/eventhorizon"
+)
+
+// CompareEvents compares two events, ignoring their version and timestamp.
+func CompareEvents(e1, e2 eh.Event) error {
+	if e1.AggregateID() != e2.AggregateID() {
+		return fmt.Errorf("incorrect aggregate ID: %s (should be %s)", e1.AggregateID(), e2.AggregateID())
+	}
+	if e1.AggregateType() != e2.AggregateType() {
+		return fmt.Errorf("incorrect aggregate type: %s (should be %s)", e1.AggregateType(), e2.AggregateType())
+	}
+	if e1.EventType() != e2.EventType() {
+		return fmt.Errorf("incorrect event type: %s (should be %s)", e1.EventType(), e2.EventType())
+	}
+	if !reflect.DeepEqual(e1.Data(), e2.Data()) {
+		return fmt.Errorf("incorrect event data: %s (should be %s)", e1.Data(), e2.Data())
+	}
+	return nil
+}

--- a/repository.go
+++ b/repository.go
@@ -71,19 +71,19 @@ func (r *EventSourcingRepository) Load(aggregateType AggregateType, id UUID) (Ag
 		return nil, err
 	}
 
-	// Load aggregate eventRecords.
-	eventRecords, err := r.eventStore.Load(aggregate.AggregateType(), aggregate.AggregateID())
+	// Load aggregate events.
+	events, err := r.eventStore.Load(aggregate.AggregateType(), aggregate.AggregateID())
 	if err != nil {
 		return nil, err
 	}
 
 	// Apply the events.
-	for _, eventRecord := range eventRecords {
-		if eventRecord.Event().AggregateType() != aggregateType {
+	for _, event := range events {
+		if event.AggregateType() != aggregateType {
 			return nil, ErrMismatchedEventType
 		}
 
-		aggregate.ApplyEvent(eventRecord.Event())
+		aggregate.ApplyEvent(event)
 		aggregate.IncrementVersion()
 	}
 


### PR DESCRIPTION
The Event now contains the aggregate type and id, the event type
and all event metadata along with any custom event data.

Each place where events are created (new, from DB, from event bus etc)
now needs to supply their own event implementations.

Fixes #39.