### PR TITLE
resolves #125 (use project ID from application credentials file)

### DIFF
--- a/publisher/gcp/publisher_test.go
+++ b/publisher/gcp/publisher_test.go
@@ -68,19 +68,18 @@ func TestEventBusAsync(t *testing.T) {
 
 // setUpEventPublisher is a helper that creates a new GCP publisher for @appID
 func setUpEventPublisher(appID string) (*EventPublisher, error) {
-	var projectID = "looplab-eventhorizon"
+	projectID := "looplab-eventhorizon"
 
 	// See https://developers.google.com/identity/protocols/application-default-credentials
 	if creds := os.Getenv("GOOGLE_APPLICATION_CREDENTIALS"); creds != "" {
-		var m = make(map[string]string)
-
 		r, err := os.Open(creds)
 		if err != nil {
 			return nil, fmt.Errorf("unable to read credentials file: %s", err)
 		}
 		defer r.Close()
 
-		if err = json.NewDecoder(r).Decode(&m); err != nil {
+		m := map[string]string{}
+		if err := json.NewDecoder(r).Decode(&m); err != nil {
 			return nil, fmt.Errorf("unable to decode %s: %s", creds, err)
 		} else if projectID = m["project_id"]; projectID == "" {
 			return nil, fmt.Errorf("project_id key not found in %s", creds)

--- a/publisher/gcp/publisher_test.go
+++ b/publisher/gcp/publisher_test.go
@@ -15,6 +15,9 @@
 package gcp
 
 import (
+	"encoding/json"
+	"fmt"
+	"os"
 	"testing"
 
 	eh "github.com/looplab/eventhorizon"
@@ -22,13 +25,13 @@ import (
 )
 
 func TestEventBus(t *testing.T) {
-	publisher1, err := NewEventPublisher("looplab-eventhorizon", "test")
+	publisher1, err := setUpEventPublisher("test")
 	if err != nil {
 		t.Fatal("there should be no error:", err)
 	}
 	defer publisher1.Close()
 
-	publisher2, err := NewEventPublisher("looplab-eventhorizon", "test")
+	publisher2, err := setUpEventPublisher("test")
 	if err != nil {
 		t.Fatal("there should be no error:", err)
 	}
@@ -42,14 +45,14 @@ func TestEventBus(t *testing.T) {
 }
 
 func TestEventBusAsync(t *testing.T) {
-	publisher1, err := NewEventPublisher("looplab-eventhorizon", "test")
+	publisher1, err := setUpEventPublisher("test")
 	if err != nil {
 		t.Fatal("there should be no error:", err)
 	}
 	defer publisher1.Close()
 	publisher1.SetHandlingStrategy(eh.AsyncEventHandlingStrategy)
 
-	publisher2, err := NewEventPublisher("looplab-eventhorizon", "test")
+	publisher2, err := setUpEventPublisher("test")
 	if err != nil {
 		t.Fatal("there should be no error:", err)
 	}
@@ -61,4 +64,27 @@ func TestEventBusAsync(t *testing.T) {
 	<-publisher2.ready
 
 	testutil.EventPublisherCommonTests(t, publisher1, publisher2)
+}
+
+// setUpEventPublisher is a helper that creates a new GCP publisher for @appID
+func setUpEventPublisher(appID string) (*EventPublisher, error) {
+	var projectID = "looplab-eventhorizon"
+
+	// See https://developers.google.com/identity/protocols/application-default-credentials
+	if creds := os.Getenv("GOOGLE_APPLICATION_CREDENTIALS"); creds != "" {
+		var m = make(map[string]string)
+
+		r, err := os.Open(creds)
+		if err != nil {
+			return nil, fmt.Errorf("unable to read credentials file: %s", err)
+		}
+		defer r.Close()
+
+		if err = json.NewDecoder(r).Decode(&m); err != nil {
+			return nil, fmt.Errorf("unable to decode %s: %s", creds, err)
+		} else if projectID = m["project_id"]; projectID == "" {
+			return nil, fmt.Errorf("project_id key not found in %s", creds)
+		}
+	}
+	return NewEventPublisher(projectID, appID)
 }


### PR DESCRIPTION
This extracts the `project_id` from the existing `GOOGLE_APPLICATION_CREDENTIALS` file, throwing an error if the file does not exist or is malformed (in this case the test would fail anyway).