### PR TITLE
Fix event version bug / remove NewEvent from Aggregate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,27 +1,26 @@
 .PHONEY: cover clean
 
-test: docker
-	go test -v ./...
+test: run_services
+	PUBSUB_EMULATOR_HOST=localhost:8793 go test ./...
 
-test_integration: docker
-	go test -v -tags integration ./...
+test_integration: run_services
+	go test -tags integration ./...
 
 test_wercker:
 	wercker build
 
-test_cover: clean docker
+test_cover: clean run_services
 	go list -f '{{if len .TestGoFiles}}"go test -v -covermode=count -coverprofile={{.Dir}}/.coverprofile {{.ImportPath}}"{{end}}' ./... | xargs -L 1 sh -c
 	gover
 
 cover:
-	go tool cover -html=gover.coverprofile
+	go tool cover -html=.coverprofile
 
-docker:
+run_services:
 	-docker run -d --name mongo -p 27017:27017 mongo:latest
 	-docker run -d --name redis -p 6379:6379 redis:latest
 	-docker run -d --name dynamodb -p 8000:8000 peopleperhour/dynamodb:latest
 	-docker run -d --name gpubsub -p 8793:8793 google/cloud-sdk:latest gcloud beta emulators pubsub start --host-port=0.0.0.0:8793
-	export PUBSUB_EMULATOR_HOST=localhost:8793
 
 clean:
 	-find . -name \.coverprofile -type f -delete

--- a/aggregate.go
+++ b/aggregate.go
@@ -39,19 +39,25 @@ type Aggregate interface {
 
 	// Version returns the version of the aggregate.
 	Version() int
+	// Increment version increments the version of the aggregate. It should be
+	// called after an event has been successfully applied.
+	IncrementVersion()
 
-	// HandleCommand handles a command and stores events.
-	HandleCommand(context.Context, Command) error
+	// CommandHandler is used to handle commands.
+	CommandHandler
 
 	// StoreEvent creates and stores a new event as uncommitted for the aggregate.
 	StoreEvent(EventType, EventData) Event
-	// ApplyEvent applies an event to the aggregate by setting its values and
-	// increments the aggregate version.
-	ApplyEvent(context.Context, Event)
-	// UncommittedEvents gets all uncommitted events for storing.
+	// UncommittedEvents gets all uncommitted events to commit to the store.
 	UncommittedEvents() []Event
-	// ClearUncommittedEvents clears all uncommitted events after storing.
+	// ClearUncommittedEvents clears all uncommitted events after committing to
+	// the store.
 	ClearUncommittedEvents()
+
+	// ApplyEvent applies an event on the aggregate by setting its values.
+	// If there are no errors the version shoudl be incremented by calling
+	// IncrementVersion.
+	ApplyEvent(context.Context, Event) error
 }
 
 var aggregates = make(map[AggregateType]func(UUID) Aggregate)

--- a/aggregate.go
+++ b/aggregate.go
@@ -43,14 +43,12 @@ type Aggregate interface {
 	// HandleCommand handles a command and stores events.
 	HandleCommand(context.Context, Command) error
 
-	// NewEvent creates a new event with the aggregate set as type and ID.
-	NewEvent(EventType, EventData) Event
+	// StoreEvent creates and stores a new event as uncommitted for the aggregate.
+	StoreEvent(EventType, EventData) Event
 	// ApplyEvent applies an event to the aggregate by setting its values and
 	// increments the aggregate version.
 	ApplyEvent(context.Context, Event)
-	// StoreEvent stores an event as uncommitted.
-	StoreEvent(Event)
-	// GetUncommittedEvents gets all uncommitted events for storing.
+	// UncommittedEvents gets all uncommitted events for storing.
 	UncommittedEvents() []Event
 	// ClearUncommittedEvents clears all uncommitted events after storing.
 	ClearUncommittedEvents()

--- a/aggregate_test.go
+++ b/aggregate_test.go
@@ -87,9 +87,15 @@ const (
 
 type TestAggregateRegister struct{ *AggregateBase }
 
-func (a *TestAggregateRegister) AggregateType() AggregateType                             { return TestAggregateRegisterType }
-func (a *TestAggregateRegister) HandleCommand(ctx context.Context, command Command) error { return nil }
-func (a *TestAggregateRegister) ApplyEvent(ctx context.Context, event Event)              {}
+func (a *TestAggregateRegister) AggregateType() AggregateType {
+	return TestAggregateRegisterType
+}
+func (a *TestAggregateRegister) HandleCommand(ctx context.Context, command Command) error {
+	return nil
+}
+func (a *TestAggregateRegister) ApplyEvent(ctx context.Context, event Event) error {
+	return nil
+}
 
 type TestAggregateRegisterEmpty struct{ *AggregateBase }
 
@@ -99,7 +105,9 @@ func (a *TestAggregateRegisterEmpty) AggregateType() AggregateType {
 func (a *TestAggregateRegisterEmpty) HandleCommand(ctx context.Context, command Command) error {
 	return nil
 }
-func (a *TestAggregateRegisterEmpty) ApplyEvent(ctx context.Context, event Event) {}
+func (a *TestAggregateRegisterEmpty) ApplyEvent(ctx context.Context, event Event) error {
+	return nil
+}
 
 type TestAggregateRegisterTwice struct{ *AggregateBase }
 
@@ -109,5 +117,6 @@ func (a *TestAggregateRegisterTwice) AggregateType() AggregateType {
 func (a *TestAggregateRegisterTwice) HandleCommand(ctx context.Context, command Command) error {
 	return nil
 }
-func (a *TestAggregateRegisterTwice) ApplyEvent(ctx context.Context, event Event) {
+func (a *TestAggregateRegisterTwice) ApplyEvent(ctx context.Context, event Event) error {
+	return nil
 }

--- a/aggregatebase.go
+++ b/aggregatebase.go
@@ -88,25 +88,16 @@ func (a *AggregateBase) IncrementVersion() {
 	a.version++
 }
 
-// NewEvent implements the NewEvent method of the Aggregate interface.
-// The created event is only valid for the current version of the aggregate.
-// If there are uncommitted events it will mean that all the uncommitted events
-// could possibly have the same versions as they haven't been applied yet!
-// The result is that the aggregate base only supports one uncommitted event in.
-func (a *AggregateBase) NewEvent(eventType EventType, data EventData) Event {
-	e := NewEvent(eventType, data)
-	if e, ok := e.(event); ok {
-		e.aggregateType = a.aggregateType
-		e.aggregateID = a.id
-		e.version = a.Version() + 1
-		return e
-	}
-	return e
-}
-
 // StoreEvent implements the StoreEvent method of the Aggregate interface.
-func (a *AggregateBase) StoreEvent(event Event) {
-	a.uncommittedEvents = append(a.uncommittedEvents, event)
+func (a *AggregateBase) StoreEvent(eventType EventType, data EventData) Event {
+	e := NewEvent(eventType, data).(event)
+	e.aggregateType = a.aggregateType
+	e.aggregateID = a.id
+	e.version = a.Version() + len(a.uncommittedEvents) + 1
+
+	a.uncommittedEvents = append(a.uncommittedEvents, e)
+
+	return e
 }
 
 // UncommittedEvents implements the UncommittedEvents method of the Aggregate interface.

--- a/aggregatebase.go
+++ b/aggregatebase.go
@@ -38,11 +38,9 @@ package eventhorizon
 //       })
 //   }
 //
-// The aggregate must call IncrementVersion on the base to update the version.
-//   func (a *Aggregate) ApplyEvent(event Event) {
-//       // Call the base to make sure the version is incremented.
-//       defer a.IncrementVersion(event)
-//
+// The aggregate must return an error if the event can not be applied, or nil
+// to signal success which will increment the version.
+//   func (a *Aggregate) ApplyEvent(event Event) error {
 //       switch event.EventType() {
 //       case AddUserEvent:
 //           // Apply the event data to the aggregate.
@@ -90,10 +88,9 @@ func (a *AggregateBase) IncrementVersion() {
 
 // StoreEvent implements the StoreEvent method of the Aggregate interface.
 func (a *AggregateBase) StoreEvent(eventType EventType, data EventData) Event {
-	e := NewEvent(eventType, data).(event)
-	e.aggregateType = a.aggregateType
-	e.aggregateID = a.id
-	e.version = a.Version() + len(a.uncommittedEvents) + 1
+	version := a.Version() + len(a.uncommittedEvents) + 1
+	e := NewEventForAggregate(eventType, data,
+		a.AggregateType(), a.AggregateID(), version)
 
 	a.uncommittedEvents = append(a.uncommittedEvents, e)
 

--- a/commandbus.go
+++ b/commandbus.go
@@ -32,8 +32,8 @@ type CommandHandler interface {
 
 // CommandBus is an interface defining an event bus for distributing events.
 type CommandBus interface {
-	// HandleCommand handles a command on the event bus.
-	HandleCommand(context.Context, Command) error
+	// CommandHandler is used to delegate commands to the correct command handlers.
+	CommandHandler
 	// SetHandler registers a handler with a command.
 	SetHandler(CommandHandler, CommandType) error
 }

--- a/event.go
+++ b/event.go
@@ -65,6 +65,20 @@ func NewEvent(eventType EventType, data EventData) Event {
 	}
 }
 
+// NewEventForAggregate creates a new event with a type and data, setting its
+// timestamp. It also sets the aggregate data on it.
+func NewEventForAggregate(eventType EventType, data EventData,
+	aggregateType AggregateType, aggregateID UUID, version int) Event {
+	return event{
+		eventType:     eventType,
+		data:          data,
+		timestamp:     time.Now(),
+		aggregateType: aggregateType,
+		aggregateID:   aggregateID,
+		version:       version,
+	}
+}
+
 // event is an internal representation of an event, returned when the aggregate
 // uses NewEvent to create a new event. The events loaded from the db is
 // represented by each DBs internal event type, implementing Event.

--- a/event_test.go
+++ b/event_test.go
@@ -21,20 +21,44 @@ import (
 
 func TestNewEvent(t *testing.T) {
 	event := NewEvent(TestEventType, &TestEventData{"event1"})
-
 	if event.EventType() != TestEventType {
 		t.Error("the event type should be correct:", event.EventType())
 	}
 	if !reflect.DeepEqual(event.Data(), &TestEventData{"event1"}) {
 		t.Error("the data should be correct:", event.Data())
 	}
+	if event.Timestamp().IsZero() {
+		t.Error("the timestamp should not be zero:", event.Timestamp())
+	}
 	if event.Version() != 0 {
 		t.Error("the version should be zero:", event.Version())
+	}
+	if event.String() != "TestEvent@0" {
+		t.Error("the string representation should be correct:", event.String())
+	}
+
+	id := NewUUID()
+	event = NewEventForAggregate(TestEventType, &TestEventData{"event1"},
+		TestAggregateType, id, 3)
+	if event.EventType() != TestEventType {
+		t.Error("the event type should be correct:", event.EventType())
+	}
+	if !reflect.DeepEqual(event.Data(), &TestEventData{"event1"}) {
+		t.Error("the data should be correct:", event.Data())
 	}
 	if event.Timestamp().IsZero() {
 		t.Error("the timestamp should not be zero:", event.Timestamp())
 	}
-	if event.String() != "TestEvent@0" {
+	if event.AggregateType() != TestAggregateType {
+		t.Error("the aggregate type should be correct:", event.AggregateType())
+	}
+	if event.AggregateID() != id {
+		t.Error("the aggregate ID should be correct:", event.AggregateID())
+	}
+	if event.Version() != 3 {
+		t.Error("the version should be zero:", event.Version())
+	}
+	if event.String() != "TestEvent@3" {
 		t.Error("the string representation should be correct:", event.String())
 	}
 }

--- a/eventbus/testutil/common_tests.go
+++ b/eventbus/testutil/common_tests.go
@@ -36,7 +36,7 @@ func EventBusCommonTests(t *testing.T, bus1, bus2 eh.EventBus) {
 	t.Log("publish event without handler")
 	id, _ := eh.ParseUUID("c1138e5f-f6fb-4dd0-8e79-255c6c8d3756")
 	agg := mocks.NewAggregate(id)
-	event1 := agg.NewEvent(mocks.EventType, &mocks.EventData{"event1"})
+	event1 := agg.StoreEvent(mocks.EventType, &mocks.EventData{"event1"})
 	agg.IncrementVersion()
 	bus1.PublishEvent(ctx, event1)
 	expectedEvents := []eh.Event{event1}
@@ -99,7 +99,7 @@ func EventBusCommonTests(t *testing.T, bus1, bus2 eh.EventBus) {
 
 	t.Log("publish another event")
 	bus1.AddHandler(handler, mocks.EventOtherType)
-	event2 := agg.NewEvent(mocks.EventOtherType, nil)
+	event2 := agg.StoreEvent(mocks.EventOtherType, nil)
 	bus1.PublishEvent(ctx, event2)
 	handler.WaitForEvent(t)
 	expectedEvents = []eh.Event{event1, event2}

--- a/eventbus/testutil/common_tests.go
+++ b/eventbus/testutil/common_tests.go
@@ -35,9 +35,8 @@ func EventBusCommonTests(t *testing.T, bus1, bus2 eh.EventBus) {
 
 	t.Log("publish event without handler")
 	id, _ := eh.ParseUUID("c1138e5f-f6fb-4dd0-8e79-255c6c8d3756")
-	agg := mocks.NewAggregate(id)
-	event1 := agg.StoreEvent(mocks.EventType, &mocks.EventData{"event1"})
-	agg.IncrementVersion()
+	event1 := eh.NewEventForAggregate(mocks.EventType, &mocks.EventData{"event1"},
+		mocks.AggregateType, id, 1)
 	bus1.PublishEvent(ctx, event1)
 	expectedEvents := []eh.Event{event1}
 	observer1.WaitForEvent(t)
@@ -63,7 +62,6 @@ func EventBusCommonTests(t *testing.T, bus1, bus2 eh.EventBus) {
 	handler := mocks.NewEventHandler("testHandler")
 	bus1.AddHandler(handler, mocks.EventType)
 	bus1.PublishEvent(ctx, event1)
-	agg.IncrementVersion()
 	handler.WaitForEvent(t)
 	expectedEvents = []eh.Event{event1}
 	for i, event := range handler.Events {
@@ -99,7 +97,8 @@ func EventBusCommonTests(t *testing.T, bus1, bus2 eh.EventBus) {
 
 	t.Log("publish another event")
 	bus1.AddHandler(handler, mocks.EventOtherType)
-	event2 := agg.StoreEvent(mocks.EventOtherType, nil)
+	event2 := eh.NewEventForAggregate(mocks.EventOtherType, nil,
+		mocks.AggregateType, id, 2)
 	bus1.PublishEvent(ctx, event2)
 	handler.WaitForEvent(t)
 	expectedEvents = []eh.Event{event1, event2}

--- a/eventhorizon_test.go
+++ b/eventhorizon_test.go
@@ -49,6 +49,8 @@ type TestAggregate struct {
 	context           context.Context
 	appliedEvent      Event
 	numHandled        int
+
+	err error
 }
 
 func NewTestAggregate(id UUID) *TestAggregate {
@@ -61,23 +63,24 @@ func (a *TestAggregate) HandleCommand(ctx context.Context, command Command) erro
 	a.dispatchedCommand = command
 	a.context = ctx
 	a.numHandled++
+	if a.err != nil {
+		return a.err
+	}
 	switch command := command.(type) {
 	case *TestCommand:
-		if command.Content == "error" {
-			return errors.New("command error")
-		}
-		a.StoreEvent(TestEventType,
-			&TestEventData{command.Content})
+		a.StoreEvent(TestEventType, &TestEventData{command.Content})
 		return nil
 	}
 	return errors.New("couldn't handle command")
 }
 
-func (a *TestAggregate) ApplyEvent(ctx context.Context, event Event) {
-	defer a.IncrementVersion()
-
+func (a *TestAggregate) ApplyEvent(ctx context.Context, event Event) error {
 	a.appliedEvent = event
 	a.context = ctx
+	if a.err != nil {
+		return a.err
+	}
+	return nil
 }
 
 type TestAggregate2 struct {
@@ -87,6 +90,8 @@ type TestAggregate2 struct {
 	context           context.Context
 	appliedEvent      Event
 	numHandled        int
+
+	err error
 }
 
 func NewTestAggregate2(id UUID) *TestAggregate2 {
@@ -99,21 +104,24 @@ func (a *TestAggregate2) HandleCommand(ctx context.Context, command Command) err
 	a.dispatchedCommand = command
 	a.context = ctx
 	a.numHandled++
+	if a.err != nil {
+		return a.err
+	}
 	switch command := command.(type) {
 	case *TestCommand2:
-		if command.Content == "error" {
-			return errors.New("command error")
-		}
-		a.StoreEvent(TestEventType,
-			&TestEvent2Data{command.Content})
+		a.StoreEvent(TestEventType, &TestEvent2Data{command.Content})
 		return nil
 	}
 	return errors.New("couldn't handle command")
 }
 
-func (a *TestAggregate2) ApplyEvent(ctx context.Context, event Event) {
+func (a *TestAggregate2) ApplyEvent(ctx context.Context, event Event) error {
 	a.appliedEvent = event
 	a.context = ctx
+	if a.err != nil {
+		return a.err
+	}
+	return nil
 }
 
 type TestCommand struct {
@@ -145,14 +153,22 @@ type TestEvent2Data struct {
 type MockRepository struct {
 	Aggregates map[UUID]Aggregate
 	Context    context.Context
+	// Used to simulate errors in the store.
+	err error
 }
 
 func (m *MockRepository) Load(ctx context.Context, aggregateType AggregateType, id UUID) (Aggregate, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
 	m.Context = ctx
 	return m.Aggregates[id], nil
 }
 
 func (m *MockRepository) Save(ctx context.Context, aggregate Aggregate) error {
+	if m.err != nil {
+		return m.err
+	}
 	m.Aggregates[aggregate.AggregateID()] = aggregate
 	m.Context = ctx
 	return nil

--- a/eventhorizon_test.go
+++ b/eventhorizon_test.go
@@ -66,8 +66,8 @@ func (a *TestAggregate) HandleCommand(ctx context.Context, command Command) erro
 		if command.Content == "error" {
 			return errors.New("command error")
 		}
-		a.StoreEvent(a.NewEvent(TestEventType,
-			&TestEventData{command.Content}))
+		a.StoreEvent(TestEventType,
+			&TestEventData{command.Content})
 		return nil
 	}
 	return errors.New("couldn't handle command")
@@ -104,8 +104,8 @@ func (a *TestAggregate2) HandleCommand(ctx context.Context, command Command) err
 		if command.Content == "error" {
 			return errors.New("command error")
 		}
-		a.StoreEvent(a.NewEvent(TestEventType,
-			&TestEvent2Data{command.Content}))
+		a.StoreEvent(TestEventType,
+			&TestEvent2Data{command.Content})
 		return nil
 	}
 	return errors.New("couldn't handle command")

--- a/eventstore/testutil/common_tests.go
+++ b/eventstore/testutil/common_tests.go
@@ -38,18 +38,16 @@ func EventStoreCommonTests(t *testing.T, ctx context.Context, store eh.EventStor
 
 	t.Log("save event, version 1")
 	id, _ := eh.ParseUUID("c1138e5f-f6fb-4dd0-8e79-255c6c8d3756")
-	agg := mocks.NewAggregate(id)
-	event1 := agg.StoreEvent(mocks.EventType, &mocks.EventData{"event1"})
+	event1 := eh.NewEventForAggregate(mocks.EventType, &mocks.EventData{"event1"},
+		mocks.AggregateType, id, 1)
 	err = store.Save(ctx, []eh.Event{event1}, 0)
 	if err != nil {
 		t.Error("there should be no error:", err)
 	}
-	agg.ApplyEvent(ctx, event1) // Apply event to increment the aggregate version.
-	agg.ClearUncommittedEvents()
 	savedEvents = append(savedEvents, event1)
-	if val, ok := agg.Context.Value("testkey").(string); !ok || val != "testval" {
-		t.Error("the context should be correct:", agg.Context)
-	}
+	// if val, ok := agg.Context.Value("testkey").(string); !ok || val != "testval" {
+	// 	t.Error("the context should be correct:", agg.Context)
+	// }
 
 	t.Log("try to save same event twice")
 	err = store.Save(ctx, []eh.Event{event1}, 1)
@@ -58,49 +56,44 @@ func EventStoreCommonTests(t *testing.T, ctx context.Context, store eh.EventStor
 	}
 
 	t.Log("save event, version 2")
-	event2 := agg.StoreEvent(mocks.EventType, &mocks.EventData{"event2"})
+	event2 := eh.NewEventForAggregate(mocks.EventType, &mocks.EventData{"event2"},
+		mocks.AggregateType, id, 2)
 	err = store.Save(ctx, []eh.Event{event2}, 1)
 	if err != nil {
 		t.Error("there should be no error:", err)
 	}
-	agg.ApplyEvent(ctx, event2) // Apply event to increment the aggregate version.
-	agg.ClearUncommittedEvents()
 	savedEvents = append(savedEvents, event2)
 
 	t.Log("save event without data, version 3")
-	event3 := agg.StoreEvent(mocks.EventOtherType, nil)
+	event3 := eh.NewEventForAggregate(mocks.EventOtherType, nil,
+		mocks.AggregateType, id, 3)
 	err = store.Save(ctx, []eh.Event{event3}, 2)
 	if err != nil {
 		t.Error("there should be no error:", err)
 	}
-	agg.ApplyEvent(ctx, event3) // Apply event to increment the aggregate version.
-	agg.ClearUncommittedEvents()
 	savedEvents = append(savedEvents, event3)
 
 	t.Log("save multiple events, version 4, 5 and 6")
-	event4 := agg.StoreEvent(mocks.EventOtherType, nil)
-	event5 := agg.StoreEvent(mocks.EventOtherType, nil)
-	event6 := agg.StoreEvent(mocks.EventOtherType, nil)
+	event4 := eh.NewEventForAggregate(mocks.EventOtherType, nil,
+		mocks.AggregateType, id, 4)
+	event5 := eh.NewEventForAggregate(mocks.EventOtherType, nil,
+		mocks.AggregateType, id, 5)
+	event6 := eh.NewEventForAggregate(mocks.EventOtherType, nil,
+		mocks.AggregateType, id, 6)
 	err = store.Save(ctx, []eh.Event{event4, event5, event6}, 3)
 	if err != nil {
 		t.Error("there should be no error:", err)
 	}
-	agg.ApplyEvent(ctx, event4) // Apply event to increment the aggregate version.
-	agg.ApplyEvent(ctx, event5) // Apply event to increment the aggregate version.
-	agg.ApplyEvent(ctx, event6) // Apply event to increment the aggregate version.
-	agg.ClearUncommittedEvents()
 	savedEvents = append(savedEvents, event4, event5, event6)
 
 	t.Log("save event for another aggregate")
 	id2, _ := eh.ParseUUID("c1138e5e-f6fb-4dd0-8e79-255c6c8d3756")
-	agg2 := mocks.NewAggregate(id2)
-	event7 := agg2.StoreEvent(mocks.EventType, &mocks.EventData{"event7"})
+	event7 := eh.NewEventForAggregate(mocks.EventType, &mocks.EventData{"event7"},
+		mocks.AggregateType, id2, 1)
 	err = store.Save(ctx, []eh.Event{event7}, 0)
 	if err != nil {
 		t.Error("there should be no error:", err)
 	}
-	agg2.ApplyEvent(ctx, event7) // Apply event to increment the aggregate version.
-	agg.ClearUncommittedEvents()
 	savedEvents = append(savedEvents, event7)
 
 	t.Log("load events for non-existing aggregate")

--- a/eventstore/trace/eventstore_test.go
+++ b/eventstore/trace/eventstore_test.go
@@ -65,7 +65,7 @@ func TestEventStore(t *testing.T) {
 	for _, e := range aggregate1events {
 		agg.ApplyEvent(ctx, e)
 	}
-	event7 := agg.NewEvent(mocks.EventType, &mocks.EventData{"event1"})
+	event7 := agg.StoreEvent(mocks.EventType, &mocks.EventData{"event1"})
 	agg.ApplyEvent(ctx, event7) // Apply event to increment the aggregate version.
 	err := store.Save(ctx, []eh.Event{event7}, 6)
 	if err != nil {

--- a/eventstore/trace/eventstore_test.go
+++ b/eventstore/trace/eventstore_test.go
@@ -61,21 +61,17 @@ func TestEventStore(t *testing.T) {
 	ctx := context.Background()
 
 	t.Log("save event, version 7")
-	agg := mocks.NewAggregate(event1.AggregateID())
-	for _, e := range aggregate1events {
-		agg.ApplyEvent(ctx, e)
-	}
-	event7 := agg.StoreEvent(mocks.EventType, &mocks.EventData{"event1"})
-	agg.ApplyEvent(ctx, event7) // Apply event to increment the aggregate version.
+	event7 := eh.NewEventForAggregate(mocks.EventType, &mocks.EventData{"event1"},
+		mocks.AggregateType, event1.AggregateID(), 7)
 	err := store.Save(ctx, []eh.Event{event7}, 6)
 	if err != nil {
 		t.Error("there should be no error:", err)
 	}
+	aggregate1events = append(aggregate1events, event1)
 	trace = store.GetTrace()
 	if len(trace) != 0 {
 		t.Error("there should be no events traced:", trace)
 	}
-	aggregate1events = append(aggregate1events, event1)
 
 	t.Log("load events without tracing")
 	events, err := store.Load(ctx, event1.AggregateType(), event1.AggregateID())

--- a/examples/domain/aggregate.go
+++ b/examples/domain/aggregate.go
@@ -128,9 +128,7 @@ func (a *InvitationAggregate) HandleCommand(ctx context.Context, command eh.Comm
 }
 
 // ApplyEvent implements the ApplyEvent method of the Aggregate interface.
-func (a *InvitationAggregate) ApplyEvent(ctx context.Context, event eh.Event) {
-	defer a.IncrementVersion()
-
+func (a *InvitationAggregate) ApplyEvent(ctx context.Context, event eh.Event) error {
 	switch event.EventType() {
 	case InviteCreatedEvent:
 		if data, ok := event.Data().(*InviteCreatedData); ok {
@@ -148,4 +146,5 @@ func (a *InvitationAggregate) ApplyEvent(ctx context.Context, event eh.Event) {
 	case InviteDeniedEvent:
 		a.denied = true
 	}
+	return nil
 }

--- a/examples/domain/aggregate.go
+++ b/examples/domain/aggregate.go
@@ -60,12 +60,12 @@ func NewInvitationAggregate(id eh.UUID) *InvitationAggregate {
 func (a *InvitationAggregate) HandleCommand(ctx context.Context, command eh.Command) error {
 	switch command := command.(type) {
 	case *CreateInvite:
-		a.StoreEvent(a.NewEvent(InviteCreatedEvent,
+		a.StoreEvent(InviteCreatedEvent,
 			&InviteCreatedData{
 				command.Name,
 				command.Age,
 			},
-		))
+		)
 		return nil
 
 	case *AcceptInvite:
@@ -81,7 +81,7 @@ func (a *InvitationAggregate) HandleCommand(ctx context.Context, command eh.Comm
 			return nil
 		}
 
-		a.StoreEvent(a.NewEvent(InviteAcceptedEvent, nil))
+		a.StoreEvent(InviteAcceptedEvent, nil)
 		return nil
 
 	case *DeclineInvite:
@@ -97,7 +97,7 @@ func (a *InvitationAggregate) HandleCommand(ctx context.Context, command eh.Comm
 			return nil
 		}
 
-		a.StoreEvent(a.NewEvent(InviteDeclinedEvent, nil))
+		a.StoreEvent(InviteDeclinedEvent, nil)
 		return nil
 
 	case *ConfirmInvite:
@@ -109,7 +109,7 @@ func (a *InvitationAggregate) HandleCommand(ctx context.Context, command eh.Comm
 			return fmt.Errorf("only accepted invites can be confirmed")
 		}
 
-		a.StoreEvent(a.NewEvent(InviteConfirmedEvent, nil))
+		a.StoreEvent(InviteConfirmedEvent, nil)
 		return nil
 
 	case *DenyInvite:
@@ -121,7 +121,7 @@ func (a *InvitationAggregate) HandleCommand(ctx context.Context, command eh.Comm
 			return fmt.Errorf("only accepted invites can be denied")
 		}
 
-		a.StoreEvent(a.NewEvent(InviteDeniedEvent, nil))
+		a.StoreEvent(InviteDeniedEvent, nil)
 		return nil
 	}
 	return fmt.Errorf("couldn't handle command")

--- a/mocks/mocks.go
+++ b/mocks/mocks.go
@@ -81,11 +81,13 @@ func (a *Aggregate) HandleCommand(ctx context.Context, command eh.Command) error
 }
 
 // ApplyEvent implements the ApplyEvent method of the eventhorizon.Aggregate interface.
-func (a *Aggregate) ApplyEvent(ctx context.Context, event eh.Event) {
-	defer a.IncrementVersion()
-
+func (a *Aggregate) ApplyEvent(ctx context.Context, event eh.Event) error {
+	if a.Err != nil {
+		return a.Err
+	}
 	a.Events = append(a.Events, event)
 	a.Context = ctx
+	return nil
 }
 
 // EventData is a mocked event data, useful in testing.

--- a/repository_test.go
+++ b/repository_test.go
@@ -79,7 +79,7 @@ func TestEventSourcingRepositoryLoadEvents(t *testing.T) {
 
 	id := NewUUID()
 	agg := NewTestAggregate(id)
-	event1 := agg.NewEvent(TestEventType, &TestEventData{"event1"})
+	event1 := agg.StoreEvent(TestEventType, &TestEventData{"event1"})
 	store.Save(ctx, []Event{event1}, 0)
 	t.Log(store.Events)
 	loadedAgg, err := repo.Load(ctx, TestAggregateType, id)
@@ -109,12 +109,12 @@ func TestEventSourcingRepositoryLoadEventsMismatchedEventType(t *testing.T) {
 
 	id := NewUUID()
 	agg := NewTestAggregate(id)
-	event1 := agg.NewEvent(TestEventType, &TestEventData{"event"})
+	event1 := agg.StoreEvent(TestEventType, &TestEventData{"event"})
 	store.Save(ctx, []Event{event1}, 0)
 
 	otherAggregateID := NewUUID()
 	otherAgg := NewTestAggregate2(otherAggregateID)
-	event2 := otherAgg.NewEvent(TestEvent2Type, &TestEvent2Data{"event2"})
+	event2 := otherAgg.StoreEvent(TestEvent2Type, &TestEvent2Data{"event2"})
 	store.Save(ctx, []Event{event2}, 0)
 
 	loadedAgg, err := repo.Load(ctx, TestAggregateType, otherAggregateID)
@@ -133,8 +133,7 @@ func TestEventSourcingRepositorySaveEvents(t *testing.T) {
 
 	id := NewUUID()
 	agg := NewTestAggregate(id)
-	event1 := agg.NewEvent(TestEventType, &TestEventData{"event"})
-	agg.StoreEvent(event1)
+	event1 := agg.StoreEvent(TestEventType, &TestEventData{"event"})
 	err := repo.Save(ctx, agg)
 	if err != nil {
 		t.Error("there should be no error:", err)
@@ -161,11 +160,11 @@ func TestEventSourcingRepositorySaveEvents(t *testing.T) {
 		t.Error("there should be an event on the bus:", bus.Events)
 	}
 
-	agg.StoreEvent(event1)
-	store.err = errors.New("error")
-	if err = repo.Save(ctx, agg); err == nil || err.Error() != "error" {
-		t.Error("there should be an error named 'error':", err)
-	}
+	// agg.StoreEvent(event1)
+	// store.err = errors.New("error")
+	// if err = repo.Save(ctx, agg); err == nil || err.Error() != "error" {
+	// 	t.Error("there should be an error named 'error':", err)
+	// }
 }
 
 func TestEventSourcingRepositoryAggregateNotRegistered(t *testing.T) {

--- a/repository_test.go
+++ b/repository_test.go
@@ -54,7 +54,7 @@ func TestNewEventSourcingRepository(t *testing.T) {
 	}
 }
 
-func TestEventSourcingRepositoryLoadNoEvents(t *testing.T) {
+func TestEventSourcingRepository_LoadNoEvents(t *testing.T) {
 	repo, _, _ := createRepoAndStore(t)
 
 	ctx := context.Background()
@@ -72,7 +72,7 @@ func TestEventSourcingRepositoryLoadNoEvents(t *testing.T) {
 	}
 }
 
-func TestEventSourcingRepositoryLoadEvents(t *testing.T) {
+func TestEventSourcingRepository_LoadEvents(t *testing.T) {
 	repo, store, _ := createRepoAndStore(t)
 
 	ctx := context.Background()
@@ -96,13 +96,16 @@ func TestEventSourcingRepositoryLoadEvents(t *testing.T) {
 		t.Error("the event should be correct:", loadedAgg.(*TestAggregate).appliedEvent)
 	}
 
+	// Store error.
 	store.err = errors.New("error")
-	if _, err = repo.Load(ctx, TestAggregateType, id); err == nil || err.Error() != "error" {
+	_, err = repo.Load(ctx, TestAggregateType, id)
+	if err == nil || err.Error() != "error" {
 		t.Error("there should be an error named 'error':", err)
 	}
+	store.err = nil
 }
 
-func TestEventSourcingRepositoryLoadEventsMismatchedEventType(t *testing.T) {
+func TestEventSourcingRepository_LoadEvents_MismatchedEventType(t *testing.T) {
 	repo, store, _ := createRepoAndStore(t)
 
 	ctx := context.Background()
@@ -126,15 +129,20 @@ func TestEventSourcingRepositoryLoadEventsMismatchedEventType(t *testing.T) {
 	}
 }
 
-func TestEventSourcingRepositorySaveEvents(t *testing.T) {
+func TestEventSourcingRepository_SaveEvents(t *testing.T) {
 	repo, store, bus := createRepoAndStore(t)
 
 	ctx := context.Background()
 
 	id := NewUUID()
 	agg := NewTestAggregate(id)
-	event1 := agg.StoreEvent(TestEventType, &TestEventData{"event"})
 	err := repo.Save(ctx, agg)
+	if err != nil {
+		t.Error("there should be no error:", err)
+	}
+
+	event1 := agg.StoreEvent(TestEventType, &TestEventData{"event"})
+	err = repo.Save(ctx, agg)
 	if err != nil {
 		t.Error("there should be no error:", err)
 	}
@@ -160,14 +168,25 @@ func TestEventSourcingRepositorySaveEvents(t *testing.T) {
 		t.Error("there should be an event on the bus:", bus.Events)
 	}
 
-	// agg.StoreEvent(event1)
-	// store.err = errors.New("error")
-	// if err = repo.Save(ctx, agg); err == nil || err.Error() != "error" {
-	// 	t.Error("there should be an error named 'error':", err)
-	// }
+	// Store error.
+	event1 = agg.StoreEvent(TestEventType, &TestEventData{"event"})
+	store.err = errors.New("error")
+	err = repo.Save(ctx, agg)
+	if err == nil || err.Error() != "error" {
+		t.Error("there should be an error named 'error':", err)
+	}
+	store.err = nil
+
+	// Aggregate error.
+	event1 = agg.StoreEvent(TestEventType, &TestEventData{"event"})
+	agg.err = errors.New("error")
+	err = repo.Save(ctx, agg)
+	if _, ok := err.(ApplyEventError); !ok {
+		t.Error("there should be an error of type ApplyEventError:", err)
+	}
 }
 
-func TestEventSourcingRepositoryAggregateNotRegistered(t *testing.T) {
+func TestEventSourcingRepository_AggregateNotRegistered(t *testing.T) {
 	repo, _, _ := createRepoAndStore(t)
 
 	ctx := context.Background()

--- a/saga_test.go
+++ b/saga_test.go
@@ -31,7 +31,7 @@ func TestSagaHandler(t *testing.T) {
 
 	id := NewUUID()
 	agg := NewTestAggregate(id)
-	event := agg.NewEvent(TestEventType, &TestEventData{"event1"})
+	event := agg.StoreEvent(TestEventType, &TestEventData{"event1"})
 	saga.commands = []Command{&TestCommand{NewUUID(), "content"}}
 	sagaHandler.HandleEvent(ctx, event)
 	if saga.event != event {


### PR DESCRIPTION
Instead use StoreEvent to both create a new event and store it. This
fixes a bug where the aggregate version was incorrect when creating
multiple events without applying them in between.