### PR TITLE
Register marshaler and unmarshaler for the namespace context

### DIFF
--- a/context_test.go
+++ b/context_test.go
@@ -20,16 +20,16 @@ import (
 )
 
 func TestContextMarshaler(t *testing.T) {
-	if len(contextMarshalFuncs) != 0 {
-		t.Error("there should be no context marshalers")
+	if len(contextMarshalFuncs) != 1 {
+		t.Error("there should be one context marshaler")
 	}
 	RegisterContextMarshaler(func(ctx context.Context, vals map[string]interface{}) {
 		if val, ok := ContextTestOne(ctx); ok {
 			vals[contextTestKeyOneStr] = val
 		}
 	})
-	if len(contextMarshalFuncs) != 1 {
-		t.Error("there should be one context marshaler")
+	if len(contextMarshalFuncs) != 2 {
+		t.Error("there should be two context marshaler")
 	}
 
 	ctx := context.Background()
@@ -46,8 +46,8 @@ func TestContextMarshaler(t *testing.T) {
 }
 
 func TestContextUnmarshaler(t *testing.T) {
-	if len(contextUnmarshalFuncs) != 0 {
-		t.Error("there should be no context marshalers")
+	if len(contextUnmarshalFuncs) != 1 {
+		t.Error("there should be one context marshaler")
 	}
 	RegisterContextUnmarshaler(func(ctx context.Context, vals map[string]interface{}) context.Context {
 		if val, ok := vals[contextTestKeyOneStr].(string); ok {
@@ -55,8 +55,8 @@ func TestContextUnmarshaler(t *testing.T) {
 		}
 		return ctx
 	})
-	if len(contextUnmarshalFuncs) != 1 {
-		t.Error("there should be one context unmarshalers")
+	if len(contextUnmarshalFuncs) != 2 {
+		t.Error("there should be two context unmarshalers")
 	}
 
 	vals := map[string]interface{}{}

--- a/namespace.go
+++ b/namespace.go
@@ -16,6 +16,20 @@ package eventhorizon
 
 import "context"
 
+func init() {
+	RegisterContextMarshaler(func(ctx context.Context, vals map[string]interface{}) {
+		if ns, ok := ctx.Value(namespaceKey).(string); ok {
+			vals[namespaceKeyStr] = ns
+		}
+	})
+	RegisterContextUnmarshaler(func(ctx context.Context, vals map[string]interface{}) context.Context {
+		if ns, ok := vals[namespaceKeyStr].(string); ok {
+			return WithNamespace(ctx, ns)
+		}
+		return ctx
+	})
+}
+
 // DefaultNamespace is the namespace to use if not set in the context.
 const DefaultNamespace = "default"
 
@@ -24,6 +38,11 @@ type contextKey int
 const (
 	// namespaceKey is the context key for the namespace value.
 	namespaceKey contextKey = iota
+)
+
+const (
+	// The string key used to marshal namespaceKey.
+	namespaceKeyStr = "eh_namespace"
 )
 
 // Namespace returns the namespace from the context, or the default namespace.

--- a/namespace_test.go
+++ b/namespace_test.go
@@ -30,4 +30,17 @@ func TestContextNamespace(t *testing.T) {
 	if ns := Namespace(ctx); ns != "ns" {
 		t.Error("the namespace should be correct:", ns)
 	}
+
+	vals := MarshalContext(ctx)
+	if ns, ok := vals[namespaceKeyStr].(string); !ok || ns != "ns" {
+		t.Error("the marshaled namespace shoud be correct:", ns)
+	}
+
+	vals = map[string]interface{}{
+		namespaceKeyStr: "ns",
+	}
+	ctx = UnmarshalContext(vals)
+	if ns := Namespace(ctx); ns != "ns" {
+		t.Error("the namespace should be correct:", ns)
+	}
 }


### PR DESCRIPTION
This was missing from the original implementation, crucial for sending and receiving the namespace with distributed event buses and similar. 

Fixes #77.