### PR TITLE
Add EventWaiter util to wait for some event to happen

### DIFF
--- a/publisher/gcp/publisher.go
+++ b/publisher/gcp/publisher.go
@@ -142,7 +142,10 @@ func (b *EventPublisher) recv() {
 
 	// Create the subscription, it should not exist as we use a new UUID as name.
 	id := "subscriber_" + eh.NewUUID().String()
-	sub, err := b.client.CreateSubscription(ctx, id, b.topic, 10*time.Second, nil)
+	sub, err := b.client.CreateSubscription(ctx, id, pubsub.SubscriptionConfig{
+		Topic:       b.topic,
+		AckDeadline: 10 * time.Second,
+	})
 	if err != nil {
 		// TODO: Handle error.
 		log.Println("eventpublisher: could not create subscription:", err)

--- a/utils/eventwaiter.go
+++ b/utils/eventwaiter.go
@@ -34,7 +34,8 @@ func NewEventWaiter() *EventWaiter {
 	}
 }
 
-// Notify implements the Notify method of the eventhorizon.EventObserver interface.
+// Notify implements the eventhorizon.EventObserver.Notify method which forwards
+// events to the waiters so that they can match the events.
 func (w *EventWaiter) Notify(ctx context.Context, event eh.Event) error {
 	w.waitsMu.RLock()
 	defer w.waitsMu.RUnlock()

--- a/utils/eventwaiter.go
+++ b/utils/eventwaiter.go
@@ -1,0 +1,77 @@
+// Copyright (c) 2017 - Max Ekman <max@looplab.se>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"context"
+	"sync"
+
+	eh "github.com/looplab/eventhorizon"
+)
+
+// EventWaiter waits for certain events to match a criteria.
+type EventWaiter struct {
+	waits   map[eh.UUID]chan eh.Event
+	waitsMu sync.RWMutex
+}
+
+// NewEventWaiter returns a new EventWaiter.
+func NewEventWaiter() *EventWaiter {
+	return &EventWaiter{
+		waits: map[eh.UUID]chan eh.Event{},
+	}
+}
+
+// Notify implements the Notify method of the eventhorizon.EventObserver interface.
+func (w *EventWaiter) Notify(ctx context.Context, event eh.Event) error {
+	w.waitsMu.RLock()
+	defer w.waitsMu.RUnlock()
+	for _, ch := range w.waits {
+		ch <- event
+	}
+
+	return nil
+}
+
+// Wait waits unil the match function returns true for an event, or the context
+// deadline expires. The match function can be used to filter or otherwise select
+// interesting events by analysing the event data.
+func (w *EventWaiter) Wait(ctx context.Context, match func(eh.Event) bool) (eh.Event, error) {
+	id := eh.NewUUID()
+	ch := make(chan eh.Event, 1) // Use bufferd chan to not block other waits.
+
+	// Add us to the in-flight waits and make sure we get removed when done.
+	w.waitsMu.Lock()
+	w.waits[id] = ch
+	w.waitsMu.Unlock()
+	defer func() {
+		w.waitsMu.Lock()
+		delete(w.waits, id)
+		w.waitsMu.Unlock()
+	}()
+
+	// Wait for a matching event or that the context is cancelled. Use the done
+	// func to match events.
+	for {
+		select {
+		case event := <-ch:
+			if match(event) {
+				return event, nil
+			}
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+}

--- a/utils/eventwaiter_test.go
+++ b/utils/eventwaiter_test.go
@@ -1,0 +1,84 @@
+// Copyright (c) 2017 - Max Ekman <max@looplab.se>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"time"
+
+	eh "github.com/looplab/eventhorizon"
+	"github.com/looplab/eventhorizon/mocks"
+)
+
+func TestEventWaiter(t *testing.T) {
+	w := NewEventWaiter()
+
+	// Event should match when waiting.
+	expectedEvent := eh.NewEventForAggregate(mocks.EventType, nil, mocks.AggregateType, eh.NewUUID(), 1)
+	go func() {
+		time.Sleep(time.Millisecond)
+		if err := w.Notify(context.Background(), expectedEvent); err != nil {
+			t.Error(err)
+		}
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	event, err := w.Wait(context.Background(), func(event eh.Event) bool {
+		if event.EventType() == mocks.EventType {
+			return true
+		}
+		return false
+	})
+	if err != nil {
+		t.Error(err)
+	}
+	if !reflect.DeepEqual(event, expectedEvent) {
+		t.Error("the event should be correct:", event)
+	}
+	if len(w.waits) > 0 {
+		t.Error("there should be no open waits")
+	}
+
+	// Other events should not match.
+	otherEvent := eh.NewEventForAggregate(mocks.EventOtherType, nil, mocks.AggregateType, eh.NewUUID(), 1)
+	go func() {
+		time.Sleep(time.Millisecond)
+		if err := w.Notify(context.Background(), otherEvent); err != nil {
+			t.Error(err)
+		}
+	}()
+
+	ctx, cancel = context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+	event, err = w.Wait(ctx, func(event eh.Event) bool {
+		if event.EventType() == mocks.EventType {
+			return true
+		}
+		return false
+	})
+	if err == nil || err.Error() != "context deadline exceeded" {
+		t.Error("there should be a context deadline exceeded error")
+	}
+	if event != nil {
+		t.Error("the event should be nil:", event)
+	}
+	if len(w.waits) > 0 {
+		t.Error("there should be no open waits")
+	}
+}


### PR DESCRIPTION
Can be used when a command is expected to produce an event and the caller wants to wait for that to happen before returning, for example when simulating request/reply on top of event sourcing.