### PR TITLE
EventStore.Load only using AggregateID to load events for Aggregate

### DIFF
--- a/aggregate.go
+++ b/aggregate.go
@@ -25,7 +25,7 @@ import (
 type AggregateType string
 
 // Aggregate is an interface representing a versioned data entity created from
-// events. It receives commands and generates evens that are stored.
+// events. It receives commands and generates events that are stored.
 //
 // The aggregate is created/loaded and saved by the Repository inside the
 // Dispatcher. A domain specific aggregate can either implement the full interface,
@@ -55,7 +55,7 @@ type Aggregate interface {
 	ClearUncommittedEvents()
 
 	// ApplyEvent applies an event on the aggregate by setting its values.
-	// If there are no errors the version shoudl be incremented by calling
+	// If there are no errors the version should be incremented by calling
 	// IncrementVersion.
 	ApplyEvent(context.Context, Event) error
 }
@@ -75,7 +75,7 @@ func RegisterAggregate(factory func(UUID) Aggregate) {
 	// TODO: Explore the use of reflect/gob for creating concrete types without
 	// a factory func.
 
-	// Check that the created aggregate matches the type registered.
+	// Check that the created aggregate matches the registered type.
 	aggregate := factory(NewUUID())
 	if aggregate == nil {
 		panic("eventhorizon: created aggregate is nil")

--- a/aggregatebase.go
+++ b/aggregatebase.go
@@ -39,7 +39,7 @@ package eventhorizon
 //   }
 //
 // The aggregate must return an error if the event can not be applied, or nil
-// to signal success which will increment the version.
+// to signal success (which will increment the version).
 //   func (a *Aggregate) ApplyEvent(event Event) error {
 //       switch event.EventType() {
 //       case AddUserEvent:

--- a/eventhorizon_test.go
+++ b/eventhorizon_test.go
@@ -193,7 +193,7 @@ func (m *MockEventStore) Save(ctx context.Context, events []Event, originalVersi
 	return nil
 }
 
-func (m *MockEventStore) Load(ctx context.Context, aggregateType AggregateType, id UUID) ([]Event, error) {
+func (m *MockEventStore) Load(ctx context.Context, id UUID) ([]Event, error) {
 	if m.err != nil {
 		return nil, m.err
 	}

--- a/eventstore.go
+++ b/eventstore.go
@@ -53,7 +53,7 @@ type EventStore interface {
 	Save(ctx context.Context, events []Event, originalVersion int) error
 
 	// Load loads all events for the aggregate id from the store.
-	Load(context.Context, AggregateType, UUID) ([]Event, error)
+	Load(context.Context, UUID) ([]Event, error)
 }
 
 // EventStoreMaintainer is an interface for a maintainer of an EventStore.

--- a/eventstore/dynamodb/eventstore.go
+++ b/eventstore/dynamodb/eventstore.go
@@ -165,7 +165,7 @@ func (s *EventStore) Save(ctx context.Context, events []eh.Event, originalVersio
 }
 
 // Load implements the Load method of the eventhorizon.EventStore interface.
-func (s *EventStore) Load(ctx context.Context, aggregateType eh.AggregateType, id eh.UUID) ([]eh.Event, error) {
+func (s *EventStore) Load(ctx context.Context, id eh.UUID) ([]eh.Event, error) {
 	params := &dynamodb.QueryInput{
 		TableName:              aws.String(s.tableName(ctx)),
 		KeyConditionExpression: aws.String("AggregateID = :id"),

--- a/eventstore/memory/eventstore.go
+++ b/eventstore/memory/eventstore.go
@@ -115,7 +115,7 @@ func (s *EventStore) Save(ctx context.Context, events []eh.Event, originalVersio
 }
 
 // Load implements the Load method of the eventhorizon.EventStore interface.
-func (s *EventStore) Load(ctx context.Context, aggregateType eh.AggregateType, id eh.UUID) ([]eh.Event, error) {
+func (s *EventStore) Load(ctx context.Context, id eh.UUID) ([]eh.Event, error) {
 	s.dbMu.RLock()
 	defer s.dbMu.RUnlock()
 

--- a/eventstore/mongodb/eventstore.go
+++ b/eventstore/mongodb/eventstore.go
@@ -164,7 +164,6 @@ func (s *EventStore) Save(ctx context.Context, events []eh.Event, originalVersio
 }
 
 // Load implements the Load method of the eventhorizon.EventStore interface.
-// Load implements the Load method of the eventhorizon.EventStore interface.
 func (s *EventStore) Load(ctx context.Context, aggregateType eh.AggregateType, id eh.UUID) ([]eh.Event, error) {
 	sess := s.session.Copy()
 	defer sess.Close()

--- a/eventstore/mongodb/eventstore.go
+++ b/eventstore/mongodb/eventstore.go
@@ -164,7 +164,7 @@ func (s *EventStore) Save(ctx context.Context, events []eh.Event, originalVersio
 }
 
 // Load implements the Load method of the eventhorizon.EventStore interface.
-func (s *EventStore) Load(ctx context.Context, aggregateType eh.AggregateType, id eh.UUID) ([]eh.Event, error) {
+func (s *EventStore) Load(ctx context.Context, id eh.UUID) ([]eh.Event, error) {
 	sess := s.session.Copy()
 	defer sess.Close()
 

--- a/eventstore/testutil/common_tests.go
+++ b/eventstore/testutil/common_tests.go
@@ -97,7 +97,7 @@ func EventStoreCommonTests(t *testing.T, ctx context.Context, store eh.EventStor
 	savedEvents = append(savedEvents, event7)
 
 	t.Log("load events for non-existing aggregate")
-	events, err := store.Load(ctx, mocks.AggregateType, eh.NewUUID())
+	events, err := store.Load(ctx, eh.NewUUID())
 	if err != nil {
 		t.Error("there should be no error:", err)
 	}
@@ -106,7 +106,7 @@ func EventStoreCommonTests(t *testing.T, ctx context.Context, store eh.EventStor
 	}
 
 	t.Log("load events")
-	events, err = store.Load(ctx, mocks.AggregateType, id)
+	events, err = store.Load(ctx, id)
 	if err != nil {
 		t.Error("there should be no error:", err)
 	}
@@ -126,7 +126,7 @@ func EventStoreCommonTests(t *testing.T, ctx context.Context, store eh.EventStor
 	}
 
 	t.Log("load events for another aggregate")
-	events, err = store.Load(ctx, mocks.AggregateType, id2)
+	events, err = store.Load(ctx, id2)
 	if err != nil {
 		t.Error("there should be no error:", err)
 	}
@@ -180,7 +180,7 @@ func EventStoreMaintainerCommonTests(t *testing.T, ctx context.Context, store eh
 	if err := store.Replace(ctx, event2Mod); err != nil {
 		t.Error("there should be no error:", err)
 	}
-	events, err := store.Load(ctx, mocks.AggregateType, id)
+	events, err := store.Load(ctx, id)
 	if err != nil {
 		t.Error("there should be no error:", err)
 	}
@@ -216,7 +216,7 @@ func EventStoreMaintainerCommonTests(t *testing.T, ctx context.Context, store eh
 	if err := store.RenameEvent(ctx, oldEventType, newEventType); err != nil {
 		t.Error("there should be no error:", err)
 	}
-	events, err = store.Load(ctx, mocks.AggregateType, id1)
+	events, err = store.Load(ctx, id1)
 	if err != nil {
 		t.Error("there should be no error:", err)
 	}
@@ -227,7 +227,7 @@ func EventStoreMaintainerCommonTests(t *testing.T, ctx context.Context, store eh
 	if err := mocks.CompareEvents(events[0], newEvent1); err != nil {
 		t.Error("the event was incorrect:", err)
 	}
-	events, err = store.Load(ctx, mocks.AggregateType, id2)
+	events, err = store.Load(ctx, id2)
 	if err != nil {
 		t.Error("there should be no error:", err)
 	}

--- a/eventstore/trace/eventstore_test.go
+++ b/eventstore/trace/eventstore_test.go
@@ -74,7 +74,7 @@ func TestEventStore(t *testing.T) {
 	}
 
 	t.Log("load events without tracing")
-	events, err := store.Load(ctx, event1.AggregateType(), event1.AggregateID())
+	events, err := store.Load(ctx, event1.AggregateID())
 	if err != nil {
 		t.Error("there should be no error:", err)
 	}

--- a/examples/domain/logger.go
+++ b/examples/domain/logger.go
@@ -24,7 +24,7 @@ import (
 // Logger is a simple event handler for logging all events.
 type Logger struct{}
 
-// Notify implements the HandleEvent method of the EventHandler interface.
+// Notify implements the Notify method of the EventObserver interface.
 func (l *Logger) Notify(ctx context.Context, event eh.Event) error {
 	log.Println("event:", event)
 	return nil

--- a/mocks/mocks.go
+++ b/mocks/mocks.go
@@ -343,7 +343,7 @@ func (m *EventStore) Save(ctx context.Context, events []eh.Event, originalVersio
 }
 
 // Load implements the Load method of the eventhorizon.EventStore interface.
-func (m *EventStore) Load(ctx context.Context, aggregateType eh.AggregateType, id eh.UUID) ([]eh.Event, error) {
+func (m *EventStore) Load(ctx context.Context, id eh.UUID) ([]eh.Event, error) {
 	if m.Err != nil {
 		return nil, m.Err
 	}

--- a/repository.go
+++ b/repository.go
@@ -87,7 +87,7 @@ func (r *EventSourcingRepository) Load(ctx context.Context, aggregateType Aggreg
 	}
 
 	// Load aggregate events.
-	events, err := r.eventStore.Load(ctx, aggregate.AggregateType(), aggregate.AggregateID())
+	events, err := r.eventStore.Load(ctx, aggregate.AggregateID())
 	if err != nil {
 		return nil, err
 	}

--- a/repository_test.go
+++ b/repository_test.go
@@ -147,7 +147,7 @@ func TestEventSourcingRepository_SaveEvents(t *testing.T) {
 		t.Error("there should be no error:", err)
 	}
 
-	events, err := store.Load(ctx, TestAggregateType, id)
+	events, err := store.Load(ctx, id)
 	if err != nil {
 		t.Error("there should be no error:", err)
 	}

--- a/utils/eventwaiter.go
+++ b/utils/eventwaiter.go
@@ -51,7 +51,7 @@ func (w *EventWaiter) Notify(ctx context.Context, event eh.Event) error {
 // interesting events by analysing the event data.
 func (w *EventWaiter) Wait(ctx context.Context, match func(eh.Event) bool) (eh.Event, error) {
 	id := eh.NewUUID()
-	ch := make(chan eh.Event, 1) // Use bufferd chan to not block other waits.
+	ch := make(chan eh.Event, 1) // Use buffered chan to not block other waits.
 
 	// Add us to the in-flight waits and make sure we get removed when done.
 	w.waitsMu.Lock()


### PR DESCRIPTION
This resolves #123 and updates documentation.