### PR TITLE
ISSUE-81 / Delayed command execution

### DIFF
--- a/aggregate.go
+++ b/aggregate.go
@@ -61,7 +61,7 @@ type Aggregate interface {
 }
 
 var aggregates = make(map[AggregateType]func(UUID) Aggregate)
-var registerAggregateLock sync.RWMutex
+var aggregatesMu sync.RWMutex
 
 // ErrAggregateNotRegistered is when no aggregate factory was registered.
 var ErrAggregateNotRegistered = errors.New("aggregate not registered")
@@ -85,8 +85,8 @@ func RegisterAggregate(factory func(UUID) Aggregate) {
 		panic("eventhorizon: attempt to register empty aggregate type")
 	}
 
-	registerAggregateLock.Lock()
-	defer registerAggregateLock.Unlock()
+	aggregatesMu.Lock()
+	defer aggregatesMu.Unlock()
 	if _, ok := aggregates[aggregateType]; ok {
 		panic(fmt.Sprintf("eventhorizon: registering duplicate types for %q", aggregateType))
 	}
@@ -96,8 +96,8 @@ func RegisterAggregate(factory func(UUID) Aggregate) {
 // CreateAggregate creates an aggregate of a type with an ID using the factory
 // registered with RegisterAggregate.
 func CreateAggregate(aggregateType AggregateType, id UUID) (Aggregate, error) {
-	registerAggregateLock.RLock()
-	defer registerAggregateLock.RUnlock()
+	aggregatesMu.RLock()
+	defer aggregatesMu.RUnlock()
 	if factory, ok := aggregates[aggregateType]; ok {
 		return factory(id), nil
 	}

--- a/aggregate_test.go
+++ b/aggregate_test.go
@@ -90,7 +90,7 @@ type TestAggregateRegister struct{ *AggregateBase }
 func (a *TestAggregateRegister) AggregateType() AggregateType {
 	return TestAggregateRegisterType
 }
-func (a *TestAggregateRegister) HandleCommand(ctx context.Context, command Command) error {
+func (a *TestAggregateRegister) HandleCommand(ctx context.Context, cmd Command) error {
 	return nil
 }
 func (a *TestAggregateRegister) ApplyEvent(ctx context.Context, event Event) error {
@@ -102,7 +102,7 @@ type TestAggregateRegisterEmpty struct{ *AggregateBase }
 func (a *TestAggregateRegisterEmpty) AggregateType() AggregateType {
 	return TestAggregateRegisterEmptyType
 }
-func (a *TestAggregateRegisterEmpty) HandleCommand(ctx context.Context, command Command) error {
+func (a *TestAggregateRegisterEmpty) HandleCommand(ctx context.Context, cmd Command) error {
 	return nil
 }
 func (a *TestAggregateRegisterEmpty) ApplyEvent(ctx context.Context, event Event) error {
@@ -114,7 +114,7 @@ type TestAggregateRegisterTwice struct{ *AggregateBase }
 func (a *TestAggregateRegisterTwice) AggregateType() AggregateType {
 	return TestAggregateRegisterTwiceType
 }
-func (a *TestAggregateRegisterTwice) HandleCommand(ctx context.Context, command Command) error {
+func (a *TestAggregateRegisterTwice) HandleCommand(ctx context.Context, cmd Command) error {
 	return nil
 }
 func (a *TestAggregateRegisterTwice) ApplyEvent(ctx context.Context, event Event) error {

--- a/command_test.go
+++ b/command_test.go
@@ -19,19 +19,19 @@ import (
 )
 
 func TestCreateCommand(t *testing.T) {
-	command, err := CreateCommand(TestCommandRegisterType)
+	cmd, err := CreateCommand(TestCommandRegisterType)
 	if err != ErrCommandNotRegistered {
 		t.Error("there should be a command not registered error:", err)
 	}
 
 	RegisterCommand(func() Command { return &TestCommandRegister{} })
 
-	command, err = CreateCommand(TestCommandRegisterType)
+	cmd, err = CreateCommand(TestCommandRegisterType)
 	if err != nil {
 		t.Error("there should be no error:", err)
 	}
-	if command.CommandType() != TestCommandRegisterType {
-		t.Error("the command type should be correct:", command.CommandType())
+	if cmd.CommandType() != TestCommandRegisterType {
+		t.Error("the command type should be correct:", cmd.CommandType())
 	}
 }
 

--- a/commandbus/local/commandbus.go
+++ b/commandbus/local/commandbus.go
@@ -37,26 +37,26 @@ func NewCommandBus() *CommandBus {
 }
 
 // HandleCommand handles a command with a handler capable of handling it.
-func (b *CommandBus) HandleCommand(ctx context.Context, command eh.Command) error {
+func (b *CommandBus) HandleCommand(ctx context.Context, cmd eh.Command) error {
 	b.handlersMu.RLock()
 	defer b.handlersMu.RUnlock()
 
-	if handler, ok := b.handlers[command.CommandType()]; ok {
-		return handler.HandleCommand(ctx, command)
+	if handler, ok := b.handlers[cmd.CommandType()]; ok {
+		return handler.HandleCommand(ctx, cmd)
 	}
 
 	return eh.ErrHandlerNotFound
 }
 
 // SetHandler adds a handler for a specific command.
-func (b *CommandBus) SetHandler(handler eh.CommandHandler, commandType eh.CommandType) error {
+func (b *CommandBus) SetHandler(handler eh.CommandHandler, cmdType eh.CommandType) error {
 	b.handlersMu.Lock()
 	defer b.handlersMu.Unlock()
 
-	if _, ok := b.handlers[commandType]; ok {
+	if _, ok := b.handlers[cmdType]; ok {
 		return eh.ErrHandlerAlreadySet
 	}
 
-	b.handlers[commandType] = handler
+	b.handlers[cmdType] = handler
 	return nil
 }

--- a/commandbus/local/commandbus_test.go
+++ b/commandbus/local/commandbus_test.go
@@ -31,8 +31,8 @@ func TestCommandBus(t *testing.T) {
 	ctx := context.WithValue(context.Background(), "testkey", "testval")
 
 	t.Log("handle with no handler")
-	command1 := &mocks.Command{eh.NewUUID(), "command1"}
-	err := bus.HandleCommand(ctx, command1)
+	cmd := &mocks.Command{eh.NewUUID(), "command1"}
+	err := bus.HandleCommand(ctx, cmd)
 	if err != eh.ErrHandlerNotFound {
 		t.Error("there should be a ErrHandlerNotFound error:", err)
 	}
@@ -45,11 +45,11 @@ func TestCommandBus(t *testing.T) {
 	}
 
 	t.Log("handle with handler")
-	err = bus.HandleCommand(ctx, command1)
+	err = bus.HandleCommand(ctx, cmd)
 	if err != nil {
 		t.Error("there should be no error:", err)
 	}
-	if handler.Command != command1 {
+	if handler.Command != cmd {
 		t.Error("the handled command should be correct:", handler.Command)
 	}
 	if val, ok := handler.Context.Value("testkey").(string); !ok || val != "testval" {

--- a/commandhandler.go
+++ b/commandhandler.go
@@ -67,39 +67,39 @@ func NewAggregateCommandHandler(repository Repository) (*AggregateCommandHandler
 }
 
 // SetAggregate sets an aggregate as handler for a command.
-func (h *AggregateCommandHandler) SetAggregate(aggregateType AggregateType, commandType CommandType) error {
+func (h *AggregateCommandHandler) SetAggregate(aggregateType AggregateType, cmdType CommandType) error {
 	// Check for already existing handler.
-	if _, ok := h.aggregates[commandType]; ok {
+	if _, ok := h.aggregates[cmdType]; ok {
 		return ErrAggregateAlreadySet
 	}
 
 	// Add aggregate type to command type.
-	h.aggregates[commandType] = aggregateType
+	h.aggregates[cmdType] = aggregateType
 
 	return nil
 }
 
 // HandleCommand handles a command with the registered aggregate.
 // Returns ErrAggregateNotFound if no aggregate could be found.
-func (h *AggregateCommandHandler) HandleCommand(ctx context.Context, command Command) error {
-	err := h.checkCommand(command)
+func (h *AggregateCommandHandler) HandleCommand(ctx context.Context, cmd Command) error {
+	err := h.checkCommand(cmd)
 	if err != nil {
 		return err
 	}
 
-	aggregateType, ok := h.aggregates[command.CommandType()]
+	aggregateType, ok := h.aggregates[cmd.CommandType()]
 	if !ok {
 		return ErrAggregateNotFound
 	}
 
-	aggregate, err := h.repository.Load(ctx, aggregateType, command.AggregateID())
+	aggregate, err := h.repository.Load(ctx, aggregateType, cmd.AggregateID())
 	if err != nil {
 		return err
 	} else if aggregate == nil {
 		return ErrAggregateNotFound
 	}
 
-	if err = aggregate.HandleCommand(ctx, command); err != nil {
+	if err = aggregate.HandleCommand(ctx, cmd); err != nil {
 		return err
 	}
 
@@ -110,8 +110,8 @@ func (h *AggregateCommandHandler) HandleCommand(ctx context.Context, command Com
 	return nil
 }
 
-func (h *AggregateCommandHandler) checkCommand(command Command) error {
-	rv := reflect.Indirect(reflect.ValueOf(command))
+func (h *AggregateCommandHandler) checkCommand(cmd Command) error {
+	rv := reflect.Indirect(reflect.ValueOf(cmd))
 	rt := rv.Type()
 
 	for i := 0; i < rt.NumField(); i++ {

--- a/commandhandler/scheduler/scheduler.go
+++ b/commandhandler/scheduler/scheduler.go
@@ -1,0 +1,96 @@
+// Copyright (c) 2017 - Max Ekman <max@looplab.se>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package scheduler
+
+import (
+	"context"
+	"time"
+
+	eh "github.com/looplab/eventhorizon"
+)
+
+// Command is a scheduled command with an execution time.
+type Command interface {
+	eh.Command
+
+	// ExecuteAt returns the time when the command will execute.
+	ExecuteAt() time.Time
+}
+
+// CommandWithExecuteTime returns a wrapped command with a execution time set.
+func CommandWithExecuteTime(cmd eh.Command, t time.Time) Command {
+	return &command{Command: cmd, t: t}
+}
+
+// private implementation to wrap ordinary commands and add a execution time.
+type command struct {
+	eh.Command
+	t time.Time
+}
+
+// ExecuteAt implements the ExecuteAt method of the Command interface.
+func (c *command) ExecuteAt() time.Time {
+	return c.t
+}
+
+// CommandHandler handles commands either directly or with a delay on a schedule.
+type CommandHandler struct {
+	eh.CommandHandler
+	errCh chan error
+}
+
+// NewCommandHandler creates a CommandHandler.
+func NewCommandHandler(handler eh.CommandHandler) *CommandHandler {
+	return &CommandHandler{
+		CommandHandler: handler,
+		errCh:          make(chan error, 1),
+	}
+}
+
+// Error returns the error channel.
+func (b *CommandHandler) Error() <-chan error {
+	return b.errCh
+}
+
+// HandleCommand implements the HandleCommand method of the
+// eventhorizon.CommandHandler interface.
+func (b *CommandHandler) HandleCommand(ctx context.Context, cmd eh.Command) error {
+	// Delayed command execution.
+	if c, ok := cmd.(Command); ok {
+		go func() {
+			t := time.NewTimer(c.ExecuteAt().Sub(time.Now()))
+			defer t.Stop()
+
+			var err error
+			select {
+			case <-ctx.Done():
+				err = ctx.Err()
+			case <-t.C:
+				err = b.CommandHandler.HandleCommand(ctx, cmd)
+			}
+
+			if err != nil {
+				select {
+				case b.errCh <- err:
+				default:
+				}
+			}
+		}()
+		return nil
+	}
+
+	// Immediate command execution.
+	return b.CommandHandler.HandleCommand(ctx, cmd)
+}

--- a/commandhandler/scheduler/scheduler_test.go
+++ b/commandhandler/scheduler/scheduler_test.go
@@ -1,0 +1,147 @@
+// Copyright (c) 2017 - Max Ekman <max@looplab.se>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package scheduler
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+
+	"golang.org/x/net/context"
+
+	eh "github.com/looplab/eventhorizon"
+	"github.com/looplab/eventhorizon/mocks"
+)
+
+func TestCommandHandler_Immediate(t *testing.T) {
+	h := &mocks.CommandHandler{}
+	sch := NewCommandHandler(h)
+	cmd := mocks.Command{
+		ID:      eh.NewUUID(),
+		Content: "content",
+	}
+	if err := sch.HandleCommand(context.Background(), cmd); err != nil {
+		t.Error("there should be no error:", err)
+	}
+	if !reflect.DeepEqual(h.Command, cmd) {
+		t.Error("the command should have been handled:", cmd)
+	}
+}
+
+func TestCommandHandler_Delayed(t *testing.T) {
+	h := &mocks.CommandHandler{}
+	sch := NewCommandHandler(h)
+	cmd := mocks.Command{
+		ID:      eh.NewUUID(),
+		Content: "content",
+	}
+	c := CommandWithExecuteTime(cmd, time.Now().Add(5*time.Millisecond))
+	if err := sch.HandleCommand(context.Background(), c); err != nil {
+		t.Error("there should be no error:", err)
+	}
+	if h.Command != nil {
+		t.Error("the command should not have been handled yet:", h.Command)
+	}
+	time.Sleep(10 * time.Millisecond)
+	if !reflect.DeepEqual(h.Command, c) {
+		t.Error("the command should have been handled:", h.Command)
+	}
+}
+
+func TestCommandHandler_Errors(t *testing.T) {
+	handlerErr := errors.New("handler error")
+	h := &mocks.CommandHandler{
+		Err: handlerErr,
+	}
+	sch := NewCommandHandler(h)
+	cmd := mocks.Command{
+		ID:      eh.NewUUID(),
+		Content: "content",
+	}
+	c := CommandWithExecuteTime(cmd, time.Now().Add(5*time.Millisecond))
+	if err := sch.HandleCommand(context.Background(), c); err != nil {
+		t.Error("there should be no error:", err)
+	}
+	if h.Command != nil {
+		t.Error("the command should not have been handled yet:", h.Command)
+	}
+	var err error
+	select {
+	case err = <-sch.Error():
+	case <-time.After(10 * time.Millisecond):
+	}
+	if err != handlerErr {
+		t.Error("there should be an error:", err)
+	}
+}
+
+func TestCommandHandler_ContextCanceled(t *testing.T) {
+	handlerErr := errors.New("handler error")
+	h := &mocks.CommandHandler{
+		Err: handlerErr,
+	}
+	sch := NewCommandHandler(h)
+	cmd := mocks.Command{
+		ID:      eh.NewUUID(),
+		Content: "content",
+	}
+	c := CommandWithExecuteTime(cmd, time.Now().Add(5*time.Millisecond))
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := sch.HandleCommand(ctx, c); err != nil {
+		t.Error("there should be no error:", err)
+	}
+	if h.Command != nil {
+		t.Error("the command should not have been handled yet:", h.Command)
+	}
+	var err error
+	select {
+	case err = <-sch.Error():
+	case <-time.After(10 * time.Millisecond):
+	}
+	if err == nil || err.Error() != "context canceled" {
+		t.Error("there should be an error:", err)
+	}
+}
+
+func TestCommandHandler_ContextDeadline(t *testing.T) {
+	handlerErr := errors.New("handler error")
+	h := &mocks.CommandHandler{
+		Err: handlerErr,
+	}
+	sch := NewCommandHandler(h)
+	cmd := mocks.Command{
+		ID:      eh.NewUUID(),
+		Content: "content",
+	}
+	c := CommandWithExecuteTime(cmd, time.Now().Add(5*time.Millisecond))
+	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
+	defer cancel()
+	if err := sch.HandleCommand(ctx, c); err != nil {
+		t.Error("there should be no error:", err)
+	}
+	if h.Command != nil {
+		t.Error("the command should not have been handled yet:", h.Command)
+	}
+	var err error
+	select {
+	case err = <-sch.Error():
+	case <-time.After(10 * time.Millisecond):
+	}
+	if err == nil || err.Error() != "context deadline exceeded" {
+		t.Error("there should be an error:", err)
+	}
+}

--- a/commandhandler_test.go
+++ b/commandhandler_test.go
@@ -47,12 +47,12 @@ func TestCommandHandler(t *testing.T) {
 
 	ctx := context.WithValue(context.Background(), "testkey", "testval")
 
-	command1 := &TestCommand{aggregate.AggregateID(), "command1"}
-	err := handler.HandleCommand(ctx, command1)
+	cmd := &TestCommand{aggregate.AggregateID(), "command1"}
+	err := handler.HandleCommand(ctx, cmd)
 	if err != nil {
 		t.Error("there should be no error:", err)
 	}
-	if aggregate.dispatchedCommand != command1 {
+	if aggregate.dispatchedCommand != cmd {
 		t.Error("the dispatched command should be correct:", aggregate.dispatchedCommand)
 	}
 	if val, ok := aggregate.context.Value("testkey").(string); !ok || val != "testval" {
@@ -72,8 +72,8 @@ func TestCommandHandler_AggregateNotFound(t *testing.T) {
 		t.Fatal("there should be a handler")
 	}
 
-	command := &TestCommand{NewUUID(), "command1"}
-	err = handler.HandleCommand(context.Background(), command)
+	cmd := &TestCommand{NewUUID(), "command1"}
+	err = handler.HandleCommand(context.Background(), cmd)
 	if err != ErrAggregateNotFound {
 		t.Error("there should be a command error:", err)
 	}
@@ -83,12 +83,12 @@ func TestCommandHandler_ErrorInHandler(t *testing.T) {
 	aggregate, handler, _ := createAggregateAndHandler(t)
 
 	aggregate.err = errors.New("command error")
-	command := &TestCommand{aggregate.AggregateID(), "command1"}
-	err := handler.HandleCommand(context.Background(), command)
+	cmd := &TestCommand{aggregate.AggregateID(), "command1"}
+	err := handler.HandleCommand(context.Background(), cmd)
 	if err == nil || err.Error() != "command error" {
 		t.Error("there should be a command error:", err)
 	}
-	if aggregate.dispatchedCommand != command {
+	if aggregate.dispatchedCommand != cmd {
 		t.Error("the dispatched command should be correct:", aggregate.dispatchedCommand)
 	}
 }
@@ -97,8 +97,8 @@ func TestCommandHandler_ErrorWhenSaving(t *testing.T) {
 	aggregate, handler, repo := createAggregateAndHandler(t)
 
 	repo.err = errors.New("save error")
-	command := &TestCommand{aggregate.AggregateID(), "command1"}
-	err := handler.HandleCommand(context.Background(), command)
+	cmd := &TestCommand{aggregate.AggregateID(), "command1"}
+	err := handler.HandleCommand(context.Background(), cmd)
 	if err == nil || err.Error() != "save error" {
 		t.Error("there should be a command error:", err)
 	}
@@ -107,8 +107,8 @@ func TestCommandHandler_ErrorWhenSaving(t *testing.T) {
 func TestCommandHandler_NoHandlers(t *testing.T) {
 	_, handler, _ := createAggregateAndHandler(t)
 
-	command1 := &TestCommand{NewUUID(), "command1"}
-	err := handler.HandleCommand(context.Background(), command1)
+	cmd := &TestCommand{NewUUID(), "command1"}
+	err := handler.HandleCommand(context.Background(), cmd)
 	if err != ErrAggregateNotFound {
 		t.Error("there should be a ErrAggregateNotFound error:", nil)
 	}
@@ -211,9 +211,9 @@ func BenchmarkCommandHandler(b *testing.B) {
 
 	ctx := context.WithValue(context.Background(), "testkey", "testval")
 
-	command1 := &TestCommand{aggregate.AggregateID(), "command1"}
+	cmd := &TestCommand{aggregate.AggregateID(), "command1"}
 	for i := 0; i < b.N; i++ {
-		handler.HandleCommand(ctx, command1)
+		handler.HandleCommand(ctx, cmd)
 	}
 	if aggregate.numHandled != b.N {
 		b.Error("the num handled commands should be correct:", aggregate.numHandled, b.N)

--- a/context_test.go
+++ b/context_test.go
@@ -67,7 +67,7 @@ func TestContextMinVersion(t *testing.T) {
 
 	vals := MarshalContext(ctx)
 	if v, ok := vals[minVersionKeyStr].(int); !ok || v != 8 {
-		t.Error("the marshaled namespace shoud be correct:", v)
+		t.Error("the marshaled min version shoud be correct:", v)
 	}
 	b, err := json.Marshal(vals)
 	if err != nil {
@@ -82,13 +82,13 @@ func TestContextMinVersion(t *testing.T) {
 	}
 	ctx = UnmarshalContext(vals)
 	if v, ok := MinVersionFromContext(ctx); !ok || v != 8 {
-		t.Error("the namespace should be correct:", v)
+		t.Error("the min version should be correct:", v)
 	}
 }
 
 func TestContextMarshaler(t *testing.T) {
 	if len(contextMarshalFuncs) != 2 {
-		t.Error("there should be one context marshaler")
+		t.Error("there should be two context marshalers")
 	}
 	RegisterContextMarshaler(func(ctx context.Context, vals map[string]interface{}) {
 		if val, ok := ContextTestOne(ctx); ok {
@@ -96,7 +96,7 @@ func TestContextMarshaler(t *testing.T) {
 		}
 	})
 	if len(contextMarshalFuncs) != 3 {
-		t.Error("there should be two context marshaler")
+		t.Error("there should be three context marshaler")
 	}
 
 	ctx := context.Background()
@@ -114,7 +114,7 @@ func TestContextMarshaler(t *testing.T) {
 
 func TestContextUnmarshaler(t *testing.T) {
 	if len(contextUnmarshalFuncs) != 2 {
-		t.Error("there should be one context marshaler")
+		t.Error("there should be two context marshalers")
 	}
 	RegisterContextUnmarshaler(func(ctx context.Context, vals map[string]interface{}) context.Context {
 		if val, ok := vals[contextTestKeyOneStr].(string); ok {
@@ -123,7 +123,7 @@ func TestContextUnmarshaler(t *testing.T) {
 		return ctx
 	})
 	if len(contextUnmarshalFuncs) != 3 {
-		t.Error("there should be two context unmarshalers")
+		t.Error("there should be three context unmarshalers")
 	}
 
 	vals := map[string]interface{}{}

--- a/event.go
+++ b/event.go
@@ -127,7 +127,7 @@ func (e event) String() string {
 }
 
 var eventDataFactories = make(map[EventType]func() EventData)
-var registerEventDataMu sync.RWMutex
+var eventDataFactoriesMu sync.RWMutex
 
 // ErrEventDataNotRegistered is when no event data factory was registered.
 var ErrEventDataNotRegistered = errors.New("event data not registered")
@@ -145,8 +145,8 @@ func RegisterEventData(eventType EventType, factory func() EventData) {
 		panic("eventhorizon: attempt to register empty event type")
 	}
 
-	registerEventDataMu.Lock()
-	defer registerEventDataMu.Unlock()
+	eventDataFactoriesMu.Lock()
+	defer eventDataFactoriesMu.Unlock()
 	if _, ok := eventDataFactories[eventType]; ok {
 		panic(fmt.Sprintf("eventhorizon: registering duplicate types for %q", eventType))
 	}
@@ -161,8 +161,8 @@ func UnregisterEventData(eventType EventType) {
 		panic("eventhorizon: attempt to unregister empty event type")
 	}
 
-	registerEventDataMu.Lock()
-	defer registerEventDataMu.Unlock()
+	eventDataFactoriesMu.Lock()
+	defer eventDataFactoriesMu.Unlock()
 	if _, ok := eventDataFactories[eventType]; !ok {
 		panic(fmt.Sprintf("eventhorizon: unregister of non-registered type %q", eventType))
 	}
@@ -172,8 +172,8 @@ func UnregisterEventData(eventType EventType) {
 // CreateEventData creates an event data of a type using the factory registered
 // with RegisterEventData.
 func CreateEventData(eventType EventType) (EventData, error) {
-	registerEventDataMu.RLock()
-	defer registerEventDataMu.RUnlock()
+	eventDataFactoriesMu.RLock()
+	defer eventDataFactoriesMu.RUnlock()
 	if factory, ok := eventDataFactories[eventType]; ok {
 		return factory(), nil
 	}

--- a/eventhandler/saga/saga.go
+++ b/eventhandler/saga/saga.go
@@ -52,13 +52,13 @@ func NewEventHandler(saga Saga, commandBus eh.CommandBus) *EventHandler {
 // HandleEvent implements the HandleEvent method of the EventHandler interface.
 func (h *EventHandler) HandleEvent(ctx context.Context, event eh.Event) error {
 	// Run the saga and collect commands.
-	commands := h.saga.RunSaga(ctx, event)
+	cmds := h.saga.RunSaga(ctx, event)
 
 	// Dispatch commands back on the command bus.
-	for _, command := range commands {
-		if err := h.commandBus.HandleCommand(ctx, command); err != nil {
+	for _, cmd := range cmds {
+		if err := h.commandBus.HandleCommand(ctx, cmd); err != nil {
 			return errors.New("could not handle command '" +
-				string(command.CommandType()) + "' from saga '" +
+				string(cmd.CommandType()) + "' from saga '" +
 				string(h.saga.SagaType()) + "': " + err.Error())
 		}
 	}

--- a/eventhorizon_test.go
+++ b/eventhorizon_test.go
@@ -59,16 +59,16 @@ func NewTestAggregate(id UUID) *TestAggregate {
 	}
 }
 
-func (a *TestAggregate) HandleCommand(ctx context.Context, command Command) error {
-	a.dispatchedCommand = command
+func (a *TestAggregate) HandleCommand(ctx context.Context, cmd Command) error {
+	a.dispatchedCommand = cmd
 	a.context = ctx
 	a.numHandled++
 	if a.err != nil {
 		return a.err
 	}
-	switch command := command.(type) {
+	switch cmd := cmd.(type) {
 	case *TestCommand:
-		a.StoreEvent(TestEventType, &TestEventData{command.Content})
+		a.StoreEvent(TestEventType, &TestEventData{cmd.Content})
 		return nil
 	}
 	return errors.New("couldn't handle command")
@@ -100,16 +100,16 @@ func NewTestAggregate2(id UUID) *TestAggregate2 {
 	}
 }
 
-func (a *TestAggregate2) HandleCommand(ctx context.Context, command Command) error {
-	a.dispatchedCommand = command
+func (a *TestAggregate2) HandleCommand(ctx context.Context, cmd Command) error {
+	a.dispatchedCommand = cmd
 	a.context = ctx
 	a.numHandled++
 	if a.err != nil {
 		return a.err
 	}
-	switch command := command.(type) {
+	switch cmd := cmd.(type) {
 	case *TestCommand2:
-		a.StoreEvent(TestEventType, &TestEvent2Data{command.Content})
+		a.StoreEvent(TestEventType, &TestEvent2Data{cmd.Content})
 		return nil
 	}
 	return errors.New("couldn't handle command")

--- a/examples/domain/aggregate.go
+++ b/examples/domain/aggregate.go
@@ -57,13 +57,13 @@ func NewInvitationAggregate(id eh.UUID) *InvitationAggregate {
 }
 
 // HandleCommand implements the HandleCommand method of the Aggregate interface.
-func (a *InvitationAggregate) HandleCommand(ctx context.Context, command eh.Command) error {
-	switch command := command.(type) {
+func (a *InvitationAggregate) HandleCommand(ctx context.Context, cmd eh.Command) error {
+	switch cmd := cmd.(type) {
 	case *CreateInvite:
 		a.StoreEvent(InviteCreatedEvent,
 			&InviteCreatedData{
-				command.Name,
-				command.Age,
+				cmd.Name,
+				cmd.Age,
 			},
 		)
 		return nil

--- a/mocks/mocks.go
+++ b/mocks/mocks.go
@@ -148,12 +148,17 @@ type SimpleModel struct {
 type CommandHandler struct {
 	Command eh.Command
 	Context context.Context
+	// Used to simulate errors when handling.
+	Err error
 }
 
 // HandleCommand implements the HandleCommand method of the eventhorizon.CommandHandler interface.
-func (t *CommandHandler) HandleCommand(ctx context.Context, cmd eh.Command) error {
-	t.Command = cmd
-	t.Context = ctx
+func (h *CommandHandler) HandleCommand(ctx context.Context, cmd eh.Command) error {
+	if h.Err != nil {
+		return h.Err
+	}
+	h.Command = cmd
+	h.Context = ctx
 	return nil
 }
 

--- a/mocks/mocks.go
+++ b/mocks/mocks.go
@@ -71,11 +71,11 @@ func NewAggregate(id eh.UUID) *Aggregate {
 }
 
 // HandleCommand implements the HandleCommand method of the eventhorizon.Aggregate interface.
-func (a *Aggregate) HandleCommand(ctx context.Context, command eh.Command) error {
+func (a *Aggregate) HandleCommand(ctx context.Context, cmd eh.Command) error {
 	if a.Err != nil {
 		return a.Err
 	}
-	a.Commands = append(a.Commands, command)
+	a.Commands = append(a.Commands, cmd)
 	a.Context = ctx
 	return nil
 }
@@ -151,8 +151,8 @@ type CommandHandler struct {
 }
 
 // HandleCommand implements the HandleCommand method of the eventhorizon.CommandHandler interface.
-func (t *CommandHandler) HandleCommand(ctx context.Context, command eh.Command) error {
-	t.Command = command
+func (t *CommandHandler) HandleCommand(ctx context.Context, cmd eh.Command) error {
+	t.Command = cmd
 	t.Context = ctx
 	return nil
 }
@@ -366,11 +366,11 @@ type CommandBus struct {
 }
 
 // HandleCommand implements the HandleCommand method of the eventhorizon.CommandBus interface.
-func (m *CommandBus) HandleCommand(ctx context.Context, command eh.Command) error {
+func (m *CommandBus) HandleCommand(ctx context.Context, cmd eh.Command) error {
 	if m.Err != nil {
 		return m.Err
 	}
-	m.Commands = append(m.Commands, command)
+	m.Commands = append(m.Commands, cmd)
 	m.Context = ctx
 	return nil
 }


### PR DESCRIPTION
A CommandHandler that will delay command execution based on a delay set in the context.

Fixes #81.

Todo:
- [x] Handle errors that occurs when handling delayed commands.
- [x] Maybe persist commands to not loose data on restarts. See #109.