### PR TITLE
Use CommandHandler in Saga instead of CommandBus

### DIFF
--- a/commandbus/local/commandbus_test.go
+++ b/commandbus/local/commandbus_test.go
@@ -16,6 +16,7 @@ package local
 
 import (
 	"context"
+	"reflect"
 	"testing"
 
 	eh "github.com/looplab/eventhorizon"
@@ -49,8 +50,8 @@ func TestCommandBus(t *testing.T) {
 	if err != nil {
 		t.Error("there should be no error:", err)
 	}
-	if handler.Command != cmd {
-		t.Error("the handled command should be correct:", handler.Command)
+	if !reflect.DeepEqual(handler.Commands, []eh.Command{cmd}) {
+		t.Error("the handled command should be correct:", handler.Commands)
 	}
 	if val, ok := handler.Context.Value("testkey").(string); !ok || val != "testval" {
 		t.Error("the context should be correct:", handler.Context)

--- a/commandhandler/scheduler/scheduler.go
+++ b/commandhandler/scheduler/scheduler.go
@@ -67,8 +67,8 @@ func (b *CommandHandler) Error() <-chan error {
 // HandleCommand implements the HandleCommand method of the
 // eventhorizon.CommandHandler interface.
 func (b *CommandHandler) HandleCommand(ctx context.Context, cmd eh.Command) error {
-	// Delayed command execution.
-	if c, ok := cmd.(Command); ok {
+	// Delayed command execution if there is time set.
+	if c, ok := cmd.(Command); ok && !c.ExecuteAt().IsZero() {
 		go func() {
 			t := time.NewTimer(c.ExecuteAt().Sub(time.Now()))
 			defer t.Stop()

--- a/commandhandler/scheduler/scheduler_test.go
+++ b/commandhandler/scheduler/scheduler_test.go
@@ -36,7 +36,7 @@ func TestCommandHandler_Immediate(t *testing.T) {
 	if err := sch.HandleCommand(context.Background(), cmd); err != nil {
 		t.Error("there should be no error:", err)
 	}
-	if !reflect.DeepEqual(h.Command, cmd) {
+	if !reflect.DeepEqual(h.Commands, []eh.Command{cmd}) {
 		t.Error("the command should have been handled:", cmd)
 	}
 }
@@ -52,12 +52,12 @@ func TestCommandHandler_Delayed(t *testing.T) {
 	if err := sch.HandleCommand(context.Background(), c); err != nil {
 		t.Error("there should be no error:", err)
 	}
-	if h.Command != nil {
-		t.Error("the command should not have been handled yet:", h.Command)
+	if len(h.Commands) != 0 {
+		t.Error("the command should not have been handled yet:", h.Commands)
 	}
 	time.Sleep(10 * time.Millisecond)
-	if !reflect.DeepEqual(h.Command, c) {
-		t.Error("the command should have been handled:", h.Command)
+	if !reflect.DeepEqual(h.Commands, []eh.Command{c}) {
+		t.Error("the command should have been handled:", h.Commands)
 	}
 }
 
@@ -75,8 +75,8 @@ func TestCommandHandler_Errors(t *testing.T) {
 	if err := sch.HandleCommand(context.Background(), c); err != nil {
 		t.Error("there should be no error:", err)
 	}
-	if h.Command != nil {
-		t.Error("the command should not have been handled yet:", h.Command)
+	if len(h.Commands) != 0 {
+		t.Error("the command should not have been handled yet:", h.Commands)
 	}
 	var err error
 	select {
@@ -104,8 +104,8 @@ func TestCommandHandler_ContextCanceled(t *testing.T) {
 	if err := sch.HandleCommand(ctx, c); err != nil {
 		t.Error("there should be no error:", err)
 	}
-	if h.Command != nil {
-		t.Error("the command should not have been handled yet:", h.Command)
+	if len(h.Commands) != 0 {
+		t.Error("the command should not have been handled yet:", h.Commands)
 	}
 	var err error
 	select {
@@ -133,8 +133,8 @@ func TestCommandHandler_ContextDeadline(t *testing.T) {
 	if err := sch.HandleCommand(ctx, c); err != nil {
 		t.Error("there should be no error:", err)
 	}
-	if h.Command != nil {
-		t.Error("the command should not have been handled yet:", h.Command)
+	if len(h.Commands) != 0 {
+		t.Error("the command should not have been handled yet:", h.Commands)
 	}
 	var err error
 	select {

--- a/commandhandler/scheduler/scheduler_test.go
+++ b/commandhandler/scheduler/scheduler_test.go
@@ -37,7 +37,7 @@ func TestCommandHandler_Immediate(t *testing.T) {
 		t.Error("there should be no error:", err)
 	}
 	if !reflect.DeepEqual(h.Commands, []eh.Command{cmd}) {
-		t.Error("the command should have been handled:", cmd)
+		t.Error("the command should have been handled:", h.Commands)
 	}
 }
 
@@ -56,6 +56,22 @@ func TestCommandHandler_Delayed(t *testing.T) {
 		t.Error("the command should not have been handled yet:", h.Commands)
 	}
 	time.Sleep(10 * time.Millisecond)
+	if !reflect.DeepEqual(h.Commands, []eh.Command{c}) {
+		t.Error("the command should have been handled:", h.Commands)
+	}
+}
+
+func TestCommandHandler_ZeroTime(t *testing.T) {
+	h := &mocks.CommandHandler{}
+	sch := NewCommandHandler(h)
+	cmd := mocks.Command{
+		ID:      eh.NewUUID(),
+		Content: "content",
+	}
+	c := CommandWithExecuteTime(cmd, time.Time{})
+	if err := sch.HandleCommand(context.Background(), c); err != nil {
+		t.Error("there should be no error:", err)
+	}
 	if !reflect.DeepEqual(h.Commands, []eh.Command{c}) {
 		t.Error("the command should have been handled:", h.Commands)
 	}

--- a/eventhandler/saga/saga.go
+++ b/eventhandler/saga/saga.go
@@ -37,15 +37,15 @@ type Type string
 
 // EventHandler is a CQRS saga handler to run a Saga implementation.
 type EventHandler struct {
-	saga       Saga
-	commandBus eh.CommandBus
+	saga           Saga
+	commandHandler eh.CommandHandler
 }
 
 // NewEventHandler creates a new EventHandler.
-func NewEventHandler(saga Saga, commandBus eh.CommandBus) *EventHandler {
+func NewEventHandler(saga Saga, commandHandler eh.CommandHandler) *EventHandler {
 	return &EventHandler{
-		saga:       saga,
-		commandBus: commandBus,
+		saga:           saga,
+		commandHandler: commandHandler,
 	}
 }
 
@@ -56,7 +56,7 @@ func (h *EventHandler) HandleEvent(ctx context.Context, event eh.Event) error {
 
 	// Dispatch commands back on the command bus.
 	for _, cmd := range cmds {
-		if err := h.commandBus.HandleCommand(ctx, cmd); err != nil {
+		if err := h.commandHandler.HandleCommand(ctx, cmd); err != nil {
 			return errors.New("could not handle command '" +
 				string(cmd.CommandType()) + "' from saga '" +
 				string(h.saga.SagaType()) + "': " + err.Error())

--- a/eventhandler/saga/saga_test.go
+++ b/eventhandler/saga/saga_test.go
@@ -24,11 +24,11 @@ import (
 )
 
 func TestEventHandler(t *testing.T) {
-	commandBus := &mocks.CommandBus{
+	commandHandler := &mocks.CommandHandler{
 		Commands: []eh.Command{},
 	}
 	saga := &TestSaga{}
-	handler := NewEventHandler(saga, commandBus)
+	handler := NewEventHandler(saga, commandHandler)
 
 	ctx := context.Background()
 
@@ -40,8 +40,8 @@ func TestEventHandler(t *testing.T) {
 	if saga.event != event {
 		t.Error("the handled event should be correct:", saga.event)
 	}
-	if !reflect.DeepEqual(commandBus.Commands, saga.commands) {
-		t.Error("the produced commands should be correct:", commandBus.Commands)
+	if !reflect.DeepEqual(commandHandler.Commands, saga.commands) {
+		t.Error("the produced commands should be correct:", commandHandler.Commands)
 	}
 }
 

--- a/mocks/mocks.go
+++ b/mocks/mocks.go
@@ -146,8 +146,8 @@ type SimpleModel struct {
 
 // CommandHandler is a mocked eventhorizon.CommandHandler, useful in testing.
 type CommandHandler struct {
-	Command eh.Command
-	Context context.Context
+	Commands []eh.Command
+	Context  context.Context
 	// Used to simulate errors when handling.
 	Err error
 }
@@ -157,7 +157,7 @@ func (h *CommandHandler) HandleCommand(ctx context.Context, cmd eh.Command) erro
 	if h.Err != nil {
 		return h.Err
 	}
-	h.Command = cmd
+	h.Commands = append(h.Commands, cmd)
 	h.Context = ctx
 	return nil
 }
@@ -359,29 +359,6 @@ func (m *EventStore) Replace(ctx context.Context, event eh.Event) error {
 	}
 	m.Events = []eh.Event{event}
 	m.Context = ctx
-	return nil
-}
-
-// CommandBus is a mocked eventhorizon.CommandBus, useful in testing.
-type CommandBus struct {
-	Commands []eh.Command
-	Context  context.Context
-	// Used to simulate errors in the store.
-	Err error
-}
-
-// HandleCommand implements the HandleCommand method of the eventhorizon.CommandBus interface.
-func (m *CommandBus) HandleCommand(ctx context.Context, cmd eh.Command) error {
-	if m.Err != nil {
-		return m.Err
-	}
-	m.Commands = append(m.Commands, cmd)
-	m.Context = ctx
-	return nil
-}
-
-// SetHandler implements the SetHandler method of the eventhorizon.CommandBus interface.
-func (m *CommandBus) SetHandler(handler eh.CommandHandler, commandType eh.CommandType) error {
 	return nil
 }
 

--- a/mocks/mocks_test.go
+++ b/mocks/mocks_test.go
@@ -84,12 +84,6 @@ func TestMocks(t *testing.T) {
 		t.Error("the mocked event store is incorrect")
 	}
 
-	var commandBus interface{}
-	commandBus = &CommandBus{}
-	if _, ok := commandBus.(eh.CommandBus); !ok {
-		t.Error("the mocked command bus is incorrect")
-	}
-
 	var eventBus interface{}
 	eventBus = &EventBus{}
 	if _, ok := eventBus.(eh.EventBus); !ok {


### PR DESCRIPTION
Enables wrapping the CommandHandler in sagas with middleware, like the command scheduler.