### PR TITLE
Issue 50 / use context objects

### DIFF
--- a/aggregate.go
+++ b/aggregate.go
@@ -47,7 +47,7 @@ type Aggregate interface {
 	NewEvent(EventType, EventData) Event
 	// ApplyEvent applies an event to the aggregate by setting its values and
 	// increments the aggregate version.
-	ApplyEvent(Event)
+	ApplyEvent(context.Context, Event)
 	// StoreEvent stores an event as uncommitted.
 	StoreEvent(Event)
 	// GetUncommittedEvents gets all uncommitted events for storing.

--- a/aggregate.go
+++ b/aggregate.go
@@ -15,6 +15,7 @@
 package eventhorizon
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"sync"
@@ -40,7 +41,7 @@ type Aggregate interface {
 	Version() int
 
 	// HandleCommand handles a command and stores events.
-	HandleCommand(Command) error
+	HandleCommand(context.Context, Command) error
 
 	// NewEvent creates a new event with the aggregate set as type and ID.
 	NewEvent(EventType, EventData) Event

--- a/aggregate_test.go
+++ b/aggregate_test.go
@@ -14,7 +14,10 @@
 
 package eventhorizon
 
-import "testing"
+import (
+	"context"
+	"testing"
+)
 
 func TestCreateAggregate(t *testing.T) {
 	id := NewUUID()
@@ -84,22 +87,26 @@ const (
 
 type TestAggregateRegister struct{ *AggregateBase }
 
-func (a *TestAggregateRegister) AggregateType() AggregateType        { return TestAggregateRegisterType }
-func (a *TestAggregateRegister) HandleCommand(command Command) error { return nil }
-func (a *TestAggregateRegister) ApplyEvent(event Event)              {}
+func (a *TestAggregateRegister) AggregateType() AggregateType                             { return TestAggregateRegisterType }
+func (a *TestAggregateRegister) HandleCommand(ctx context.Context, command Command) error { return nil }
+func (a *TestAggregateRegister) ApplyEvent(event Event)                                   {}
 
 type TestAggregateRegisterEmpty struct{ *AggregateBase }
 
 func (a *TestAggregateRegisterEmpty) AggregateType() AggregateType {
 	return TestAggregateRegisterEmptyType
 }
-func (a *TestAggregateRegisterEmpty) HandleCommand(command Command) error { return nil }
-func (a *TestAggregateRegisterEmpty) ApplyEvent(event Event)              {}
+func (a *TestAggregateRegisterEmpty) HandleCommand(ctx context.Context, command Command) error {
+	return nil
+}
+func (a *TestAggregateRegisterEmpty) ApplyEvent(event Event) {}
 
 type TestAggregateRegisterTwice struct{ *AggregateBase }
 
 func (a *TestAggregateRegisterTwice) AggregateType() AggregateType {
 	return TestAggregateRegisterTwiceType
 }
-func (a *TestAggregateRegisterTwice) HandleCommand(command Command) error { return nil }
-func (a *TestAggregateRegisterTwice) ApplyEvent(event Event)              {}
+func (a *TestAggregateRegisterTwice) HandleCommand(ctx context.Context, command Command) error {
+	return nil
+}
+func (a *TestAggregateRegisterTwice) ApplyEvent(event Event) {}

--- a/aggregate_test.go
+++ b/aggregate_test.go
@@ -89,7 +89,7 @@ type TestAggregateRegister struct{ *AggregateBase }
 
 func (a *TestAggregateRegister) AggregateType() AggregateType                             { return TestAggregateRegisterType }
 func (a *TestAggregateRegister) HandleCommand(ctx context.Context, command Command) error { return nil }
-func (a *TestAggregateRegister) ApplyEvent(event Event)                                   {}
+func (a *TestAggregateRegister) ApplyEvent(ctx context.Context, event Event)              {}
 
 type TestAggregateRegisterEmpty struct{ *AggregateBase }
 
@@ -99,7 +99,7 @@ func (a *TestAggregateRegisterEmpty) AggregateType() AggregateType {
 func (a *TestAggregateRegisterEmpty) HandleCommand(ctx context.Context, command Command) error {
 	return nil
 }
-func (a *TestAggregateRegisterEmpty) ApplyEvent(event Event) {}
+func (a *TestAggregateRegisterEmpty) ApplyEvent(ctx context.Context, event Event) {}
 
 type TestAggregateRegisterTwice struct{ *AggregateBase }
 
@@ -109,4 +109,5 @@ func (a *TestAggregateRegisterTwice) AggregateType() AggregateType {
 func (a *TestAggregateRegisterTwice) HandleCommand(ctx context.Context, command Command) error {
 	return nil
 }
-func (a *TestAggregateRegisterTwice) ApplyEvent(event Event) {}
+func (a *TestAggregateRegisterTwice) ApplyEvent(ctx context.Context, event Event) {
+}

--- a/commandbus.go
+++ b/commandbus.go
@@ -15,6 +15,7 @@
 package eventhorizon
 
 import (
+	"context"
 	"errors"
 )
 
@@ -26,13 +27,13 @@ var ErrHandlerNotFound = errors.New("no handlers for command")
 
 // CommandHandler is an interface that all handlers of commands should implement.
 type CommandHandler interface {
-	HandleCommand(Command) error
+	HandleCommand(context.Context, Command) error
 }
 
 // CommandBus is an interface defining an event bus for distributing events.
 type CommandBus interface {
 	// HandleCommand handles a command on the event bus.
-	HandleCommand(Command) error
+	HandleCommand(context.Context, Command) error
 	// SetHandler registers a handler with a command.
 	SetHandler(CommandHandler, CommandType) error
 }

--- a/commandbus/local/commandbus.go
+++ b/commandbus/local/commandbus.go
@@ -15,6 +15,7 @@
 package local
 
 import (
+	"context"
 	"sync"
 
 	eh "github.com/looplab/eventhorizon"
@@ -36,12 +37,12 @@ func NewCommandBus() *CommandBus {
 }
 
 // HandleCommand handles a command with a handler capable of handling it.
-func (b *CommandBus) HandleCommand(command eh.Command) error {
+func (b *CommandBus) HandleCommand(ctx context.Context, command eh.Command) error {
 	b.handlersMu.RLock()
 	defer b.handlersMu.RUnlock()
 
 	if handler, ok := b.handlers[command.CommandType()]; ok {
-		return handler.HandleCommand(command)
+		return handler.HandleCommand(ctx, command)
 	}
 
 	return eh.ErrHandlerNotFound

--- a/commandbus/local/commandbus_test.go
+++ b/commandbus/local/commandbus_test.go
@@ -15,6 +15,7 @@
 package local
 
 import (
+	"context"
 	"testing"
 
 	eh "github.com/looplab/eventhorizon"
@@ -27,9 +28,11 @@ func TestCommandBus(t *testing.T) {
 		t.Fatal("there should be a bus")
 	}
 
+	ctx := context.WithValue(context.Background(), "testkey", "testval")
+
 	t.Log("handle with no handler")
 	command1 := &mocks.Command{eh.NewUUID(), "command1"}
-	err := bus.HandleCommand(command1)
+	err := bus.HandleCommand(ctx, command1)
 	if err != eh.ErrHandlerNotFound {
 		t.Error("there should be a ErrHandlerNotFound error:", err)
 	}
@@ -42,12 +45,15 @@ func TestCommandBus(t *testing.T) {
 	}
 
 	t.Log("handle with handler")
-	err = bus.HandleCommand(command1)
+	err = bus.HandleCommand(ctx, command1)
 	if err != nil {
 		t.Error("there should be no error:", err)
 	}
 	if handler.Command != command1 {
 		t.Error("the handled command should be correct:", handler.Command)
+	}
+	if val, ok := handler.Context.Value("testkey").(string); !ok || val != "testval" {
+		t.Error("the context should be correct:", handler.Context)
 	}
 
 	err = bus.SetHandler(handler, mocks.CommandType)

--- a/commandhandler.go
+++ b/commandhandler.go
@@ -15,6 +15,7 @@
 package eventhorizon
 
 import (
+	"context"
 	"errors"
 	"reflect"
 	"time"
@@ -80,7 +81,7 @@ func (h *AggregateCommandHandler) SetAggregate(aggregateType AggregateType, comm
 
 // HandleCommand handles a command with the registered aggregate.
 // Returns ErrAggregateNotFound if no aggregate could be found.
-func (h *AggregateCommandHandler) HandleCommand(command Command) error {
+func (h *AggregateCommandHandler) HandleCommand(ctx context.Context, command Command) error {
 	err := h.checkCommand(command)
 	if err != nil {
 		return err
@@ -98,7 +99,7 @@ func (h *AggregateCommandHandler) HandleCommand(command Command) error {
 		return ErrAggregateNotFound
 	}
 
-	if err = aggregate.HandleCommand(command); err != nil {
+	if err = aggregate.HandleCommand(ctx, command); err != nil {
 		return err
 	}
 

--- a/commandhandler.go
+++ b/commandhandler.go
@@ -92,7 +92,7 @@ func (h *AggregateCommandHandler) HandleCommand(ctx context.Context, command Com
 		return ErrAggregateNotFound
 	}
 
-	aggregate, err := h.repository.Load(aggregateType, command.AggregateID())
+	aggregate, err := h.repository.Load(ctx, aggregateType, command.AggregateID())
 	if err != nil {
 		return err
 	} else if aggregate == nil {
@@ -103,7 +103,7 @@ func (h *AggregateCommandHandler) HandleCommand(ctx context.Context, command Com
 		return err
 	}
 
-	if err = h.repository.Save(aggregate); err != nil {
+	if err = h.repository.Save(ctx, aggregate); err != nil {
 		return err
 	}
 

--- a/context.go
+++ b/context.go
@@ -1,0 +1,89 @@
+// Copyright (c) 2014 - Max Ekman <max@looplab.se>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package eventhorizon
+
+import (
+	"context"
+	"sync"
+)
+
+var (
+	contextMarshalFuncs   = []ContextMarshalFunc{}
+	contextMarshalFuncsMu = sync.RWMutex{}
+
+	contextUnmarshalFuncs   = []ContextUnmarshalFunc{}
+	contextUnmarshalFuncsMu = sync.RWMutex{}
+)
+
+// ContextMarshalFunc is a function that marshalls any context values to a map,
+// used for sending context on the wire.
+type ContextMarshalFunc func(context.Context, map[string]interface{})
+
+// RegisterContextMarshaler registers a marshaler function used by MarshalContext.
+func RegisterContextMarshaler(f ContextMarshalFunc) {
+	contextMarshalFuncsMu.Lock()
+	defer contextMarshalFuncsMu.Unlock()
+	contextMarshalFuncs = append(contextMarshalFuncs, f)
+}
+
+// MarshalContext marshals a context into a map.
+func MarshalContext(ctx context.Context) map[string]interface{} {
+	contextMarshalFuncsMu.RLock()
+	defer contextMarshalFuncsMu.RUnlock()
+
+	allVals := map[string]interface{}{}
+
+	for _, f := range contextMarshalFuncs {
+		vals := map[string]interface{}{}
+		f(ctx, vals)
+
+		for key, val := range vals {
+			if _, ok := allVals[key]; ok {
+				panic("duplicate context entry for: " + key)
+			}
+			allVals[key] = val
+		}
+	}
+
+	return allVals
+}
+
+// ContextUnmarshalFunc is a function that marshalls any context values to a map,
+// used for sending context on the wire.
+type ContextUnmarshalFunc func(context.Context, map[string]interface{}) context.Context
+
+// RegisterContextUnmarshaler registers a marshaler function used by UnmarshalContext.
+func RegisterContextUnmarshaler(f ContextUnmarshalFunc) {
+	contextUnmarshalFuncsMu.Lock()
+	defer contextUnmarshalFuncsMu.Unlock()
+	contextUnmarshalFuncs = append(contextUnmarshalFuncs, f)
+}
+
+// UnmarshalContext unmarshals a context from a map.
+func UnmarshalContext(vals map[string]interface{}) context.Context {
+	contextUnmarshalFuncsMu.RLock()
+	defer contextUnmarshalFuncsMu.RUnlock()
+
+	ctx := context.Background()
+	if vals == nil {
+		return ctx
+	}
+
+	for _, f := range contextUnmarshalFuncs {
+		ctx = f(ctx, vals)
+	}
+
+	return ctx
+}

--- a/context_test.go
+++ b/context_test.go
@@ -1,0 +1,94 @@
+// Copyright (c) 2016 - Max Ekman <max@looplab.se>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package eventhorizon
+
+import (
+	"context"
+	"testing"
+)
+
+func TestContextMarshaler(t *testing.T) {
+	if len(contextMarshalFuncs) != 0 {
+		t.Error("there should be no context marshalers")
+	}
+	RegisterContextMarshaler(func(ctx context.Context, vals map[string]interface{}) {
+		if val, ok := ContextTestOne(ctx); ok {
+			vals[contextTestKeyOneStr] = val
+		}
+	})
+	if len(contextMarshalFuncs) != 1 {
+		t.Error("there should be one context marshaler")
+	}
+
+	ctx := context.Background()
+
+	vals := MarshalContext(ctx)
+	if _, ok := vals[contextTestKeyOneStr]; ok {
+		t.Error("the marshaled values should be empty:", vals)
+	}
+	ctx = WithContextTestOne(ctx, "testval")
+	vals = MarshalContext(ctx)
+	if val, ok := vals[contextTestKeyOneStr]; !ok || val != "testval" {
+		t.Error("the marshaled value should be correct:", val)
+	}
+}
+
+func TestContextUnmarshaler(t *testing.T) {
+	if len(contextUnmarshalFuncs) != 0 {
+		t.Error("there should be no context marshalers")
+	}
+	RegisterContextUnmarshaler(func(ctx context.Context, vals map[string]interface{}) context.Context {
+		if val, ok := vals[contextTestKeyOneStr].(string); ok {
+			return WithContextTestOne(ctx, val)
+		}
+		return ctx
+	})
+	if len(contextUnmarshalFuncs) != 1 {
+		t.Error("there should be one context unmarshalers")
+	}
+
+	vals := map[string]interface{}{}
+	ctx := UnmarshalContext(vals)
+	if _, ok := ContextTestOne(ctx); ok {
+		t.Error("the unmarshaled context should be empty:", ctx)
+	}
+	vals[contextTestKeyOneStr] = "testval"
+	ctx = UnmarshalContext(vals)
+	if val, ok := ContextTestOne(ctx); !ok || val != "testval" {
+		t.Error("the unmarshaled context should be correct:", val)
+	}
+}
+
+type contextTestKey int
+
+const (
+	contextTestKeyOne contextTestKey = iota
+)
+
+const (
+	// The string key used to marshal contextTestKeyOne.
+	contextTestKeyOneStr = "test_context_one"
+)
+
+// WithContextTestOne sets a value for One one the context.
+func WithContextTestOne(ctx context.Context, val string) context.Context {
+	return context.WithValue(ctx, contextTestKeyOne, val)
+}
+
+// ContextTestOne returns a value for One from the context.
+func ContextTestOne(ctx context.Context) (string, bool) {
+	val, ok := ctx.Value(contextTestKeyOne).(string)
+	return val, ok
+}

--- a/eventbus.go
+++ b/eventbus.go
@@ -14,13 +14,15 @@
 
 package eventhorizon
 
+import "context"
+
 // EventBus is an interface defining an event bus for distributing events.
 type EventBus interface {
 	// PublishEvent publishes an event on the event bus.
 	// Only one handler of each handler type that is registered for the event
 	// will receive it.
 	// All the observers will receive the event.
-	PublishEvent(Event)
+	PublishEvent(context.Context, Event)
 
 	// AddHandler adds a handler for an event.
 	// TODO: Use a pattern instead of event for what to handle.
@@ -37,7 +39,7 @@ type EventBus interface {
 // Only one handler of the same type will receive an event.
 type EventHandler interface {
 	// HandleEvent handles an event.
-	HandleEvent(Event)
+	HandleEvent(context.Context, Event)
 
 	// HandlerType returns the type of the handler.
 	HandlerType() EventHandlerType
@@ -51,7 +53,7 @@ type EventHandlerType string
 // All observers will receive an event.
 type EventObserver interface {
 	// Notify is notifed about an event.
-	Notify(Event)
+	Notify(context.Context, Event)
 }
 
 // EventHandlingStrategy is the strategy to use when handling events.

--- a/eventhorizon_test.go
+++ b/eventhorizon_test.go
@@ -73,10 +73,11 @@ func (a *TestAggregate) HandleCommand(ctx context.Context, command Command) erro
 	return errors.New("couldn't handle command")
 }
 
-func (a *TestAggregate) ApplyEvent(event Event) {
+func (a *TestAggregate) ApplyEvent(ctx context.Context, event Event) {
 	defer a.IncrementVersion()
 
 	a.appliedEvent = event
+	a.context = ctx
 }
 
 type TestAggregate2 struct {
@@ -110,8 +111,9 @@ func (a *TestAggregate2) HandleCommand(ctx context.Context, command Command) err
 	return errors.New("couldn't handle command")
 }
 
-func (a *TestAggregate2) ApplyEvent(event Event) {
+func (a *TestAggregate2) ApplyEvent(ctx context.Context, event Event) {
 	a.appliedEvent = event
+	a.context = ctx
 }
 
 type TestCommand struct {

--- a/eventhorizon_test.go
+++ b/eventhorizon_test.go
@@ -185,11 +185,13 @@ func (m *MockEventStore) Load(ctx context.Context, aggregateType AggregateType, 
 }
 
 type MockEventBus struct {
-	Events []Event
+	Events  []Event
+	Context context.Context
 }
 
-func (m *MockEventBus) PublishEvent(event Event) {
+func (m *MockEventBus) PublishEvent(ctx context.Context, event Event) {
 	m.Events = append(m.Events, event)
+	m.Context = ctx
 }
 
 func (m *MockEventBus) AddHandler(handler EventHandler, eventType EventType) {}

--- a/eventhorizon_test.go
+++ b/eventhorizon_test.go
@@ -157,27 +157,30 @@ func (m *MockRepository) Save(ctx context.Context, aggregate Aggregate) error {
 }
 
 type MockEventStore struct {
-	Events []Event
-	Loaded UUID
+	Events  []Event
+	Loaded  UUID
+	Context context.Context
 	// Used to simulate errors in the store.
 	err error
 }
 
-func (m *MockEventStore) Save(events []Event, originalVersion int) error {
+func (m *MockEventStore) Save(ctx context.Context, events []Event, originalVersion int) error {
 	if m.err != nil {
 		return m.err
 	}
 	for _, event := range events {
 		m.Events = append(m.Events, event)
 	}
+	m.Context = ctx
 	return nil
 }
 
-func (m *MockEventStore) Load(aggregateType AggregateType, id UUID) ([]Event, error) {
+func (m *MockEventStore) Load(ctx context.Context, aggregateType AggregateType, id UUID) ([]Event, error) {
 	if m.err != nil {
 		return nil, m.err
 	}
 	m.Loaded = id
+	m.Context = ctx
 	return m.Events, nil
 }
 

--- a/eventhorizon_test.go
+++ b/eventhorizon_test.go
@@ -199,3 +199,18 @@ func (m *MockEventBus) PublishEvent(ctx context.Context, event Event) {
 func (m *MockEventBus) AddHandler(handler EventHandler, eventType EventType) {}
 func (m *MockEventBus) AddObserver(observer EventObserver)                   {}
 func (m *MockEventBus) SetHandlingStrategy(strategy EventHandlingStrategy)   {}
+
+type MockCommandBus struct {
+	Commands []Command
+	Context  context.Context
+}
+
+func (m *MockCommandBus) HandleCommand(ctx context.Context, command Command) error {
+	m.Commands = append(m.Commands, command)
+	m.Context = ctx
+	return nil
+}
+
+func (m *MockCommandBus) SetHandler(handler CommandHandler, commandType CommandType) error {
+	return nil
+}

--- a/eventhorizon_test.go
+++ b/eventhorizon_test.go
@@ -142,14 +142,17 @@ type TestEvent2Data struct {
 
 type MockRepository struct {
 	Aggregates map[UUID]Aggregate
+	Context    context.Context
 }
 
-func (m *MockRepository) Load(aggregateType AggregateType, id UUID) (Aggregate, error) {
+func (m *MockRepository) Load(ctx context.Context, aggregateType AggregateType, id UUID) (Aggregate, error) {
+	m.Context = ctx
 	return m.Aggregates[id], nil
 }
 
-func (m *MockRepository) Save(aggregate Aggregate) error {
+func (m *MockRepository) Save(ctx context.Context, aggregate Aggregate) error {
 	m.Aggregates[aggregate.AggregateID()] = aggregate
+	m.Context = ctx
 	return nil
 }
 

--- a/eventhorizon_test.go
+++ b/eventhorizon_test.go
@@ -14,7 +14,10 @@
 
 package eventhorizon
 
-import "errors"
+import (
+	"context"
+	"errors"
+)
 
 func init() {
 	RegisterAggregate(func(id UUID) Aggregate {
@@ -43,6 +46,7 @@ type TestAggregate struct {
 	*AggregateBase
 
 	dispatchedCommand Command
+	context           context.Context
 	appliedEvent      Event
 	numHandled        int
 }
@@ -53,8 +57,9 @@ func NewTestAggregate(id UUID) *TestAggregate {
 	}
 }
 
-func (a *TestAggregate) HandleCommand(command Command) error {
+func (a *TestAggregate) HandleCommand(ctx context.Context, command Command) error {
 	a.dispatchedCommand = command
+	a.context = ctx
 	a.numHandled++
 	switch command := command.(type) {
 	case *TestCommand:
@@ -78,6 +83,7 @@ type TestAggregate2 struct {
 	*AggregateBase
 
 	dispatchedCommand Command
+	context           context.Context
 	appliedEvent      Event
 	numHandled        int
 }
@@ -88,8 +94,9 @@ func NewTestAggregate2(id UUID) *TestAggregate2 {
 	}
 }
 
-func (a *TestAggregate2) HandleCommand(command Command) error {
+func (a *TestAggregate2) HandleCommand(ctx context.Context, command Command) error {
 	a.dispatchedCommand = command
+	a.context = ctx
 	a.numHandled++
 	switch command := command.(type) {
 	case *TestCommand2:

--- a/eventstore.go
+++ b/eventstore.go
@@ -14,7 +14,10 @@
 
 package eventhorizon
 
-import "errors"
+import (
+	"context"
+	"errors"
+)
 
 // ErrNoEventsToAppend is when no events are available to append.
 var ErrNoEventsToAppend = errors.New("no events to append")
@@ -28,8 +31,8 @@ var ErrIncorrectEventVersion = errors.New("mismatching event version")
 // EventStore is an interface for an event sourcing event store.
 type EventStore interface {
 	// Save appends all events in the event stream to the store.
-	Save(events []Event, originalVersion int) error
+	Save(ctx context.Context, events []Event, originalVersion int) error
 
 	// Load loads all events for the aggregate id from the store.
-	Load(AggregateType, UUID) ([]Event, error)
+	Load(context.Context, AggregateType, UUID) ([]Event, error)
 }

--- a/eventstore/dynamodb/eventstore.go
+++ b/eventstore/dynamodb/eventstore.go
@@ -15,6 +15,7 @@
 package dynamodb
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"reflect"
@@ -85,7 +86,7 @@ func NewEventStore(config *EventStoreConfig) (*EventStore, error) {
 }
 
 // Save appends all events in the event stream to the database.
-func (s *EventStore) Save(events []eh.Event, originalVersion int) error {
+func (s *EventStore) Save(ctx context.Context, events []eh.Event, originalVersion int) error {
 	if len(events) == 0 {
 		return eh.ErrNoEventsToAppend
 	}
@@ -153,7 +154,7 @@ func (s *EventStore) Save(events []eh.Event, originalVersion int) error {
 
 // Load loads all events for the aggregate id from the database.
 // Returns ErrNoEventsFound if no events can be found.
-func (s *EventStore) Load(aggregateType eh.AggregateType, id eh.UUID) ([]eh.Event, error) {
+func (s *EventStore) Load(ctx context.Context, aggregateType eh.AggregateType, id eh.UUID) ([]eh.Event, error) {
 	params := &dynamodb.QueryInput{
 		TableName:              aws.String(s.config.Table),
 		KeyConditionExpression: aws.String("AggregateID = :id"),

--- a/eventstore/memory/eventstore.go
+++ b/eventstore/memory/eventstore.go
@@ -15,6 +15,7 @@
 package memory
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"sync"
@@ -41,7 +42,7 @@ func NewEventStore() *EventStore {
 }
 
 // Save appends all events in the event stream to the memory store.
-func (s *EventStore) Save(events []eh.Event, originalVersion int) error {
+func (s *EventStore) Save(ctx context.Context, events []eh.Event, originalVersion int) error {
 	if len(events) == 0 {
 		return eh.ErrNoEventsToAppend
 	}
@@ -108,7 +109,7 @@ func (s *EventStore) Save(events []eh.Event, originalVersion int) error {
 
 // Load loads all events for the aggregate id from the memory store.
 // Returns ErrNoEventsFound if no events can be found.
-func (s *EventStore) Load(aggregateType eh.AggregateType, id eh.UUID) ([]eh.Event, error) {
+func (s *EventStore) Load(ctx context.Context, aggregateType eh.AggregateType, id eh.UUID) ([]eh.Event, error) {
 	s.aggregateRecordsMu.RLock()
 	defer s.aggregateRecordsMu.RUnlock()
 

--- a/eventstore/mongodb/eventstore.go
+++ b/eventstore/mongodb/eventstore.go
@@ -15,6 +15,7 @@
 package mongodb
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"time"
@@ -80,7 +81,7 @@ func NewEventStoreWithSession(session *mgo.Session, database string) (*EventStor
 }
 
 // Save appends all events in the event stream to the database.
-func (s *EventStore) Save(events []eh.Event, originalVersion int) error {
+func (s *EventStore) Save(ctx context.Context, events []eh.Event, originalVersion int) error {
 	if len(events) == 0 {
 		return eh.ErrNoEventsToAppend
 	}
@@ -159,7 +160,7 @@ func (s *EventStore) Save(events []eh.Event, originalVersion int) error {
 
 // Load loads all events for the aggregate id from the database.
 // Returns ErrNoEventsFound if no events can be found.
-func (s *EventStore) Load(aggregateType eh.AggregateType, id eh.UUID) ([]eh.Event, error) {
+func (s *EventStore) Load(ctx context.Context, aggregateType eh.AggregateType, id eh.UUID) ([]eh.Event, error) {
 	sess := s.session.Copy()
 	defer sess.Close()
 

--- a/eventstore/testutil/common_tests.go
+++ b/eventstore/testutil/common_tests.go
@@ -15,6 +15,7 @@
 package testutil
 
 import (
+	"context"
 	"strings"
 	"testing"
 
@@ -27,8 +28,10 @@ import (
 func EventStoreCommonTests(t *testing.T, store eh.EventStore) []eh.Event {
 	savedEvents := []eh.Event{}
 
+	ctx := context.Background()
+
 	t.Log("save no events")
-	err := store.Save([]eh.Event{}, 0)
+	err := store.Save(ctx, []eh.Event{}, 0)
 	if err != eh.ErrNoEventsToAppend {
 		t.Error("there shoud be a ErrNoEventsToAppend error:", err)
 	}
@@ -38,14 +41,14 @@ func EventStoreCommonTests(t *testing.T, store eh.EventStore) []eh.Event {
 	agg := mocks.NewAggregate(id)
 	event1 := agg.NewEvent(mocks.EventType, &mocks.EventData{"event1"})
 	agg.ApplyEvent(event1) // Apply event to increment the aggregate version.
-	err = store.Save([]eh.Event{event1}, 0)
+	err = store.Save(ctx, []eh.Event{event1}, 0)
 	if err != nil {
 		t.Error("there should be no error:", err)
 	}
 	savedEvents = append(savedEvents, event1)
 
 	t.Log("try to save same event twice")
-	err = store.Save([]eh.Event{event1}, 1)
+	err = store.Save(ctx, []eh.Event{event1}, 1)
 	if err != eh.ErrIncorrectEventVersion {
 		t.Error("there should be a ErrIncerrectEventVersion error:", err)
 	}
@@ -53,7 +56,7 @@ func EventStoreCommonTests(t *testing.T, store eh.EventStore) []eh.Event {
 	t.Log("save event, version 2")
 	event2 := agg.NewEvent(mocks.EventType, &mocks.EventData{"event2"})
 	agg.ApplyEvent(event2) // Apply event to increment the aggregate version.
-	err = store.Save([]eh.Event{event2}, 1)
+	err = store.Save(ctx, []eh.Event{event2}, 1)
 	if err != nil {
 		t.Error("there should be no error:", err)
 	}
@@ -62,7 +65,7 @@ func EventStoreCommonTests(t *testing.T, store eh.EventStore) []eh.Event {
 	t.Log("save event without data, version 3")
 	event3 := agg.NewEvent(mocks.EventOtherType, nil)
 	agg.ApplyEvent(event3) // Apply event to increment the aggregate version.
-	err = store.Save([]eh.Event{event3}, 2)
+	err = store.Save(ctx, []eh.Event{event3}, 2)
 	if err != nil {
 		t.Error("there should be no error:", err)
 	}
@@ -75,7 +78,7 @@ func EventStoreCommonTests(t *testing.T, store eh.EventStore) []eh.Event {
 	agg.ApplyEvent(event5) // Apply event to increment the aggregate version.
 	event6 := agg.NewEvent(mocks.EventOtherType, nil)
 	agg.ApplyEvent(event6) // Apply event to increment the aggregate version.
-	err = store.Save([]eh.Event{event4, event5, event6}, 3)
+	err = store.Save(ctx, []eh.Event{event4, event5, event6}, 3)
 	if err != nil {
 		t.Error("there should be no error:", err)
 	}
@@ -86,14 +89,14 @@ func EventStoreCommonTests(t *testing.T, store eh.EventStore) []eh.Event {
 	agg2 := mocks.NewAggregate(id2)
 	event7 := agg2.NewEvent(mocks.EventType, &mocks.EventData{"event7"})
 	agg2.ApplyEvent(event7) // Apply event to increment the aggregate version.
-	err = store.Save([]eh.Event{event7}, 0)
+	err = store.Save(ctx, []eh.Event{event7}, 0)
 	if err != nil {
 		t.Error("there should be no error:", err)
 	}
 	savedEvents = append(savedEvents, event7)
 
 	t.Log("load events for non-existing aggregate")
-	events, err := store.Load(mocks.AggregateType, eh.NewUUID())
+	events, err := store.Load(ctx, mocks.AggregateType, eh.NewUUID())
 	if err != nil {
 		t.Error("there should be no error:", err)
 	}
@@ -102,7 +105,7 @@ func EventStoreCommonTests(t *testing.T, store eh.EventStore) []eh.Event {
 	}
 
 	t.Log("load events")
-	events, err = store.Load(mocks.AggregateType, id)
+	events, err = store.Load(ctx, mocks.AggregateType, id)
 	if err != nil {
 		t.Error("there should be no error:", err)
 	}
@@ -123,7 +126,7 @@ func EventStoreCommonTests(t *testing.T, store eh.EventStore) []eh.Event {
 	t.Log(events)
 
 	t.Log("load events for another aggregate")
-	events, err = store.Load(mocks.AggregateType, id2)
+	events, err = store.Load(ctx, mocks.AggregateType, id2)
 	if err != nil {
 		t.Error("there should be no error:", err)
 	}

--- a/eventstore/trace/eventstore.go
+++ b/eventstore/trace/eventstore.go
@@ -15,6 +15,7 @@
 package trace
 
 import (
+	"context"
 	"errors"
 	"sync"
 
@@ -42,12 +43,12 @@ func NewEventStore(eventStore eh.EventStore) *EventStore {
 }
 
 // Save appends all events to the base store and trace them if enabled.
-func (s *EventStore) Save(events []eh.Event, originalVersion int) error {
+func (s *EventStore) Save(ctx context.Context, events []eh.Event, originalVersion int) error {
 	if s.eventStore == nil {
 		return ErrNoEventStoreDefined
 	}
 
-	if err := s.eventStore.Save(events, originalVersion); err != nil {
+	if err := s.eventStore.Save(ctx, events, originalVersion); err != nil {
 		return err
 	}
 
@@ -63,9 +64,9 @@ func (s *EventStore) Save(events []eh.Event, originalVersion int) error {
 
 // Load loads all events for the aggregate id from the base store.
 // Returns ErrNoEventStoreDefined if no event store could be found.
-func (s *EventStore) Load(aggregateType eh.AggregateType, id eh.UUID) ([]eh.Event, error) {
+func (s *EventStore) Load(ctx context.Context, aggregateType eh.AggregateType, id eh.UUID) ([]eh.Event, error) {
 	if s.eventStore != nil {
-		return s.eventStore.Load(aggregateType, id)
+		return s.eventStore.Load(ctx, aggregateType, id)
 	}
 
 	return nil, ErrNoEventStoreDefined

--- a/eventstore/trace/eventstore_test.go
+++ b/eventstore/trace/eventstore_test.go
@@ -15,6 +15,7 @@
 package trace
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -57,6 +58,8 @@ func TestEventStore(t *testing.T) {
 		}
 	}
 
+	ctx := context.Background()
+
 	t.Log("save event, version 7")
 	agg := mocks.NewAggregate(event1.AggregateID())
 	for _, e := range aggregate1events {
@@ -64,7 +67,7 @@ func TestEventStore(t *testing.T) {
 	}
 	event7 := agg.NewEvent(mocks.EventType, &mocks.EventData{"event1"})
 	agg.ApplyEvent(event7) // Apply event to increment the aggregate version.
-	err := store.Save([]eh.Event{event7}, 6)
+	err := store.Save(ctx, []eh.Event{event7}, 6)
 	if err != nil {
 		t.Error("there should be no error:", err)
 	}
@@ -75,7 +78,7 @@ func TestEventStore(t *testing.T) {
 	aggregate1events = append(aggregate1events, event1)
 
 	t.Log("load events without tracing")
-	events, err := store.Load(event1.AggregateType(), event1.AggregateID())
+	events, err := store.Load(ctx, event1.AggregateType(), event1.AggregateID())
 	if err != nil {
 		t.Error("there should be no error:", err)
 	}

--- a/eventstore/trace/eventstore_test.go
+++ b/eventstore/trace/eventstore_test.go
@@ -63,10 +63,10 @@ func TestEventStore(t *testing.T) {
 	t.Log("save event, version 7")
 	agg := mocks.NewAggregate(event1.AggregateID())
 	for _, e := range aggregate1events {
-		agg.ApplyEvent(e)
+		agg.ApplyEvent(ctx, e)
 	}
 	event7 := agg.NewEvent(mocks.EventType, &mocks.EventData{"event1"})
-	agg.ApplyEvent(event7) // Apply event to increment the aggregate version.
+	agg.ApplyEvent(ctx, event7) // Apply event to increment the aggregate version.
 	err := store.Save(ctx, []eh.Event{event7}, 6)
 	if err != nil {
 		t.Error("there should be no error:", err)

--- a/examples/domain/aggregate.go
+++ b/examples/domain/aggregate.go
@@ -15,6 +15,7 @@
 package domain
 
 import (
+	"context"
 	"fmt"
 	"log"
 
@@ -56,7 +57,7 @@ func NewInvitationAggregate(id eh.UUID) *InvitationAggregate {
 }
 
 // HandleCommand implements the HandleCommand method of the Aggregate interface.
-func (a *InvitationAggregate) HandleCommand(command eh.Command) error {
+func (a *InvitationAggregate) HandleCommand(ctx context.Context, command eh.Command) error {
 	switch command := command.(type) {
 	case *CreateInvite:
 		a.StoreEvent(a.NewEvent(InviteCreatedEvent,

--- a/examples/domain/aggregate.go
+++ b/examples/domain/aggregate.go
@@ -128,7 +128,7 @@ func (a *InvitationAggregate) HandleCommand(ctx context.Context, command eh.Comm
 }
 
 // ApplyEvent implements the ApplyEvent method of the Aggregate interface.
-func (a *InvitationAggregate) ApplyEvent(event eh.Event) {
+func (a *InvitationAggregate) ApplyEvent(ctx context.Context, event eh.Event) {
 	defer a.IncrementVersion()
 
 	switch event.EventType() {

--- a/examples/domain/logger.go
+++ b/examples/domain/logger.go
@@ -15,6 +15,7 @@
 package domain
 
 import (
+	"context"
 	"log"
 
 	eh "github.com/looplab/eventhorizon"
@@ -24,6 +25,6 @@ import (
 type Logger struct{}
 
 // Notify implements the HandleEvent method of the EventHandler interface.
-func (l *Logger) Notify(event eh.Event) {
+func (l *Logger) Notify(ctx context.Context, event eh.Event) {
 	log.Println("event:", event)
 }

--- a/examples/domain/projectors.go
+++ b/examples/domain/projectors.go
@@ -49,7 +49,7 @@ func (p *InvitationProjector) HandlerType() eh.EventHandlerType {
 }
 
 // HandleEvent implements the HandleEvent method of the EventHandler interface.
-func (p *InvitationProjector) HandleEvent(event eh.Event) {
+func (p *InvitationProjector) HandleEvent(ctx context.Context, event eh.Event) {
 	// Load or create the model.
 	var i *Invitation
 	if m, _ := p.repository.Find(context.Background(), event.AggregateID()); m != nil {
@@ -128,7 +128,7 @@ func (p *GuestListProjector) HandlerType() eh.EventHandlerType {
 }
 
 // HandleEvent implements the HandleEvent method of the EventHandler interface.
-func (p *GuestListProjector) HandleEvent(event eh.Event) {
+func (p *GuestListProjector) HandleEvent(ctx context.Context, event eh.Event) {
 	// NOTE: Temp fix because we need to count the guests atomically.
 	p.repositoryMu.Lock()
 	defer p.repositoryMu.Unlock()

--- a/examples/domain/saga.go
+++ b/examples/domain/saga.go
@@ -15,6 +15,7 @@
 package domain
 
 import (
+	"context"
 	"sync"
 
 	eh "github.com/looplab/eventhorizon"
@@ -26,22 +27,17 @@ const ResponseSagaType eh.SagaType = "ResponseSaga"
 // ResponseSaga is a saga that confirmes all accepted invites until a guest
 // limit has been reached.
 type ResponseSaga struct {
-	*eh.SagaBase
-
 	acceptedGuests   map[eh.UUID]bool
 	acceptedGuestsMu sync.RWMutex
 	guestLimit       int
 }
 
 // NewResponseSaga returns a new ResponseSage with a guest limit.
-func NewResponseSaga(commandBus eh.CommandBus, guestLimit int) *ResponseSaga {
-	s := &ResponseSaga{
+func NewResponseSaga(guestLimit int) *ResponseSaga {
+	return &ResponseSaga{
 		acceptedGuests: map[eh.UUID]bool{},
 		guestLimit:     guestLimit,
 	}
-	s.SagaBase = eh.NewSagaBase(commandBus, s)
-
-	return s
 }
 
 // SagaType implements the SagaType method of the Saga interface.
@@ -50,7 +46,7 @@ func (s *ResponseSaga) SagaType() eh.SagaType {
 }
 
 // RunSaga implements the Run saga method of the Saga interface.
-func (s *ResponseSaga) RunSaga(event eh.Event) []eh.Command {
+func (s *ResponseSaga) RunSaga(ctx context.Context, event eh.Event) []eh.Command {
 	switch event.EventType() {
 	case InviteAcceptedEvent:
 		// Do nothing for already accepted guests.

--- a/examples/mongodb/mongodb_test.go
+++ b/examples/mongodb/mongodb_test.go
@@ -109,7 +109,7 @@ func Example() {
 
 	// Setup the saga that responds to the accepted guests and limits the total
 	// amount of guests, responding with a confirmation or denial.
-	responseSaga := domain.NewResponseSaga(commandBus, 2)
+	responseSaga := eh.NewSagaHandler(domain.NewResponseSaga(2), commandBus)
 	eventBus.AddHandler(responseSaga, domain.InviteAcceptedEvent)
 
 	// Clear DB collections.

--- a/examples/simple/simple_test.go
+++ b/examples/simple/simple_test.go
@@ -88,7 +88,7 @@ func Example() {
 
 	// Setup the saga that responds to the accepted guests and limits the total
 	// amount of guests, responding with a confirmation or denial.
-	responseSaga := domain.NewResponseSaga(commandBus, 2)
+	responseSaga := eh.NewSagaHandler(domain.NewResponseSaga(2), commandBus)
 	eventBus.AddHandler(responseSaga, domain.InviteAcceptedEvent)
 
 	// IDs for all the guests.

--- a/examples/simple/simple_test.go
+++ b/examples/simple/simple_test.go
@@ -97,34 +97,36 @@ func Example() {
 	zeusID := eh.NewUUID()
 	poseidonID := eh.NewUUID()
 
+	ctx := context.Background()
+
 	// Issue some invitations and responses. Error checking omitted here.
-	commandBus.HandleCommand(&domain.CreateInvite{InvitationID: athenaID, Name: "Athena", Age: 42})
-	commandBus.HandleCommand(&domain.CreateInvite{InvitationID: hadesID, Name: "Hades"})
-	commandBus.HandleCommand(&domain.CreateInvite{InvitationID: zeusID, Name: "Zeus"})
-	commandBus.HandleCommand(&domain.CreateInvite{InvitationID: poseidonID, Name: "Poseidon"})
+	commandBus.HandleCommand(ctx, &domain.CreateInvite{InvitationID: athenaID, Name: "Athena", Age: 42})
+	commandBus.HandleCommand(ctx, &domain.CreateInvite{InvitationID: hadesID, Name: "Hades"})
+	commandBus.HandleCommand(ctx, &domain.CreateInvite{InvitationID: zeusID, Name: "Zeus"})
+	commandBus.HandleCommand(ctx, &domain.CreateInvite{InvitationID: poseidonID, Name: "Poseidon"})
 
 	// The invited guests accept and decline the event.
 	// Note that Athena tries to decline the event after first accepting, but
 	// that is not allowed by the domain logic in InvitationAggregate. The
 	// result is that she is still accepted.
-	commandBus.HandleCommand(&domain.AcceptInvite{InvitationID: athenaID})
-	err = commandBus.HandleCommand(&domain.DeclineInvite{InvitationID: athenaID})
+	commandBus.HandleCommand(ctx, &domain.AcceptInvite{InvitationID: athenaID})
+	err = commandBus.HandleCommand(ctx, &domain.DeclineInvite{InvitationID: athenaID})
 	if err != nil {
 		log.Printf("error: %s\n", err)
 	}
-	commandBus.HandleCommand(&domain.AcceptInvite{InvitationID: hadesID})
-	commandBus.HandleCommand(&domain.DeclineInvite{InvitationID: zeusID})
+	commandBus.HandleCommand(ctx, &domain.AcceptInvite{InvitationID: hadesID})
+	commandBus.HandleCommand(ctx, &domain.DeclineInvite{InvitationID: zeusID})
 
 	// Poseidon is a bit late to the party...
 	time.Sleep(10 * time.Millisecond)
-	commandBus.HandleCommand(&domain.AcceptInvite{InvitationID: poseidonID})
+	commandBus.HandleCommand(ctx, &domain.AcceptInvite{InvitationID: poseidonID})
 
 	// Wait for simulated eventual consistency before reading.
 	time.Sleep(10 * time.Millisecond)
 
 	// Read all invites.
 	invitationStrs := []string{}
-	invitations, _ := invitationRepository.FindAll(context.Background())
+	invitations, _ := invitationRepository.FindAll(ctx)
 	for _, i := range invitations {
 		if i, ok := i.(*domain.Invitation); ok {
 			invitationStrs = append(invitationStrs, fmt.Sprintf("%s - %s", i.Name, i.Status))
@@ -139,7 +141,7 @@ func Example() {
 	}
 
 	// Read the guest list.
-	l, _ := guestListRepository.Find(context.Background(), eventID)
+	l, _ := guestListRepository.Find(ctx, eventID)
 	if l, ok := l.(*domain.GuestList); ok {
 		log.Printf("guest list: %d invited - %d accepted, %d declined - %d confirmed, %d denied\n",
 			l.NumGuests, l.NumAccepted, l.NumDeclined, l.NumConfirmed, l.NumDenied)

--- a/mocks/mocks.go
+++ b/mocks/mocks.go
@@ -292,8 +292,10 @@ func (m *CommandBus) HandleCommand(ctx context.Context, command eh.Command) {
 	m.Context = ctx
 }
 
-// AddHandler implements the AddHandler method of the eventhorizon.CommandBus interface.
-func (m *CommandBus) AddHandler(handler eh.CommandHandler, event eh.Command) {}
+// SetHandler implements the SetHandler method of the eventhorizon.CommandBus interface.
+func (m *CommandBus) SetHandler(handler eh.CommandHandler, commandType eh.CommandType) error {
+	return nil
+}
 
 // EventBus is a mocked eventhorizon.EventBus, useful in testing.
 type EventBus struct {

--- a/mocks/mocks.go
+++ b/mocks/mocks.go
@@ -56,6 +56,7 @@ type Aggregate struct {
 	*eh.AggregateBase
 	Commands []eh.Command
 	Events   []eh.Event
+	Context  context.Context
 	// Used to simulate errors in HandleCommand.
 	Err error
 }
@@ -70,11 +71,12 @@ func NewAggregate(id eh.UUID) *Aggregate {
 }
 
 // HandleCommand implements the HandleCommand method of the eventhorizon.Aggregate interface.
-func (a *Aggregate) HandleCommand(command eh.Command) error {
+func (a *Aggregate) HandleCommand(ctx context.Context, command eh.Command) error {
 	if a.Err != nil {
 		return a.Err
 	}
 	a.Commands = append(a.Commands, command)
+	a.Context = ctx
 	return nil
 }
 
@@ -142,11 +144,13 @@ type SimpleModel struct {
 // CommandHandler is a mocked eventhorizon.CommandHandler, useful in testing.
 type CommandHandler struct {
 	Command eh.Command
+	Context context.Context
 }
 
 // HandleCommand implements the HandleCommand method of the eventhorizon.CommandHandler interface.
-func (t *CommandHandler) HandleCommand(command eh.Command) error {
+func (t *CommandHandler) HandleCommand(ctx context.Context, command eh.Command) error {
 	t.Command = command
+	t.Context = ctx
 	return nil
 }
 
@@ -266,11 +270,13 @@ func (m *EventStore) Load(aggregateType eh.AggregateType, id eh.UUID) ([]eh.Even
 // CommandBus is a mocked eventhorizon.CommandBus, useful in testing.
 type CommandBus struct {
 	Commands []eh.Command
+	Context  context.Context
 }
 
 // HandleCommand implements the HandleCommand method of the eventhorizon.CommandBus interface.
-func (m *CommandBus) HandleCommand(event eh.Command) {
-	m.Commands = append(m.Commands, event)
+func (m *CommandBus) HandleCommand(ctx context.Context, command eh.Command) {
+	m.Commands = append(m.Commands, command)
+	m.Context = ctx
 }
 
 // AddHandler implements the AddHandler method of the eventhorizon.CommandBus interface.

--- a/mocks/mocks.go
+++ b/mocks/mocks.go
@@ -244,29 +244,32 @@ func (m *Repository) Save(ctx context.Context, aggregate eh.Aggregate) error {
 
 // EventStore is a mocked eventhorizon.EventStore, useful in testing.
 type EventStore struct {
-	Events []eh.Event
-	Loaded eh.UUID
+	Events  []eh.Event
+	Loaded  eh.UUID
+	Context context.Context
 	// Used to simulate errors in the store.
 	Err error
 }
 
 // Save implements the Save method of the eventhorizon.EventStore interface.
-func (m *EventStore) Save(events []eh.Event, originalVersion int) error {
+func (m *EventStore) Save(ctx context.Context, events []eh.Event, originalVersion int) error {
 	if m.Err != nil {
 		return m.Err
 	}
 	for _, event := range events {
 		m.Events = append(m.Events, event)
 	}
+	m.Context = ctx
 	return nil
 }
 
 // Load implements the Load method of the eventhorizon.EventStore interface.
-func (m *EventStore) Load(aggregateType eh.AggregateType, id eh.UUID) ([]eh.Event, error) {
+func (m *EventStore) Load(ctx context.Context, aggregateType eh.AggregateType, id eh.UUID) ([]eh.Event, error) {
 	if m.Err != nil {
 		return nil, m.Err
 	}
 	m.Loaded = id
+	m.Context = ctx
 	return m.Events, nil
 }
 

--- a/mocks/mocks.go
+++ b/mocks/mocks.go
@@ -226,15 +226,18 @@ func (m *EventObserver) WaitForEvent(t *testing.T) {
 // Repository is a mocked Repository, useful in testing.
 type Repository struct {
 	Aggregates map[eh.UUID]eh.Aggregate
+	Context    context.Context
 }
 
 // Load implements the Load method of the eventhorizon.Repository interface.
-func (m *Repository) Load(aggregateType eh.AggregateType, id eh.UUID) (eh.Aggregate, error) {
+func (m *Repository) Load(ctx context.Context, aggregateType eh.AggregateType, id eh.UUID) (eh.Aggregate, error) {
+	m.Context = ctx
 	return m.Aggregates[id], nil
 }
 
 // Save implements the Save method of the eventhorizon.Repository interface.
-func (m *Repository) Save(aggregate eh.Aggregate) error {
+func (m *Repository) Save(ctx context.Context, aggregate eh.Aggregate) error {
+	m.Context = ctx
 	m.Aggregates[aggregate.AggregateID()] = aggregate
 	return nil
 }

--- a/mocks/mocks.go
+++ b/mocks/mocks.go
@@ -81,10 +81,11 @@ func (a *Aggregate) HandleCommand(ctx context.Context, command eh.Command) error
 }
 
 // ApplyEvent implements the ApplyEvent method of the eventhorizon.Aggregate interface.
-func (a *Aggregate) ApplyEvent(event eh.Event) {
+func (a *Aggregate) ApplyEvent(ctx context.Context, event eh.Event) {
 	defer a.IncrementVersion()
 
 	a.Events = append(a.Events, event)
+	a.Context = ctx
 }
 
 // EventData is a mocked event data, useful in testing.

--- a/readrepository/memory/readrepository.go
+++ b/readrepository/memory/readrepository.go
@@ -119,12 +119,13 @@ func (r *ReadRepository) indexOfModel(model interface{}) int {
 
 // Repository returns a parent ReadRepository if there is one.
 func Repository(repo eh.ReadRepository) *ReadRepository {
+	if repo == nil {
+		return nil
+	}
+
 	if r, ok := repo.(*ReadRepository); ok {
 		return r
 	}
-	parent := repo.Parent()
-	if parent == nil {
-		return nil
-	}
-	return Repository(parent)
+
+	return Repository(repo.Parent())
 }

--- a/readrepository/memory/readrepository_test.go
+++ b/readrepository/memory/readrepository_test.go
@@ -35,6 +35,10 @@ func TestReadRepository(t *testing.T) {
 }
 
 func TestRepository(t *testing.T) {
+	if r := Repository(nil); r != nil {
+		t.Error("the parent repository should be nil:", r)
+	}
+
 	inner := &mocks.ReadRepository{}
 	if r := Repository(inner); r != nil {
 		t.Error("the parent repository should be nil:", r)

--- a/readrepository/mongodb/readrepository.go
+++ b/readrepository/mongodb/readrepository.go
@@ -204,12 +204,13 @@ func (r *ReadRepository) Close() {
 
 // Repository returns a parent ReadRepository if there is one.
 func Repository(repo eh.ReadRepository) *ReadRepository {
+	if repo == nil {
+		return nil
+	}
+
 	if r, ok := repo.(*ReadRepository); ok {
 		return r
 	}
-	parent := repo.Parent()
-	if parent == nil {
-		return nil
-	}
-	return Repository(parent)
+
+	return Repository(repo.Parent())
 }

--- a/readrepository/mongodb/readrepository_test.go
+++ b/readrepository/mongodb/readrepository_test.go
@@ -121,6 +121,10 @@ func TestReadRepository(t *testing.T) {
 }
 
 func TestRepository(t *testing.T) {
+	if r := Repository(nil); r != nil {
+		t.Error("the parent repository should be nil:", r)
+	}
+
 	inner := &mocks.ReadRepository{}
 	if r := Repository(inner); r != nil {
 		t.Error("the parent repository should be nil:", r)

--- a/readrepository/mongodb/readrepository_test.go
+++ b/readrepository/mongodb/readrepository_test.go
@@ -126,10 +126,21 @@ func TestRepository(t *testing.T) {
 		t.Error("the parent repository should be nil:", r)
 	}
 
-	repo, err := NewReadRepository("", "", "")
+	// Support Wercker testing with MongoDB.
+	host := os.Getenv("MONGO_PORT_27017_TCP_ADDR")
+	port := os.Getenv("MONGO_PORT_27017_TCP_PORT")
+
+	url := "localhost"
+	if host != "" && port != "" {
+		url = host + ":" + port
+	}
+
+	repo, err := NewReadRepository(url, "test", "mocks.Model")
 	if err != nil {
 		t.Error("there should be no error:", err)
 	}
+	defer repo.Close()
+
 	outer := &mocks.ReadRepository{ParentRepo: repo}
 	if r := Repository(outer); r != repo {
 		t.Error("the parent repository should be correct:", r)

--- a/readrepository/version/readrepository.go
+++ b/readrepository/version/readrepository.go
@@ -146,12 +146,13 @@ func WithMinVersion(ctx context.Context, minVersion int) context.Context {
 
 // Repository returns a parent ReadRepository if there is one.
 func Repository(repo eh.ReadRepository) *ReadRepository {
+	if repo == nil {
+		return nil
+	}
+
 	if r, ok := repo.(*ReadRepository); ok {
 		return r
 	}
-	parent := repo.Parent()
-	if parent == nil {
-		return nil
-	}
-	return Repository(parent)
+
+	return Repository(repo.Parent())
 }

--- a/readrepository/version/readrepository_test.go
+++ b/readrepository/version/readrepository_test.go
@@ -193,6 +193,10 @@ func TestContextMinVersion(t *testing.T) {
 }
 
 func TestRepository(t *testing.T) {
+	if r := Repository(nil); r != nil {
+		t.Error("the parent repository should be nil:", r)
+	}
+
 	inner := &mocks.ReadRepository{}
 	if r := Repository(inner); r != nil {
 		t.Error("the parent repository should be nil:", r)

--- a/repository.go
+++ b/repository.go
@@ -114,7 +114,7 @@ func (r *EventSourcingRepository) Save(ctx context.Context, aggregate Aggregate)
 
 	// Publish all events on the bus.
 	for _, event := range uncommittedEvents {
-		r.eventBus.PublishEvent(event)
+		r.eventBus.PublishEvent(ctx, event)
 	}
 
 	aggregate.ClearUncommittedEvents()

--- a/repository.go
+++ b/repository.go
@@ -15,6 +15,7 @@
 package eventhorizon
 
 import (
+	"context"
 	"errors"
 )
 
@@ -30,10 +31,10 @@ var ErrMismatchedEventType = errors.New("mismatched event type and aggregate typ
 // Repository is a repository responsible for loading and saving aggregates.
 type Repository interface {
 	// Load loads the most recent version of an aggregate with a type and id.
-	Load(AggregateType, UUID) (Aggregate, error)
+	Load(context.Context, AggregateType, UUID) (Aggregate, error)
 
 	// Save saves the uncommittend events for an aggregate.
-	Save(Aggregate) error
+	Save(context.Context, Aggregate) error
 }
 
 // EventSourcingRepository is an aggregate repository using event sourcing. It
@@ -64,7 +65,7 @@ func NewEventSourcingRepository(eventStore EventStore, eventBus EventBus) (*Even
 // Load loads an aggregate from the event store. It does so by creating a new
 // aggregate of the type with the ID and then applies all events to it, thus
 // making it the most current version of the aggregate.
-func (r *EventSourcingRepository) Load(aggregateType AggregateType, id UUID) (Aggregate, error) {
+func (r *EventSourcingRepository) Load(ctx context.Context, aggregateType AggregateType, id UUID) (Aggregate, error) {
 	// Create the aggregate.
 	aggregate, err := CreateAggregate(aggregateType, id)
 	if err != nil {
@@ -90,7 +91,7 @@ func (r *EventSourcingRepository) Load(aggregateType AggregateType, id UUID) (Ag
 }
 
 // Save saves all uncommitted events from an aggregate to the event store.
-func (r *EventSourcingRepository) Save(aggregate Aggregate) error {
+func (r *EventSourcingRepository) Save(ctx context.Context, aggregate Aggregate) error {
 	uncommittedEvents := aggregate.UncommittedEvents()
 	if len(uncommittedEvents) < 1 {
 		return nil

--- a/repository.go
+++ b/repository.go
@@ -73,7 +73,7 @@ func (r *EventSourcingRepository) Load(ctx context.Context, aggregateType Aggreg
 	}
 
 	// Load aggregate events.
-	events, err := r.eventStore.Load(aggregate.AggregateType(), aggregate.AggregateID())
+	events, err := r.eventStore.Load(ctx, aggregate.AggregateType(), aggregate.AggregateID())
 	if err != nil {
 		return nil, err
 	}
@@ -98,7 +98,7 @@ func (r *EventSourcingRepository) Save(ctx context.Context, aggregate Aggregate)
 	}
 
 	// Store events, check for error after publishing on the bus.
-	if err := r.eventStore.Save(uncommittedEvents, aggregate.Version()); err != nil {
+	if err := r.eventStore.Save(ctx, uncommittedEvents, aggregate.Version()); err != nil {
 		return err
 	}
 

--- a/repository.go
+++ b/repository.go
@@ -84,7 +84,7 @@ func (r *EventSourcingRepository) Load(ctx context.Context, aggregateType Aggreg
 			return nil, ErrMismatchedEventType
 		}
 
-		aggregate.ApplyEvent(event)
+		aggregate.ApplyEvent(ctx, event)
 	}
 
 	return aggregate, nil
@@ -109,7 +109,7 @@ func (r *EventSourcingRepository) Save(ctx context.Context, aggregate Aggregate)
 			return ErrMismatchedEventType
 		}
 
-		aggregate.ApplyEvent(event)
+		aggregate.ApplyEvent(ctx, event)
 	}
 
 	// Publish all events on the bus.

--- a/repository_test.go
+++ b/repository_test.go
@@ -80,7 +80,7 @@ func TestEventSourcingRepositoryLoadEvents(t *testing.T) {
 	id := NewUUID()
 	agg := NewTestAggregate(id)
 	event1 := agg.NewEvent(TestEventType, &TestEventData{"event1"})
-	store.Save([]Event{event1}, 0)
+	store.Save(ctx, []Event{event1}, 0)
 	t.Log(store.Events)
 	loadedAgg, err := repo.Load(ctx, TestAggregateType, id)
 	if err != nil {
@@ -110,12 +110,12 @@ func TestEventSourcingRepositoryLoadEventsMismatchedEventType(t *testing.T) {
 	id := NewUUID()
 	agg := NewTestAggregate(id)
 	event1 := agg.NewEvent(TestEventType, &TestEventData{"event"})
-	store.Save([]Event{event1}, 0)
+	store.Save(ctx, []Event{event1}, 0)
 
 	otherAggregateID := NewUUID()
 	otherAgg := NewTestAggregate2(otherAggregateID)
 	event2 := otherAgg.NewEvent(TestEvent2Type, &TestEvent2Data{"event2"})
-	store.Save([]Event{event2}, 0)
+	store.Save(ctx, []Event{event2}, 0)
 
 	loadedAgg, err := repo.Load(ctx, TestAggregateType, otherAggregateID)
 	if err != ErrMismatchedEventType {
@@ -140,7 +140,7 @@ func TestEventSourcingRepositorySaveEvents(t *testing.T) {
 		t.Error("there should be no error:", err)
 	}
 
-	events, err := store.Load(TestAggregateType, id)
+	events, err := store.Load(ctx, TestAggregateType, id)
 	if err != nil {
 		t.Error("there should be no error:", err)
 	}

--- a/repository_test.go
+++ b/repository_test.go
@@ -15,6 +15,7 @@
 package eventhorizon
 
 import (
+	"context"
 	"errors"
 	"reflect"
 	"testing"
@@ -56,8 +57,10 @@ func TestNewEventSourcingRepository(t *testing.T) {
 func TestEventSourcingRepositoryLoadNoEvents(t *testing.T) {
 	repo, _, _ := createRepoAndStore(t)
 
+	ctx := context.Background()
+
 	id := NewUUID()
-	agg, err := repo.Load(TestAggregateType, id)
+	agg, err := repo.Load(ctx, TestAggregateType, id)
 	if err != nil {
 		t.Fatal("there should be no error:", err)
 	}
@@ -72,12 +75,14 @@ func TestEventSourcingRepositoryLoadNoEvents(t *testing.T) {
 func TestEventSourcingRepositoryLoadEvents(t *testing.T) {
 	repo, store, _ := createRepoAndStore(t)
 
+	ctx := context.Background()
+
 	id := NewUUID()
 	agg := NewTestAggregate(id)
 	event1 := agg.NewEvent(TestEventType, &TestEventData{"event1"})
 	store.Save([]Event{event1}, 0)
 	t.Log(store.Events)
-	loadedAgg, err := repo.Load(TestAggregateType, id)
+	loadedAgg, err := repo.Load(ctx, TestAggregateType, id)
 	if err != nil {
 		t.Fatal("there should be no error:", err)
 	}
@@ -92,13 +97,15 @@ func TestEventSourcingRepositoryLoadEvents(t *testing.T) {
 	}
 
 	store.err = errors.New("error")
-	if _, err = repo.Load(TestAggregateType, id); err == nil || err.Error() != "error" {
+	if _, err = repo.Load(ctx, TestAggregateType, id); err == nil || err.Error() != "error" {
 		t.Error("there should be an error named 'error':", err)
 	}
 }
 
 func TestEventSourcingRepositoryLoadEventsMismatchedEventType(t *testing.T) {
 	repo, store, _ := createRepoAndStore(t)
+
+	ctx := context.Background()
 
 	id := NewUUID()
 	agg := NewTestAggregate(id)
@@ -110,7 +117,7 @@ func TestEventSourcingRepositoryLoadEventsMismatchedEventType(t *testing.T) {
 	event2 := otherAgg.NewEvent(TestEvent2Type, &TestEvent2Data{"event2"})
 	store.Save([]Event{event2}, 0)
 
-	loadedAgg, err := repo.Load(TestAggregateType, otherAggregateID)
+	loadedAgg, err := repo.Load(ctx, TestAggregateType, otherAggregateID)
 	if err != ErrMismatchedEventType {
 		t.Fatal("there should be a ErrMismatchedEventType error:", err)
 	}
@@ -122,11 +129,13 @@ func TestEventSourcingRepositoryLoadEventsMismatchedEventType(t *testing.T) {
 func TestEventSourcingRepositorySaveEvents(t *testing.T) {
 	repo, store, bus := createRepoAndStore(t)
 
+	ctx := context.Background()
+
 	id := NewUUID()
 	agg := NewTestAggregate(id)
 	event1 := agg.NewEvent(TestEventType, &TestEventData{"event"})
 	agg.StoreEvent(event1)
-	err := repo.Save(agg)
+	err := repo.Save(ctx, agg)
 	if err != nil {
 		t.Error("there should be no error:", err)
 	}
@@ -154,7 +163,7 @@ func TestEventSourcingRepositorySaveEvents(t *testing.T) {
 
 	agg.StoreEvent(event1)
 	store.err = errors.New("error")
-	if err = repo.Save(agg); err == nil || err.Error() != "error" {
+	if err = repo.Save(ctx, agg); err == nil || err.Error() != "error" {
 		t.Error("there should be an error named 'error':", err)
 	}
 }
@@ -162,8 +171,10 @@ func TestEventSourcingRepositorySaveEvents(t *testing.T) {
 func TestEventSourcingRepositoryAggregateNotRegistered(t *testing.T) {
 	repo, _, _ := createRepoAndStore(t)
 
+	ctx := context.Background()
+
 	id := NewUUID()
-	agg, err := repo.Load("TestAggregate3", id)
+	agg, err := repo.Load(ctx, "TestAggregate3", id)
 	if err != ErrAggregateNotRegistered {
 		t.Error("there should be a ErrAggregateNotRegistered error:", err)
 	}

--- a/saga.go
+++ b/saga.go
@@ -57,10 +57,7 @@ func NewSagaBase(commandBus CommandBus, saga Saga) *SagaBase {
 }
 
 // HandleEvent implements the HandleEvent method of the EventHandler interface.
-func (s *SagaBase) HandleEvent(event Event) {
-	// TODO: Use contexct from the event.
-	ctx := context.Background()
-
+func (s *SagaBase) HandleEvent(ctx context.Context, event Event) {
 	// Run the saga and collect commands.
 	commands := s.saga.RunSaga(event)
 

--- a/saga.go
+++ b/saga.go
@@ -15,6 +15,7 @@
 package eventhorizon
 
 import (
+	"context"
 	"log"
 )
 
@@ -57,12 +58,15 @@ func NewSagaBase(commandBus CommandBus, saga Saga) *SagaBase {
 
 // HandleEvent implements the HandleEvent method of the EventHandler interface.
 func (s *SagaBase) HandleEvent(event Event) {
+	// TODO: Use contexct from the event.
+	ctx := context.Background()
+
 	// Run the saga and collect commands.
 	commands := s.saga.RunSaga(event)
 
 	// Dispatch commands back on the command bus.
 	for _, command := range commands {
-		if err := s.commandBus.HandleCommand(command); err != nil {
+		if err := s.commandBus.HandleCommand(ctx, command); err != nil {
 			// TODO: Better error handling.
 			log.Println("could not handle command in saga:", err)
 		}

--- a/saga_test.go
+++ b/saga_test.go
@@ -1,0 +1,63 @@
+// Copyright (c) 2016 - Max Ekman <max@looplab.se>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package eventhorizon
+
+import (
+	"context"
+	"reflect"
+	"testing"
+)
+
+func TestSagaHandler(t *testing.T) {
+	commandBus := &MockCommandBus{
+		Commands: []Command{},
+	}
+	saga := &TestSaga{}
+	sagaHandler := NewSagaHandler(saga, commandBus)
+
+	ctx := context.Background()
+
+	id := NewUUID()
+	agg := NewTestAggregate(id)
+	event := agg.NewEvent(TestEventType, &TestEventData{"event1"})
+	saga.commands = []Command{&TestCommand{NewUUID(), "content"}}
+	sagaHandler.HandleEvent(ctx, event)
+	if saga.event != event {
+		t.Error("the handled event should be correct:", saga.event)
+	}
+	if !reflect.DeepEqual(commandBus.Commands, saga.commands) {
+		t.Error("the produced commands should be correct:", commandBus.Commands)
+	}
+}
+
+const (
+	TestSagaType SagaType = "TestSaga"
+)
+
+type TestSaga struct {
+	event    Event
+	context  context.Context
+	commands []Command
+}
+
+func (m *TestSaga) SagaType() SagaType {
+	return TestSagaType
+}
+
+func (m *TestSaga) RunSaga(ctx context.Context, event Event) []Command {
+	m.event = event
+	m.context = ctx
+	return m.commands
+}


### PR DESCRIPTION
This changes most places to get a context as its first parameter. It also adds support for marshalling and unmarshaling contexts for sending over the wire (only used lightly in the redis event bus for now).

Fixes #50.