### PR TITLE
Issue 69 / read model version support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,9 +17,9 @@ cover:
 	go tool cover -html=gover.coverprofile
 
 docker:
-	-docker run -d --name mongo -p 27017:27017 mongo
-	-docker run -d --name redis -p 6379:6379 redis
-	-docker run -d --name dynamodb -p 8000:8000 peopleperhour/dynamodb
+	-docker run -d --name mongo -p 27017:27017 mongo:latest
+	-docker run -d --name redis -p 6379:6379 redis:latest
+	-docker run -d --name dynamodb -p 8000:8000 peopleperhour/dynamodb:latest
 
 clean:
 	-find . -name \.coverprofile -type f -delete

--- a/examples/domain/projectors.go
+++ b/examples/domain/projectors.go
@@ -15,6 +15,7 @@
 package domain
 
 import (
+	"context"
 	"log"
 	"sync"
 
@@ -51,7 +52,7 @@ func (p *InvitationProjector) HandlerType() eh.EventHandlerType {
 func (p *InvitationProjector) HandleEvent(event eh.Event) {
 	// Load or create the model.
 	var i *Invitation
-	if m, _ := p.repository.Find(event.AggregateID()); m != nil {
+	if m, _ := p.repository.Find(context.Background(), event.AggregateID()); m != nil {
 		var ok bool
 		if i, ok = m.(*Invitation); !ok {
 			log.Println("error: model is of incorrect type")
@@ -90,7 +91,7 @@ func (p *InvitationProjector) HandleEvent(event eh.Event) {
 	}
 
 	// Save it back, same for new and updated models.
-	if err := p.repository.Save(event.AggregateID(), i); err != nil {
+	if err := p.repository.Save(context.Background(), event.AggregateID(), i); err != nil {
 		log.Println("error: could not save model: ", err)
 	}
 }
@@ -134,7 +135,7 @@ func (p *GuestListProjector) HandleEvent(event eh.Event) {
 
 	// Load or create the guest list.
 	var g *GuestList
-	if m, _ := p.repository.Find(p.eventID); m != nil {
+	if m, _ := p.repository.Find(context.Background(), p.eventID); m != nil {
 		g = m.(*GuestList)
 	} else {
 		g = &GuestList{
@@ -156,5 +157,5 @@ func (p *GuestListProjector) HandleEvent(event eh.Event) {
 		g.NumDenied++
 	}
 
-	p.repository.Save(p.eventID, g)
+	p.repository.Save(context.Background(), p.eventID, g)
 }

--- a/examples/mongodb/mongodb_test.go
+++ b/examples/mongodb/mongodb_test.go
@@ -15,6 +15,7 @@
 package mongodb
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"os"
@@ -149,7 +150,7 @@ func Example() {
 
 	// Read all invites.
 	invitationStrs := []string{}
-	invitations, _ := invitationRepository.FindAll()
+	invitations, _ := invitationRepository.FindAll(context.Background())
 	for _, i := range invitations {
 		if i, ok := i.(*domain.Invitation); ok {
 			invitationStrs = append(invitationStrs, fmt.Sprintf("%s - %s", i.Name, i.Status))
@@ -164,7 +165,7 @@ func Example() {
 	}
 
 	// Read the guest list.
-	l, _ := guestListRepository.Find(eventID)
+	l, _ := guestListRepository.Find(context.Background(), eventID)
 	if l, ok := l.(*domain.GuestList); ok {
 		log.Printf("guest list: %d invited - %d accepted, %d declined - %d confirmed, %d denied\n",
 			l.NumGuests, l.NumAccepted, l.NumDeclined, l.NumConfirmed, l.NumDenied)

--- a/examples/simple/simple_test.go
+++ b/examples/simple/simple_test.go
@@ -15,6 +15,7 @@
 package simple
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"sort"
@@ -123,7 +124,7 @@ func Example() {
 
 	// Read all invites.
 	invitationStrs := []string{}
-	invitations, _ := invitationRepository.FindAll()
+	invitations, _ := invitationRepository.FindAll(context.Background())
 	for _, i := range invitations {
 		if i, ok := i.(*domain.Invitation); ok {
 			invitationStrs = append(invitationStrs, fmt.Sprintf("%s - %s", i.Name, i.Status))
@@ -138,7 +139,7 @@ func Example() {
 	}
 
 	// Read the guest list.
-	l, _ := guestListRepository.Find(eventID)
+	l, _ := guestListRepository.Find(context.Background(), eventID)
 	if l, ok := l.(*domain.GuestList); ok {
 		log.Printf("guest list: %d invited - %d accepted, %d declined - %d confirmed, %d denied\n",
 			l.NumGuests, l.NumAccepted, l.NumDeclined, l.NumConfirmed, l.NumDenied)

--- a/mocks/mocks.go
+++ b/mocks/mocks.go
@@ -122,8 +122,20 @@ func (t CommandOther2) CommandType() eh.CommandType     { return CommandOther2Ty
 // Model is a mocked read model, useful in testing.
 type Model struct {
 	ID        eh.UUID   `json:"id"         bson:"_id"`
+	Version   int       `json:"version"    bson:"version"`
 	Content   string    `json:"content"    bson:"content"`
 	CreatedAt time.Time `json:"created_at" bson:"created_at"`
+}
+
+// AggregateVersion implements the AggregateVersion method of the eventhorizon.Versionable interface.
+func (m *Model) AggregateVersion() int {
+	return m.Version
+}
+
+// SimpleModel is a mocked read model, useful in testing, without a version.
+type SimpleModel struct {
+	ID      eh.UUID `json:"id"         bson:"_id"`
+	Content string  `json:"content"    bson:"content"`
 }
 
 // CommandHandler is a mocked eventhorizon.CommandHandler, useful in testing.

--- a/mocks/mocks.go
+++ b/mocks/mocks.go
@@ -15,6 +15,7 @@
 package mocks
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -294,3 +295,37 @@ func (m *EventBus) AddObserver(observer eh.EventObserver) {}
 // SetHandlingStrategy implements the SetHandlingStrategy method of the
 // eventhorizon.EventBus interface.
 func (m *EventBus) SetHandlingStrategy(strategy eh.EventHandlingStrategy) {}
+
+// ReadRepository is a mocked eventhorizon.ReadRepository, useful in testing.
+type ReadRepository struct {
+	ParentRepo eh.ReadRepository
+	Item       interface{}
+	Items      []interface{}
+}
+
+// Parent implements the Parent method of the eventhorizon.ReadRepository interface.
+func (r *ReadRepository) Parent() eh.ReadRepository {
+	return r.ParentRepo
+}
+
+// Save implements the Save method of the eventhorizon.ReadRepository interface.
+func (r *ReadRepository) Save(ctx context.Context, id eh.UUID, item interface{}) error {
+	r.Item = item
+	r.Items = []interface{}{item}
+	return nil
+}
+
+// Find implements the Find method of the eventhorizon.ReadRepository interface.
+func (r *ReadRepository) Find(ctx context.Context, id eh.UUID) (interface{}, error) {
+	return r.Item, nil
+}
+
+// FindAll implements the FindAll method of the eventhorizon.ReadRepository interface.
+func (r *ReadRepository) FindAll(ctx context.Context) ([]interface{}, error) {
+	return r.Items, nil
+}
+
+// Remove implements the Remove method of the eventhorizon.ReadRepository interface.
+func (r *ReadRepository) Remove(ctx context.Context, id eh.UUID) error {
+	return nil
+}

--- a/readrepository.go
+++ b/readrepository.go
@@ -27,6 +27,10 @@ var ErrModelNotFound = errors.New("could not find model")
 
 // ReadRepository is a storage for read models.
 type ReadRepository interface {
+	// Parent returns the parent read repository, if there is one.
+	// Useful for iterating a wrapped set of repositories to get a specific one.
+	Parent() ReadRepository
+
 	// Save saves a read model with id to the repository.
 	Save(context.Context, UUID, interface{}) error
 

--- a/readrepository.go
+++ b/readrepository.go
@@ -15,6 +15,7 @@
 package eventhorizon
 
 import (
+	"context"
 	"errors"
 )
 
@@ -27,14 +28,14 @@ var ErrModelNotFound = errors.New("could not find model")
 // ReadRepository is a storage for read models.
 type ReadRepository interface {
 	// Save saves a read model with id to the repository.
-	Save(UUID, interface{}) error
+	Save(context.Context, UUID, interface{}) error
 
-	// Find returns one read model with using an id.
-	Find(UUID) (interface{}, error)
+	// Find returns a read model with an id.
+	Find(context.Context, UUID) (interface{}, error)
 
 	// FindAll returns all read models in the repository.
-	FindAll() ([]interface{}, error)
+	FindAll(context.Context) ([]interface{}, error)
 
 	// Remove removes a read model with id from the repository.
-	Remove(UUID) error
+	Remove(context.Context, UUID) error
 }

--- a/readrepository/memory/readrepository.go
+++ b/readrepository/memory/readrepository.go
@@ -37,6 +37,11 @@ func NewReadRepository() *ReadRepository {
 	return r
 }
 
+// Parent implements the Parent method of the eventhorizon.ReadRepository interface.
+func (r *ReadRepository) Parent() eh.ReadRepository {
+	return nil
+}
+
 // Save saves a read model with id to the repository.
 func (r *ReadRepository) Save(ctx context.Context, id eh.UUID, model interface{}) error {
 	r.dataMu.Lock()
@@ -110,4 +115,16 @@ func (r *ReadRepository) indexOfModel(model interface{}) int {
 		}
 	}
 	return -1
+}
+
+// Repository returns a parent ReadRepository if there is one.
+func Repository(repo eh.ReadRepository) *ReadRepository {
+	if r, ok := repo.(*ReadRepository); ok {
+		return r
+	}
+	parent := repo.Parent()
+	if parent == nil {
+		return nil
+	}
+	return Repository(parent)
 }

--- a/readrepository/memory/readrepository.go
+++ b/readrepository/memory/readrepository.go
@@ -15,6 +15,7 @@
 package memory
 
 import (
+	"context"
 	"sync"
 
 	eh "github.com/looplab/eventhorizon"
@@ -37,7 +38,7 @@ func NewReadRepository() *ReadRepository {
 }
 
 // Save saves a read model with id to the repository.
-func (r *ReadRepository) Save(id eh.UUID, model interface{}) error {
+func (r *ReadRepository) Save(ctx context.Context, id eh.UUID, model interface{}) error {
 	r.dataMu.Lock()
 	defer r.dataMu.Unlock()
 
@@ -60,19 +61,20 @@ func (r *ReadRepository) Save(id eh.UUID, model interface{}) error {
 
 // Find returns one read model with using an id. Returns
 // ErrModelNotFound if no model could be found.
-func (r *ReadRepository) Find(id eh.UUID) (interface{}, error) {
+func (r *ReadRepository) Find(ctx context.Context, id eh.UUID) (interface{}, error) {
 	r.dataMu.RLock()
 	defer r.dataMu.RUnlock()
 
-	if model, ok := r.dataByID[id]; ok {
-		return model, nil
+	model, ok := r.dataByID[id]
+	if !ok {
+		return nil, eh.ErrModelNotFound
 	}
 
-	return nil, eh.ErrModelNotFound
+	return model, nil
 }
 
 // FindAll returns all read models in the repository.
-func (r *ReadRepository) FindAll() ([]interface{}, error) {
+func (r *ReadRepository) FindAll(ctx context.Context) ([]interface{}, error) {
 	r.dataMu.RLock()
 	defer r.dataMu.RUnlock()
 
@@ -81,7 +83,7 @@ func (r *ReadRepository) FindAll() ([]interface{}, error) {
 
 // Remove removes a read model with id from the repository. Returns
 // ErrModelNotFound if no model could be found.
-func (r *ReadRepository) Remove(id eh.UUID) error {
+func (r *ReadRepository) Remove(ctx context.Context, id eh.UUID) error {
 	r.dataMu.Lock()
 	defer r.dataMu.Unlock()
 

--- a/readrepository/memory/readrepository_test.go
+++ b/readrepository/memory/readrepository_test.go
@@ -15,12 +15,9 @@
 package memory
 
 import (
-	"reflect"
 	"testing"
-	"time"
 
-	eh "github.com/looplab/eventhorizon"
-	"github.com/looplab/eventhorizon/mocks"
+	"github.com/looplab/eventhorizon/readrepository/testutil"
 )
 
 func TestReadRepository(t *testing.T) {
@@ -29,99 +26,5 @@ func TestReadRepository(t *testing.T) {
 		t.Error("there should be a repository")
 	}
 
-	// TODO: Share these tests between implementations.
-
-	t.Log("FindAll with no items")
-	result, err := repo.FindAll()
-	if err != nil {
-		t.Error("there should be no error:", err)
-	}
-	if len(result) != 0 {
-		t.Error("there should be no items:", len(result))
-	}
-
-	t.Log("Save one item")
-	model1 := &mocks.Model{eh.NewUUID(), "model1", time.Now().Round(time.Millisecond)}
-	if err = repo.Save(model1.ID, model1); err != nil {
-		t.Error("there should be no error:", err)
-	}
-	model, err := repo.Find(model1.ID)
-	if err != nil {
-		t.Error("there should be no error:", err)
-	}
-	if !reflect.DeepEqual(model, model1) {
-		t.Error("the item should be correct:", model)
-	}
-
-	t.Log("Save and overwrite with same ID")
-	model1Alt := &mocks.Model{model1.ID, "model1Alt", time.Now().Round(time.Millisecond)}
-	if err = repo.Save(model1Alt.ID, model1Alt); err != nil {
-		t.Error("there should be no error:", err)
-	}
-	model, err = repo.Find(model1Alt.ID)
-	if err != nil {
-		t.Error("there should be no error:", err)
-	}
-	if !reflect.DeepEqual(model, model1Alt) {
-		t.Error("the item should be correct:", model)
-	}
-
-	t.Log("FindAll with one item")
-	result, err = repo.FindAll()
-	if err != nil {
-		t.Error("there should be no error:", err)
-	}
-	if len(result) != 1 {
-		t.Error("there should be one item:", len(result))
-	}
-	if !reflect.DeepEqual(result[0], model1Alt) {
-		t.Error("the item should be correct:", model)
-	}
-
-	t.Log("Save with another ID")
-	model2 := &mocks.Model{eh.NewUUID(), "model2", time.Now().Round(time.Millisecond)}
-	if err = repo.Save(model2.ID, model2); err != nil {
-		t.Error("there should be no error:", err)
-	}
-	model, err = repo.Find(model2.ID)
-	if err != nil {
-		t.Error("there should be no error:", err)
-	}
-	if !reflect.DeepEqual(model, model2) {
-		t.Error("the item should be correct:", model)
-	}
-
-	t.Log("FindAll with two items")
-	result, err = repo.FindAll()
-	if err != nil {
-		t.Error("there should be no error:", err)
-	}
-	if len(result) != 2 {
-		t.Error("there should be two items:", len(result))
-	}
-	if !reflect.DeepEqual(result[0], model1Alt) || !reflect.DeepEqual(result[1], model2) {
-		t.Error("the items should be correct:", result)
-	}
-
-	t.Log("Remove one item")
-	err = repo.Remove(model1Alt.ID)
-	if err != nil {
-		t.Error("there should be no error:", err)
-	}
-	result, err = repo.FindAll()
-	if err != nil {
-		t.Error("there should be no error:", err)
-	}
-	if len(result) != 1 {
-		t.Error("there should be one item:", len(result))
-	}
-	if !reflect.DeepEqual(result[0], model2) {
-		t.Error("the item should be correct:", result[0])
-	}
-
-	t.Log("Remove non-existing item")
-	err = repo.Remove(model1Alt.ID)
-	if err != eh.ErrModelNotFound {
-		t.Error("there should be a ErrModelNotFound error:", err)
-	}
+	testutil.ReadRepositoryCommonTests(t, repo)
 }

--- a/readrepository/memory/readrepository_test.go
+++ b/readrepository/memory/readrepository_test.go
@@ -17,6 +17,7 @@ package memory
 import (
 	"testing"
 
+	"github.com/looplab/eventhorizon/mocks"
 	"github.com/looplab/eventhorizon/readrepository/testutil"
 )
 
@@ -27,4 +28,21 @@ func TestReadRepository(t *testing.T) {
 	}
 
 	testutil.ReadRepositoryCommonTests(t, repo)
+
+	if repo.Parent() != nil {
+		t.Error("the parent repo should be nil")
+	}
+}
+
+func TestRepository(t *testing.T) {
+	inner := &mocks.ReadRepository{}
+	if r := Repository(inner); r != nil {
+		t.Error("the parent repository should be nil:", r)
+	}
+
+	repo := NewReadRepository()
+	outer := &mocks.ReadRepository{ParentRepo: repo}
+	if r := Repository(outer); r != repo {
+		t.Error("the parent repository should be correct:", r)
+	}
 }

--- a/readrepository/mongodb/readrepository.go
+++ b/readrepository/mongodb/readrepository.go
@@ -74,6 +74,11 @@ func NewReadRepositoryWithSession(session *mgo.Session, database, collection str
 	return r, nil
 }
 
+// Parent implements the Parent method of the eventhorizon.ReadRepository interface.
+func (r *ReadRepository) Parent() eh.ReadRepository {
+	return nil
+}
+
 // Save saves a read model with id to the repository.
 func (r *ReadRepository) Save(ctx context.Context, id eh.UUID, model interface{}) error {
 	sess := r.session.Copy()
@@ -195,4 +200,16 @@ func (r *ReadRepository) Clear() error {
 // Close closes a database session.
 func (r *ReadRepository) Close() {
 	r.session.Close()
+}
+
+// Repository returns a parent ReadRepository if there is one.
+func Repository(repo eh.ReadRepository) *ReadRepository {
+	if r, ok := repo.(*ReadRepository); ok {
+		return r
+	}
+	parent := repo.Parent()
+	if parent == nil {
+		return nil
+	}
+	return Repository(parent)
 }

--- a/readrepository/mongodb/readrepository.go
+++ b/readrepository/mongodb/readrepository.go
@@ -15,6 +15,7 @@
 package mongodb
 
 import (
+	"context"
 	"errors"
 
 	"gopkg.in/mgo.v2"
@@ -74,7 +75,7 @@ func NewReadRepositoryWithSession(session *mgo.Session, database, collection str
 }
 
 // Save saves a read model with id to the repository.
-func (r *ReadRepository) Save(id eh.UUID, model interface{}) error {
+func (r *ReadRepository) Save(ctx context.Context, id eh.UUID, model interface{}) error {
 	sess := r.session.Copy()
 	defer sess.Close()
 
@@ -86,7 +87,7 @@ func (r *ReadRepository) Save(id eh.UUID, model interface{}) error {
 
 // Find returns one read model with using an id. Returns
 // ErrModelNotFound if no model could be found.
-func (r *ReadRepository) Find(id eh.UUID) (interface{}, error) {
+func (r *ReadRepository) Find(ctx context.Context, id eh.UUID) (interface{}, error) {
 	sess := r.session.Copy()
 	defer sess.Close()
 
@@ -108,7 +109,7 @@ func (r *ReadRepository) Find(id eh.UUID) (interface{}, error) {
 // the query in the callback and returning nil to block a second execution of
 // the same query in FindCustom. Expect a ErrInvalidQuery if returning a nil
 // query from the callback.
-func (r *ReadRepository) FindCustom(callback func(*mgo.Collection) *mgo.Query) ([]interface{}, error) {
+func (r *ReadRepository) FindCustom(ctx context.Context, callback func(*mgo.Collection) *mgo.Query) ([]interface{}, error) {
 	sess := r.session.Copy()
 	defer sess.Close()
 
@@ -137,7 +138,7 @@ func (r *ReadRepository) FindCustom(callback func(*mgo.Collection) *mgo.Query) (
 }
 
 // FindAll returns all read models in the repository.
-func (r *ReadRepository) FindAll() ([]interface{}, error) {
+func (r *ReadRepository) FindAll(ctx context.Context) ([]interface{}, error) {
 	sess := r.session.Copy()
 	defer sess.Close()
 
@@ -161,7 +162,7 @@ func (r *ReadRepository) FindAll() ([]interface{}, error) {
 
 // Remove removes a read model with id from the repository. Returns
 // ErrModelNotFound if no model could be found.
-func (r *ReadRepository) Remove(id eh.UUID) error {
+func (r *ReadRepository) Remove(ctx context.Context, id eh.UUID) error {
 	sess := r.session.Copy()
 	defer sess.Close()
 

--- a/readrepository/mongodb/readrepository_test.go
+++ b/readrepository/mongodb/readrepository_test.go
@@ -15,6 +15,7 @@
 package mongodb
 
 import (
+	"context"
 	"os"
 	"reflect"
 	"testing"
@@ -59,16 +60,18 @@ func TestReadRepository(t *testing.T) {
 
 	testutil.ReadRepositoryCommonTests(t, repo)
 
+	ctx := context.Background()
+
 	t.Log("Save one item")
 	modelCustom := &mocks.Model{
 		ID:        eh.NewUUID(),
 		Content:   "modelCustom",
 		CreatedAt: time.Now().Round(time.Millisecond),
 	}
-	if err = repo.Save(modelCustom.ID, modelCustom); err != nil {
+	if err = repo.Save(ctx, modelCustom.ID, modelCustom); err != nil {
 		t.Error("there should be no error:", err)
 	}
-	model, err := repo.Find(modelCustom.ID)
+	model, err := repo.Find(ctx, modelCustom.ID)
 	if err != nil {
 		t.Error("there should be no error:", err)
 	}
@@ -77,7 +80,7 @@ func TestReadRepository(t *testing.T) {
 	}
 
 	t.Log("FindCustom by content")
-	result, err := repo.FindCustom(func(c *mgo.Collection) *mgo.Query {
+	result, err := repo.FindCustom(ctx, func(c *mgo.Collection) *mgo.Query {
 		return c.Find(bson.M{"content": "modelCustom"})
 	})
 	if len(result) != 1 {
@@ -88,7 +91,7 @@ func TestReadRepository(t *testing.T) {
 	}
 
 	t.Log("FindCustom with no query")
-	result, err = repo.FindCustom(func(c *mgo.Collection) *mgo.Query {
+	result, err = repo.FindCustom(ctx, func(c *mgo.Collection) *mgo.Query {
 		return nil
 	})
 	if err == nil || err != ErrInvalidQuery {
@@ -97,7 +100,7 @@ func TestReadRepository(t *testing.T) {
 
 	count := 0
 	t.Log("FindCustom with query execution in the callback")
-	_, err = repo.FindCustom(func(c *mgo.Collection) *mgo.Query {
+	_, err = repo.FindCustom(ctx, func(c *mgo.Collection) *mgo.Query {
 		if count, err = c.Count(); err != nil {
 			t.Error("there should be no error:", err)
 		}

--- a/readrepository/mongodb/readrepository_test.go
+++ b/readrepository/mongodb/readrepository_test.go
@@ -25,6 +25,7 @@ import (
 
 	eh "github.com/looplab/eventhorizon"
 	"github.com/looplab/eventhorizon/mocks"
+	"github.com/looplab/eventhorizon/readrepository/testutil"
 )
 
 func TestReadRepository(t *testing.T) {
@@ -37,19 +38,18 @@ func TestReadRepository(t *testing.T) {
 		url = host + ":" + port
 	}
 
-	repo, err := NewReadRepository(url, "test", "mocks.TestModel")
+	repo, err := NewReadRepository(url, "test", "mocks.Model")
 	if err != nil {
 		t.Error("there should be no error:", err)
 	}
 	if repo == nil {
 		t.Error("there should be a repository")
 	}
-
+	defer repo.Close()
 	repo.SetModel(func() interface{} {
 		return &mocks.Model{}
 	})
 
-	defer repo.Close()
 	defer func() {
 		t.Log("clearing collection")
 		if err = repo.Clear(); err != nil {
@@ -57,89 +57,33 @@ func TestReadRepository(t *testing.T) {
 		}
 	}()
 
-	// TODO: Share these tests between implementations.
-
-	t.Log("FindAll with no items")
-	result, err := repo.FindAll()
-	if err != nil {
-		t.Error("there should be no error:", err)
-	}
-	if len(result) != 0 {
-		t.Error("there should be no items:", len(result))
-	}
+	testutil.ReadRepositoryCommonTests(t, repo)
 
 	t.Log("Save one item")
-	model1 := &mocks.Model{eh.NewUUID(), "model1", time.Now().Round(time.Millisecond)}
-	if err = repo.Save(model1.ID, model1); err != nil {
+	modelCustom := &mocks.Model{
+		ID:        eh.NewUUID(),
+		Content:   "modelCustom",
+		CreatedAt: time.Now().Round(time.Millisecond),
+	}
+	if err = repo.Save(modelCustom.ID, modelCustom); err != nil {
 		t.Error("there should be no error:", err)
 	}
-	model, err := repo.Find(model1.ID)
+	model, err := repo.Find(modelCustom.ID)
 	if err != nil {
 		t.Error("there should be no error:", err)
 	}
-	if !reflect.DeepEqual(model, model1) {
+	if !reflect.DeepEqual(model, modelCustom) {
 		t.Error("the item should be correct:", model)
-	}
-
-	t.Log("Save and overwrite with same ID")
-	model1Alt := &mocks.Model{model1.ID, "model1Alt", time.Now().Round(time.Millisecond)}
-	if err = repo.Save(model1Alt.ID, model1Alt); err != nil {
-		t.Error("there should be no error:", err)
-	}
-	model, err = repo.Find(model1Alt.ID)
-	if err != nil {
-		t.Error("there should be no error:", err)
-	}
-	if !reflect.DeepEqual(model, model1Alt) {
-		t.Error("the item should be correct:", model)
-	}
-
-	t.Log("FindAll with one item")
-	result, err = repo.FindAll()
-	if err != nil {
-		t.Error("there should be no error:", err)
-	}
-	if len(result) != 1 {
-		t.Error("there should be one item:", len(result))
-	}
-	if !reflect.DeepEqual(result[0], model1Alt) {
-		t.Error("the item should be correct:", model)
-	}
-
-	t.Log("Save with another ID")
-	model2 := &mocks.Model{eh.NewUUID(), "model2", time.Now().Round(time.Millisecond)}
-	if err = repo.Save(model2.ID, model2); err != nil {
-		t.Error("there should be no error:", err)
-	}
-	model, err = repo.Find(model2.ID)
-	if err != nil {
-		t.Error("there should be no error:", err)
-	}
-	if !reflect.DeepEqual(model, model2) {
-		t.Error("the item should be correct:", model)
-	}
-
-	t.Log("FindAll with two items")
-	result, err = repo.FindAll()
-	if err != nil {
-		t.Error("there should be no error:", err)
-	}
-	if len(result) != 2 {
-		t.Error("there should be two items:", len(result))
-	}
-	if (!reflect.DeepEqual(result[0], model1Alt) || !reflect.DeepEqual(result[1], model2)) &&
-		(!reflect.DeepEqual(result[0], model2) || !reflect.DeepEqual(result[1], model1Alt)) {
-		t.Error("the items should be correct:", result)
 	}
 
 	t.Log("FindCustom by content")
-	result, err = repo.FindCustom(func(c *mgo.Collection) *mgo.Query {
-		return c.Find(bson.M{"content": "model1Alt"})
+	result, err := repo.FindCustom(func(c *mgo.Collection) *mgo.Query {
+		return c.Find(bson.M{"content": "modelCustom"})
 	})
 	if len(result) != 1 {
 		t.Error("there should be one item:", len(result))
 	}
-	if !reflect.DeepEqual(result[0], model1Alt) {
+	if !reflect.DeepEqual(result[0], modelCustom) {
 		t.Error("the item should be correct:", model)
 	}
 
@@ -166,27 +110,5 @@ func TestReadRepository(t *testing.T) {
 	}
 	if count != 2 {
 		t.Error("the count should be correct:", count)
-	}
-
-	t.Log("Remove one item")
-	err = repo.Remove(model1Alt.ID)
-	if err != nil {
-		t.Error("there should be no error:", err)
-	}
-	result, err = repo.FindAll()
-	if err != nil {
-		t.Error("there should be no error:", err)
-	}
-	if len(result) != 1 {
-		t.Error("there should be one item:", len(result))
-	}
-	if !reflect.DeepEqual(result[0], model2) {
-		t.Error("the item should be correct:", result[0])
-	}
-
-	t.Log("Remove non-existing item")
-	err = repo.Remove(model1Alt.ID)
-	if err != eh.ErrModelNotFound {
-		t.Error("there should be a ErrModelNotFound error:", err)
 	}
 }

--- a/readrepository/mongodb/readrepository_test.go
+++ b/readrepository/mongodb/readrepository_test.go
@@ -60,6 +60,10 @@ func TestReadRepository(t *testing.T) {
 
 	testutil.ReadRepositoryCommonTests(t, repo)
 
+	if repo.Parent() != nil {
+		t.Error("the parent repo should be nil")
+	}
+
 	ctx := context.Background()
 
 	t.Log("Save one item")
@@ -113,5 +117,21 @@ func TestReadRepository(t *testing.T) {
 	}
 	if count != 2 {
 		t.Error("the count should be correct:", count)
+	}
+}
+
+func TestRepository(t *testing.T) {
+	inner := &mocks.ReadRepository{}
+	if r := Repository(inner); r != nil {
+		t.Error("the parent repository should be nil:", r)
+	}
+
+	repo, err := NewReadRepository("", "", "")
+	if err != nil {
+		t.Error("there should be no error:", err)
+	}
+	outer := &mocks.ReadRepository{ParentRepo: repo}
+	if r := Repository(outer); r != repo {
+		t.Error("the parent repository should be correct:", r)
 	}
 }

--- a/readrepository/testutil/common_tests.go
+++ b/readrepository/testutil/common_tests.go
@@ -1,0 +1,134 @@
+// Copyright (c) 2014 - Max Ekman <max@looplab.se>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testutil
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	eh "github.com/looplab/eventhorizon"
+	"github.com/looplab/eventhorizon/mocks"
+)
+
+// ReadRepositoryCommonTests are test cases that are common to all
+// implementations of read repositories.
+func ReadRepositoryCommonTests(t *testing.T, repo eh.ReadRepository) {
+	t.Log("FindAll with no items")
+	result, err := repo.FindAll()
+	if err != nil {
+		t.Error("there should be no error:", err)
+	}
+	if len(result) != 0 {
+		t.Error("there should be no items:", len(result))
+	}
+
+	t.Log("Save one item")
+	model1 := &mocks.Model{
+		ID:        eh.NewUUID(),
+		Content:   "model1",
+		CreatedAt: time.Now().Round(time.Millisecond),
+	}
+	if err = repo.Save(model1.ID, model1); err != nil {
+		t.Error("there should be no error:", err)
+	}
+	model, err := repo.Find(model1.ID)
+	if err != nil {
+		t.Error("there should be no error:", err)
+	}
+	if !reflect.DeepEqual(model, model1) {
+		t.Error("the item should be correct:", model)
+	}
+
+	t.Log("Save and overwrite with same ID")
+	model1Alt := &mocks.Model{
+		ID:        model1.ID,
+		Content:   "model1Alt",
+		CreatedAt: time.Now().Round(time.Millisecond),
+	}
+	if err = repo.Save(model1Alt.ID, model1Alt); err != nil {
+		t.Error("there should be no error:", err)
+	}
+	model, err = repo.Find(model1Alt.ID)
+	if err != nil {
+		t.Error("there should be no error:", err)
+	}
+	if !reflect.DeepEqual(model, model1Alt) {
+		t.Error("the item should be correct:", model)
+	}
+
+	t.Log("FindAll with one item")
+	result, err = repo.FindAll()
+	if err != nil {
+		t.Error("there should be no error:", err)
+	}
+	if len(result) != 1 {
+		t.Error("there should be one item:", len(result))
+	}
+	if !reflect.DeepEqual(result[0], model1Alt) {
+		t.Error("the item should be correct:", model)
+	}
+
+	t.Log("Save with another ID")
+	model2 := &mocks.Model{
+		ID:        eh.NewUUID(),
+		Content:   "model2",
+		CreatedAt: time.Now().Round(time.Millisecond),
+	}
+	if err = repo.Save(model2.ID, model2); err != nil {
+		t.Error("there should be no error:", err)
+	}
+	model, err = repo.Find(model2.ID)
+	if err != nil {
+		t.Error("there should be no error:", err)
+	}
+	if !reflect.DeepEqual(model, model2) {
+		t.Error("the item should be correct:", model)
+	}
+
+	t.Log("FindAll with two items")
+	result, err = repo.FindAll()
+	if err != nil {
+		t.Error("there should be no error:", err)
+	}
+	if len(result) != 2 {
+		t.Error("there should be two items:", len(result))
+	}
+	if !reflect.DeepEqual(result[0], model1Alt) || !reflect.DeepEqual(result[1], model2) {
+		t.Error("the items should be correct:", result)
+	}
+
+	t.Log("Remove one item")
+	err = repo.Remove(model1Alt.ID)
+	if err != nil {
+		t.Error("there should be no error:", err)
+	}
+	result, err = repo.FindAll()
+	if err != nil {
+		t.Error("there should be no error:", err)
+	}
+	if len(result) != 1 {
+		t.Error("there should be one item:", len(result))
+	}
+	if !reflect.DeepEqual(result[0], model2) {
+		t.Error("the item should be correct:", result[0])
+	}
+
+	t.Log("Remove non-existing item")
+	err = repo.Remove(model1Alt.ID)
+	if err != eh.ErrModelNotFound {
+		t.Error("there should be a ErrModelNotFound error:", err)
+	}
+}

--- a/readrepository/testutil/common_tests.go
+++ b/readrepository/testutil/common_tests.go
@@ -15,6 +15,7 @@
 package testutil
 
 import (
+	"context"
 	"reflect"
 	"testing"
 	"time"
@@ -26,8 +27,10 @@ import (
 // ReadRepositoryCommonTests are test cases that are common to all
 // implementations of read repositories.
 func ReadRepositoryCommonTests(t *testing.T, repo eh.ReadRepository) {
+	ctx := context.Background()
+
 	t.Log("FindAll with no items")
-	result, err := repo.FindAll()
+	result, err := repo.FindAll(ctx)
 	if err != nil {
 		t.Error("there should be no error:", err)
 	}
@@ -41,10 +44,10 @@ func ReadRepositoryCommonTests(t *testing.T, repo eh.ReadRepository) {
 		Content:   "model1",
 		CreatedAt: time.Now().Round(time.Millisecond),
 	}
-	if err = repo.Save(model1.ID, model1); err != nil {
+	if err = repo.Save(ctx, model1.ID, model1); err != nil {
 		t.Error("there should be no error:", err)
 	}
-	model, err := repo.Find(model1.ID)
+	model, err := repo.Find(ctx, model1.ID)
 	if err != nil {
 		t.Error("there should be no error:", err)
 	}
@@ -58,10 +61,10 @@ func ReadRepositoryCommonTests(t *testing.T, repo eh.ReadRepository) {
 		Content:   "model1Alt",
 		CreatedAt: time.Now().Round(time.Millisecond),
 	}
-	if err = repo.Save(model1Alt.ID, model1Alt); err != nil {
+	if err = repo.Save(ctx, model1Alt.ID, model1Alt); err != nil {
 		t.Error("there should be no error:", err)
 	}
-	model, err = repo.Find(model1Alt.ID)
+	model, err = repo.Find(ctx, model1Alt.ID)
 	if err != nil {
 		t.Error("there should be no error:", err)
 	}
@@ -70,7 +73,7 @@ func ReadRepositoryCommonTests(t *testing.T, repo eh.ReadRepository) {
 	}
 
 	t.Log("FindAll with one item")
-	result, err = repo.FindAll()
+	result, err = repo.FindAll(ctx)
 	if err != nil {
 		t.Error("there should be no error:", err)
 	}
@@ -87,10 +90,10 @@ func ReadRepositoryCommonTests(t *testing.T, repo eh.ReadRepository) {
 		Content:   "model2",
 		CreatedAt: time.Now().Round(time.Millisecond),
 	}
-	if err = repo.Save(model2.ID, model2); err != nil {
+	if err = repo.Save(ctx, model2.ID, model2); err != nil {
 		t.Error("there should be no error:", err)
 	}
-	model, err = repo.Find(model2.ID)
+	model, err = repo.Find(ctx, model2.ID)
 	if err != nil {
 		t.Error("there should be no error:", err)
 	}
@@ -99,7 +102,7 @@ func ReadRepositoryCommonTests(t *testing.T, repo eh.ReadRepository) {
 	}
 
 	t.Log("FindAll with two items")
-	result, err = repo.FindAll()
+	result, err = repo.FindAll(ctx)
 	if err != nil {
 		t.Error("there should be no error:", err)
 	}
@@ -111,11 +114,11 @@ func ReadRepositoryCommonTests(t *testing.T, repo eh.ReadRepository) {
 	}
 
 	t.Log("Remove one item")
-	err = repo.Remove(model1Alt.ID)
+	err = repo.Remove(ctx, model1Alt.ID)
 	if err != nil {
 		t.Error("there should be no error:", err)
 	}
-	result, err = repo.FindAll()
+	result, err = repo.FindAll(ctx)
 	if err != nil {
 		t.Error("there should be no error:", err)
 	}
@@ -127,7 +130,7 @@ func ReadRepositoryCommonTests(t *testing.T, repo eh.ReadRepository) {
 	}
 
 	t.Log("Remove non-existing item")
-	err = repo.Remove(model1Alt.ID)
+	err = repo.Remove(ctx, model1Alt.ID)
 	if err != eh.ErrModelNotFound {
 		t.Error("there should be a ErrModelNotFound error:", err)
 	}

--- a/readrepository/version/readrepository.go
+++ b/readrepository/version/readrepository.go
@@ -41,6 +41,11 @@ func NewReadRepository(repo eh.ReadRepository) *ReadRepository {
 	}
 }
 
+// Parent implements the Parent method of the eventhorizon.ReadRepository interface.
+func (r *ReadRepository) Parent() eh.ReadRepository {
+	return r.ReadRepository
+}
+
 // Find implements the Find method of the eventhorizon.ReadModel interface.
 // If the context contains a min version set by WithMinVersion it will only
 // return an item if its version is at least min version. If a timeout or
@@ -137,4 +142,16 @@ func MinVersion(ctx context.Context) int {
 // WithMinVersion returns the context with min value set.
 func WithMinVersion(ctx context.Context, minVersion int) context.Context {
 	return context.WithValue(ctx, minVersionKey, minVersion)
+}
+
+// Repository returns a parent ReadRepository if there is one.
+func Repository(repo eh.ReadRepository) *ReadRepository {
+	if r, ok := repo.(*ReadRepository); ok {
+		return r
+	}
+	parent := repo.Parent()
+	if parent == nil {
+		return nil
+	}
+	return Repository(parent)
 }

--- a/readrepository/version/readrepository.go
+++ b/readrepository/version/readrepository.go
@@ -1,0 +1,140 @@
+// Copyright (c) 2014 - Max Ekman <max@looplab.se>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package version
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/jpillora/backoff"
+	eh "github.com/looplab/eventhorizon"
+)
+
+// ErrModelHasNoVersion is when a model has no version number.
+var ErrModelHasNoVersion = errors.New("model has no version")
+
+// ErrIncorrectModelVersion is when a model has an incorrect version.
+var ErrIncorrectModelVersion = errors.New("incorrect model version")
+
+// ReadRepository is a middleware that adds version checking to a read repository.
+type ReadRepository struct {
+	eh.ReadRepository
+}
+
+// NewReadRepository creates a new ReadRepository.
+func NewReadRepository(repo eh.ReadRepository) *ReadRepository {
+	return &ReadRepository{
+		ReadRepository: repo,
+	}
+}
+
+// Find implements the Find method of the eventhorizon.ReadModel interface.
+// If the context contains a min version set by WithMinVersion it will only
+// return an item if its version is at least min version. If a timeout or
+// deadline is set on the context it will repetedly try to get the item until
+// either the version matches or the deadline is reached.
+func (r *ReadRepository) Find(ctx context.Context, id eh.UUID) (interface{}, error) {
+	// If there is no min version set just return the item as normally.
+	minVersion := MinVersion(ctx)
+	if minVersion < 1 {
+		return r.ReadRepository.Find(ctx, id)
+	}
+
+	// Try to get a model with a min version
+	model, err := r.findMinVersion(ctx, id, minVersion)
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		// Without deadline it ends here no matter what the result is.
+		return model, err
+	} else if err != nil && !(err == ErrIncorrectModelVersion || (err == eh.ErrModelNotFound && minVersion == 1)) {
+		// If we have a deadline but the error is a real error return it here.
+		return nil, err
+	}
+
+	// Try to get the item and retry with exponentially longer intervals until
+	// the deadline expires.
+	delay := &backoff.Backoff{
+		Max: deadline.Sub(time.Now()),
+	}
+	for {
+		select {
+		case <-time.After(delay.Duration()):
+			model, err := r.findMinVersion(ctx, id, minVersion)
+			if err == ErrIncorrectModelVersion ||
+				(err == eh.ErrModelNotFound && minVersion == 1) {
+				// Try another time for incorrect min versions and for the
+				// first creation of items.
+				continue
+			} else if err != nil {
+				return nil, err
+			}
+			return model, nil
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+}
+
+// findMinVersion finds an item if it has a version and it is at least minVersion.
+func (r *ReadRepository) findMinVersion(ctx context.Context, id eh.UUID, minVersion int) (interface{}, error) {
+	model, err := r.ReadRepository.Find(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+
+	versionable, ok := model.(Versionable)
+	if !ok {
+		return nil, ErrModelHasNoVersion
+	}
+
+	if versionable.AggregateVersion() < minVersion {
+		return nil, ErrIncorrectModelVersion
+	}
+
+	return model, nil
+}
+
+// Versionable is a read model that has a version number saved, used by
+// ReadRepository.FindMinVersion().
+type Versionable interface {
+	// AggregateVersion returns the aggregate version that a read model represents.
+	AggregateVersion() int
+}
+
+type contextKey int
+
+const (
+	// minVersionKey is the context key for the min version value.
+	minVersionKey contextKey = iota
+)
+
+// MinVersion returns the min version from the context.
+func MinVersion(ctx context.Context) int {
+	v := ctx.Value(minVersionKey)
+	if v == nil {
+		return 0
+	}
+	minVersion, ok := v.(int)
+	if !ok {
+		return 0
+	}
+	return minVersion
+}
+
+// WithMinVersion returns the context with min value set.
+func WithMinVersion(ctx context.Context, minVersion int) context.Context {
+	return context.WithValue(ctx, minVersionKey, minVersion)
+}

--- a/readrepository/version/readrepository_test.go
+++ b/readrepository/version/readrepository_test.go
@@ -39,6 +39,10 @@ func TestReadRepository(t *testing.T) {
 
 	testutil.ReadRepositoryCommonTests(t, repo)
 
+	if parent := repo.Parent(); parent != memoryRepo {
+		t.Error("the parent repo should be correct:", parent)
+	}
+
 	simpleMemoryRepo := memory.NewReadRepository()
 	if simpleMemoryRepo == nil {
 		t.Error("there should be a repository")
@@ -185,5 +189,18 @@ func TestContextMinVersion(t *testing.T) {
 	ctx = WithMinVersion(ctx, 8)
 	if v := MinVersion(ctx); v != 8 {
 		t.Error("the min version should be correct:", v)
+	}
+}
+
+func TestRepository(t *testing.T) {
+	inner := &mocks.ReadRepository{}
+	if r := Repository(inner); r != nil {
+		t.Error("the parent repository should be nil:", r)
+	}
+
+	repo := NewReadRepository(inner)
+	outer := &mocks.ReadRepository{ParentRepo: repo}
+	if r := Repository(outer); r != repo {
+		t.Error("the parent repository should be correct:", r)
 	}
 }

--- a/readrepository/version/readrepository_test.go
+++ b/readrepository/version/readrepository_test.go
@@ -1,0 +1,189 @@
+// Copyright (c) 2014 - Max Ekman <max@looplab.se>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package version
+
+import (
+	"context"
+	"reflect"
+	"testing"
+	"time"
+
+	eh "github.com/looplab/eventhorizon"
+	"github.com/looplab/eventhorizon/mocks"
+	"github.com/looplab/eventhorizon/readrepository/memory"
+	"github.com/looplab/eventhorizon/readrepository/testutil"
+)
+
+func TestReadRepository(t *testing.T) {
+	memoryRepo := memory.NewReadRepository()
+	if memoryRepo == nil {
+		t.Error("there should be a repository")
+	}
+
+	repo := NewReadRepository(memoryRepo)
+	if repo == nil {
+		t.Error("there should be a repository")
+	}
+
+	testutil.ReadRepositoryCommonTests(t, repo)
+
+	simpleMemoryRepo := memory.NewReadRepository()
+	if simpleMemoryRepo == nil {
+		t.Error("there should be a repository")
+	}
+
+	simpleRepo := NewReadRepository(simpleMemoryRepo)
+	if simpleRepo == nil {
+		t.Error("there should be a repository")
+	}
+
+	t.Log("Find with min version without version")
+	simpleModel := &mocks.SimpleModel{
+		ID:      eh.NewUUID(),
+		Content: "simpleModel",
+	}
+	if err := simpleRepo.Save(context.Background(), simpleModel.ID, simpleModel); err != nil {
+		t.Error("there should be no error:", err)
+	}
+	ctx := WithMinVersion(context.Background(), 1)
+	_, err := simpleRepo.Find(ctx, simpleModel.ID)
+	if err != ErrModelHasNoVersion {
+		t.Error("there should be a model has no version error:", err)
+	}
+
+	t.Log("Find with min version, too low")
+	modelMinVersion := &mocks.Model{
+		ID:        eh.NewUUID(),
+		Version:   1,
+		Content:   "modelMinVersion",
+		CreatedAt: time.Now().Round(time.Millisecond),
+	}
+	if err = repo.Save(context.Background(), modelMinVersion.ID, modelMinVersion); err != nil {
+		t.Error("there should be no error:", err)
+	}
+	ctx = WithMinVersion(context.Background(), 2)
+	model, err := repo.Find(ctx, modelMinVersion.ID)
+	if err != ErrIncorrectModelVersion {
+		t.Error("there should be a incorrect model version error:", err)
+	}
+
+	t.Log("Find with min version, exactly")
+	modelMinVersion.Version = 2
+	if err = repo.Save(context.Background(), modelMinVersion.ID, modelMinVersion); err != nil {
+		t.Error("there should be no error:", err)
+	}
+	ctx = WithMinVersion(context.Background(), 2)
+	model, err = repo.Find(ctx, modelMinVersion.ID)
+	if err != nil {
+		t.Error("there should be no error:", err)
+	}
+	if !reflect.DeepEqual(model, modelMinVersion) {
+		t.Error("the item should be correct:", model)
+	}
+
+	t.Log("Find with min version, higher")
+	modelMinVersion.Version = 3
+	if err = repo.Save(context.Background(), modelMinVersion.ID, modelMinVersion); err != nil {
+		t.Error("there should be no error:", err)
+	}
+	ctx = WithMinVersion(context.Background(), 2)
+	model, err = repo.Find(ctx, modelMinVersion.ID)
+	if err != nil {
+		t.Error("there should be no error:", err)
+	}
+	if !reflect.DeepEqual(model, modelMinVersion) {
+		t.Error("the item should be correct:", model)
+	}
+
+	t.Log("Find with min version, with timeout, data available immediately")
+	modelMinVersion.Version = 4
+	if err = repo.Save(context.Background(), modelMinVersion.ID, modelMinVersion); err != nil {
+		t.Error("there should be no error:", err)
+	}
+	ctx = WithMinVersion(context.Background(), 4)
+	ctx, _ = context.WithTimeout(ctx, time.Second)
+	model, err = repo.Find(ctx, modelMinVersion.ID)
+	if err != nil {
+		t.Error("there should be no error:", err)
+	}
+	if !reflect.DeepEqual(model, modelMinVersion) {
+		t.Error("the item should be correct:", model)
+	}
+
+	t.Log("Find with min version, with timeout, data available on retry")
+	go func() {
+		<-time.After(100 * time.Millisecond)
+		modelMinVersion.Version = 5
+		if err = repo.Save(context.Background(), modelMinVersion.ID, modelMinVersion); err != nil {
+			t.Error("there should be no error:", err)
+		}
+	}()
+	ctx = WithMinVersion(context.Background(), 5)
+	ctx, _ = context.WithTimeout(ctx, time.Second)
+	model, err = repo.Find(ctx, modelMinVersion.ID)
+	if err != nil {
+		t.Error("there should be no error:", err)
+	}
+	if !reflect.DeepEqual(model, modelMinVersion) {
+		t.Error("the item should be correct:", model)
+	}
+
+	t.Log("Find with min version, with timeout, created data available on retry")
+	modelMinVersion.ID = eh.NewUUID()
+	modelMinVersion.Version = 1
+	go func() {
+		<-time.After(100 * time.Millisecond)
+		if err = repo.Save(context.Background(), modelMinVersion.ID, modelMinVersion); err != nil {
+			t.Error("there should be no error:", err)
+		}
+	}()
+	ctx = WithMinVersion(context.Background(), 1)
+	ctx, _ = context.WithTimeout(ctx, time.Second)
+	model, err = repo.Find(ctx, modelMinVersion.ID)
+	if err != nil {
+		t.Error("there should be no error:", err)
+	}
+	if !reflect.DeepEqual(model, modelMinVersion) {
+		t.Error("the item should be correct:", model)
+	}
+
+	t.Log("Find with min version, with timeout exceeded")
+	go func() {
+		<-time.After(100 * time.Millisecond)
+		modelMinVersion.Version = 6
+		if err = repo.Save(context.Background(), modelMinVersion.ID, modelMinVersion); err != nil {
+			t.Error("there should be no error:", err)
+		}
+	}()
+	ctx = WithMinVersion(context.Background(), 6)
+	ctx, _ = context.WithTimeout(ctx, 10*time.Millisecond)
+	model, err = repo.Find(ctx, modelMinVersion.ID)
+	if err != context.DeadlineExceeded {
+		t.Error("there should be a deadline exceeded error:", err)
+	}
+}
+
+func TestContextMinVersion(t *testing.T) {
+	ctx := context.Background()
+
+	if v := MinVersion(ctx); v != 0 {
+		t.Error("there should be no min version:", v)
+	}
+
+	ctx = WithMinVersion(ctx, 8)
+	if v := MinVersion(ctx); v != 8 {
+		t.Error("the min version should be correct:", v)
+	}
+}


### PR DESCRIPTION
Adds initial support for versioning on the read model. It is implemented as a read model middleware that can check that a model is at least at some version. It also has the possibility to repeatedly retry to get an item with a min version by setting a deadline on the context. This will use an exponential back off strategy.

Fixes #69.