### PR TITLE
Issue-129 / Remove use of time.Now()

### DIFF
--- a/aggregate.go
+++ b/aggregate.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"time"
 )
 
 // AggregateType is the type of an aggregate.
@@ -47,7 +48,7 @@ type Aggregate interface {
 	CommandHandler
 
 	// StoreEvent creates and stores a new event as uncommitted for the aggregate.
-	StoreEvent(EventType, EventData) Event
+	StoreEvent(EventType, EventData, time.Time) Event
 	// UncommittedEvents gets all uncommitted events to commit to the store.
 	UncommittedEvents() []Event
 	// ClearUncommittedEvents clears all uncommitted events after committing to

--- a/aggregatebase.go
+++ b/aggregatebase.go
@@ -14,6 +14,8 @@
 
 package eventhorizon
 
+import "time"
+
 // AggregateBase is a CQRS aggregate base to embed in domain specific aggregates.
 //
 // A typical aggregate example:
@@ -87,9 +89,9 @@ func (a *AggregateBase) IncrementVersion() {
 }
 
 // StoreEvent implements the StoreEvent method of the Aggregate interface.
-func (a *AggregateBase) StoreEvent(eventType EventType, data EventData) Event {
+func (a *AggregateBase) StoreEvent(eventType EventType, data EventData, timestamp time.Time) Event {
 	version := a.Version() + len(a.uncommittedEvents) + 1
-	e := NewEventForAggregate(eventType, data,
+	e := NewEventForAggregate(eventType, data, timestamp,
 		a.AggregateType(), a.AggregateID(), version)
 
 	a.uncommittedEvents = append(a.uncommittedEvents, e)

--- a/aggregatebase_test.go
+++ b/aggregatebase_test.go
@@ -17,6 +17,7 @@ package eventhorizon
 import (
 	"reflect"
 	"testing"
+	"time"
 )
 
 func TestNewAggregateBase(t *testing.T) {
@@ -51,14 +52,15 @@ func TestAggregateVersion(t *testing.T) {
 func TestAggregateEvents(t *testing.T) {
 	id := NewUUID()
 	agg := NewTestAggregate(id)
-	event1 := agg.StoreEvent(TestEventType, &TestEventData{"event1"})
+	timestamp := time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)
+	event1 := agg.StoreEvent(TestEventType, &TestEventData{"event1"}, timestamp)
 	if event1.EventType() != TestEventType {
 		t.Error("the event type should be correct:", event1.EventType())
 	}
 	if !reflect.DeepEqual(event1.Data(), &TestEventData{"event1"}) {
 		t.Error("the data should be correct:", event1.Data())
 	}
-	if event1.Timestamp().IsZero() {
+	if !event1.Timestamp().Equal(timestamp) {
 		t.Error("the timestamp should not be zero:", event1.Timestamp())
 	}
 	if event1.Version() != 1 {
@@ -81,7 +83,7 @@ func TestAggregateEvents(t *testing.T) {
 		t.Error("the stored event should be correct:", events[0])
 	}
 
-	event2 := agg.StoreEvent(TestEventType, &TestEventData{"event1"})
+	event2 := agg.StoreEvent(TestEventType, &TestEventData{"event1"}, timestamp)
 	if event2.Version() != 2 {
 		t.Error("the version should be 2:", event2.Version())
 	}
@@ -91,14 +93,14 @@ func TestAggregateEvents(t *testing.T) {
 	if len(events) != 0 {
 		t.Error("there should be no events stored:", len(events))
 	}
-	event3 := agg.StoreEvent(TestEventType, &TestEventData{"event1"})
+	event3 := agg.StoreEvent(TestEventType, &TestEventData{"event1"}, timestamp)
 	if event3.Version() != 1 {
 		t.Error("the version should be 1 after clearing uncommitted events (without applying any):", event3.Version())
 	}
 
 	agg = NewTestAggregate(NewUUID())
-	event1 = agg.StoreEvent(TestEventType, &TestEventData{"event1"})
-	event2 = agg.StoreEvent(TestEventType, &TestEventData{"event2"})
+	event1 = agg.StoreEvent(TestEventType, &TestEventData{"event1"}, timestamp)
+	event2 = agg.StoreEvent(TestEventType, &TestEventData{"event2"}, timestamp)
 	events = agg.UncommittedEvents()
 	if len(events) != 2 {
 		t.Fatal("there should be 2 events stored:", len(events))

--- a/commandbus/local/commandbus_test.go
+++ b/commandbus/local/commandbus_test.go
@@ -32,7 +32,7 @@ func TestCommandBus(t *testing.T) {
 	ctx := context.WithValue(context.Background(), "testkey", "testval")
 
 	t.Log("handle with no handler")
-	cmd := &mocks.Command{eh.NewUUID(), "command1"}
+	cmd := &mocks.Command{ID: eh.NewUUID(), Content: "command1"}
 	err := bus.HandleCommand(ctx, cmd)
 	if err != eh.ErrHandlerNotFound {
 		t.Error("there should be a ErrHandlerNotFound error:", err)

--- a/event.go
+++ b/event.go
@@ -57,22 +57,22 @@ type Event interface {
 }
 
 // NewEvent creates a new event with a type and data, setting its timestamp.
-func NewEvent(eventType EventType, data EventData) Event {
+func NewEvent(eventType EventType, data EventData, timestamp time.Time) Event {
 	return event{
 		eventType: eventType,
 		data:      data,
-		timestamp: time.Now(),
+		timestamp: timestamp,
 	}
 }
 
 // NewEventForAggregate creates a new event with a type and data, setting its
 // timestamp. It also sets the aggregate data on it.
-func NewEventForAggregate(eventType EventType, data EventData,
+func NewEventForAggregate(eventType EventType, data EventData, timestamp time.Time,
 	aggregateType AggregateType, aggregateID UUID, version int) Event {
 	return event{
 		eventType:     eventType,
 		data:          data,
-		timestamp:     time.Now(),
+		timestamp:     timestamp,
 		aggregateType: aggregateType,
 		aggregateID:   aggregateID,
 		version:       version,

--- a/event_test.go
+++ b/event_test.go
@@ -17,17 +17,19 @@ package eventhorizon
 import (
 	"reflect"
 	"testing"
+	"time"
 )
 
 func TestNewEvent(t *testing.T) {
-	event := NewEvent(TestEventType, &TestEventData{"event1"})
+	timestamp := time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)
+	event := NewEvent(TestEventType, &TestEventData{"event1"}, timestamp)
 	if event.EventType() != TestEventType {
 		t.Error("the event type should be correct:", event.EventType())
 	}
 	if !reflect.DeepEqual(event.Data(), &TestEventData{"event1"}) {
 		t.Error("the data should be correct:", event.Data())
 	}
-	if event.Timestamp().IsZero() {
+	if !event.Timestamp().Equal(timestamp) {
 		t.Error("the timestamp should not be zero:", event.Timestamp())
 	}
 	if event.Version() != 0 {
@@ -38,7 +40,7 @@ func TestNewEvent(t *testing.T) {
 	}
 
 	id := NewUUID()
-	event = NewEventForAggregate(TestEventType, &TestEventData{"event1"},
+	event = NewEventForAggregate(TestEventType, &TestEventData{"event1"}, timestamp,
 		TestAggregateType, id, 3)
 	if event.EventType() != TestEventType {
 		t.Error("the event type should be correct:", event.EventType())
@@ -46,7 +48,7 @@ func TestNewEvent(t *testing.T) {
 	if !reflect.DeepEqual(event.Data(), &TestEventData{"event1"}) {
 		t.Error("the data should be correct:", event.Data())
 	}
-	if event.Timestamp().IsZero() {
+	if !event.Timestamp().Equal(timestamp) {
 		t.Error("the timestamp should not be zero:", event.Timestamp())
 	}
 	if event.AggregateType() != TestAggregateType {

--- a/eventbus/local/eventbus_test.go
+++ b/eventbus/local/eventbus_test.go
@@ -50,7 +50,7 @@ func EventBusCommonTests(t *testing.T, async bool) {
 	// Publish event without handler.
 	id, _ := eh.ParseUUID("c1138e5f-f6fb-4dd0-8e79-255c6c8d3756")
 	timestamp := time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)
-	event1 := eh.NewEventForAggregate(mocks.EventType, &mocks.EventData{"event1"}, timestamp,
+	event1 := eh.NewEventForAggregate(mocks.EventType, &mocks.EventData{Content: "event1"}, timestamp,
 		mocks.AggregateType, id, 1)
 	if err := bus.HandleEvent(ctx, event1); err != nil {
 		t.Error("there should be no error:", err)

--- a/eventbus/local/eventbus_test.go
+++ b/eventbus/local/eventbus_test.go
@@ -17,6 +17,7 @@ package local
 import (
 	"context"
 	"testing"
+	"time"
 
 	eh "github.com/looplab/eventhorizon"
 	"github.com/looplab/eventhorizon/mocks"
@@ -48,7 +49,8 @@ func EventBusCommonTests(t *testing.T, async bool) {
 
 	// Publish event without handler.
 	id, _ := eh.ParseUUID("c1138e5f-f6fb-4dd0-8e79-255c6c8d3756")
-	event1 := eh.NewEventForAggregate(mocks.EventType, &mocks.EventData{"event1"},
+	timestamp := time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)
+	event1 := eh.NewEventForAggregate(mocks.EventType, &mocks.EventData{"event1"}, timestamp,
 		mocks.AggregateType, id, 1)
 	if err := bus.HandleEvent(ctx, event1); err != nil {
 		t.Error("there should be no error:", err)
@@ -101,7 +103,7 @@ func EventBusCommonTests(t *testing.T, async bool) {
 
 	// Publish another event.
 	bus.AddHandler(handler, mocks.EventOtherType)
-	event2 := eh.NewEventForAggregate(mocks.EventOtherType, nil,
+	event2 := eh.NewEventForAggregate(mocks.EventOtherType, nil, timestamp,
 		mocks.AggregateType, id, 1)
 	if err := bus.HandleEvent(ctx, event2); err != nil {
 		t.Error("there should be no error:", err)

--- a/eventhandler/projector/projector_test.go
+++ b/eventhandler/projector/projector_test.go
@@ -38,8 +38,10 @@ func TestEventHandler_CreateModel(t *testing.T) {
 
 	// Driver creates item.
 	id := eh.NewUUID()
-	eventData := &mocks.EventData{"event1"}
-	event := eh.NewEventForAggregate(mocks.EventType, eventData, mocks.AggregateType, id, 1)
+	eventData := &mocks.EventData{Content: "event1"}
+	timestamp := time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)
+	event := eh.NewEventForAggregate(mocks.EventType, eventData, timestamp,
+		mocks.AggregateType, id, 1)
 	item := &mocks.SimpleModel{
 		ID: id,
 	}
@@ -72,8 +74,10 @@ func TestEventHandler_UpdateModel(t *testing.T) {
 	ctx := context.Background()
 
 	id := eh.NewUUID()
-	eventData := &mocks.EventData{"event1"}
-	event := eh.NewEventForAggregate(mocks.EventType, eventData, mocks.AggregateType, id, 1)
+	eventData := &mocks.EventData{Content: "event1"}
+	timestamp := time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)
+	event := eh.NewEventForAggregate(mocks.EventType, eventData, timestamp,
+		mocks.AggregateType, id, 1)
 	item := &mocks.SimpleModel{
 		ID: id,
 	}
@@ -107,8 +111,10 @@ func TestEventHandler_UpdateModelWithVersion(t *testing.T) {
 	ctx := context.Background()
 
 	id := eh.NewUUID()
-	eventData := &mocks.EventData{"event1"}
-	event := eh.NewEventForAggregate(mocks.EventType, eventData, mocks.AggregateType, id, 1)
+	eventData := &mocks.EventData{Content: "event1"}
+	timestamp := time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)
+	event := eh.NewEventForAggregate(mocks.EventType, eventData, timestamp,
+		mocks.AggregateType, id, 1)
 	item := &mocks.Model{
 		ID: id,
 	}
@@ -143,8 +149,10 @@ func TestEventHandler_UpdateModelWithEventsOutOfOrder(t *testing.T) {
 	ctx := context.Background()
 
 	id := eh.NewUUID()
-	eventData := &mocks.EventData{"event1"}
-	event := eh.NewEventForAggregate(mocks.EventType, eventData, mocks.AggregateType, id, 3)
+	eventData := &mocks.EventData{Content: "event1"}
+	timestamp := time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)
+	event := eh.NewEventForAggregate(mocks.EventType, eventData, timestamp,
+		mocks.AggregateType, id, 3)
 	item := &mocks.Model{
 		ID:      id,
 		Version: 1,
@@ -190,8 +198,10 @@ func TestEventHandler_DeleteModel(t *testing.T) {
 	ctx := context.Background()
 
 	id := eh.NewUUID()
-	eventData := &mocks.EventData{"event1"}
-	event := eh.NewEventForAggregate(mocks.EventType, eventData, mocks.AggregateType, id, 1)
+	eventData := &mocks.EventData{Content: "event1"}
+	timestamp := time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)
+	event := eh.NewEventForAggregate(mocks.EventType, eventData, timestamp,
+		mocks.AggregateType, id, 1)
 	item := &mocks.SimpleModel{
 		ID: id,
 	}
@@ -223,8 +233,10 @@ func TestEventHandler_LoadError(t *testing.T) {
 
 	// Driver creates item.
 	id := eh.NewUUID()
-	eventData := &mocks.EventData{"event1"}
-	event := eh.NewEventForAggregate(mocks.EventType, eventData, mocks.AggregateType, id, 1)
+	eventData := &mocks.EventData{Content: "event1"}
+	timestamp := time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)
+	event := eh.NewEventForAggregate(mocks.EventType, eventData, timestamp,
+		mocks.AggregateType, id, 1)
 	loadErr := errors.New("load error")
 	repo.LoadErr = loadErr
 	expectedErr := Error{
@@ -248,8 +260,10 @@ func TestEventHandler_SaveError(t *testing.T) {
 
 	// Driver creates item.
 	id := eh.NewUUID()
-	eventData := &mocks.EventData{"event1"}
-	event := eh.NewEventForAggregate(mocks.EventType, eventData, mocks.AggregateType, id, 1)
+	eventData := &mocks.EventData{Content: "event1"}
+	timestamp := time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)
+	event := eh.NewEventForAggregate(mocks.EventType, eventData, timestamp,
+		mocks.AggregateType, id, 1)
 	saveErr := errors.New("save error")
 	repo.SaveErr = saveErr
 	expectedErr := Error{
@@ -273,8 +287,10 @@ func TestEventHandler_ProjectError(t *testing.T) {
 
 	// Driver creates item.
 	id := eh.NewUUID()
-	eventData := &mocks.EventData{"event1"}
-	event := eh.NewEventForAggregate(mocks.EventType, eventData, mocks.AggregateType, id, 1)
+	eventData := &mocks.EventData{Content: "event1"}
+	timestamp := time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)
+	event := eh.NewEventForAggregate(mocks.EventType, eventData, timestamp,
+		mocks.AggregateType, id, 1)
 	projectErr := errors.New("save error")
 	projector.err = projectErr
 	expectedErr := Error{

--- a/eventhandler/saga/saga_test.go
+++ b/eventhandler/saga/saga_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"reflect"
 	"testing"
+	"time"
 
 	eh "github.com/looplab/eventhorizon"
 	"github.com/looplab/eventhorizon/mocks"
@@ -33,9 +34,11 @@ func TestEventHandler(t *testing.T) {
 	ctx := context.Background()
 
 	id := eh.NewUUID()
-	eventData := &mocks.EventData{"event1"}
-	event := eh.NewEventForAggregate(mocks.EventType, eventData, mocks.AggregateType, id, 1)
-	saga.commands = []eh.Command{&mocks.Command{eh.NewUUID(), "content"}}
+	eventData := &mocks.EventData{Content: "event1"}
+	timestamp := time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)
+	event := eh.NewEventForAggregate(mocks.EventType, eventData, timestamp,
+		mocks.AggregateType, id, 1)
+	saga.commands = []eh.Command{&mocks.Command{ID: eh.NewUUID(), Content: "content"}}
 	handler.HandleEvent(ctx, event)
 	if saga.event != event {
 		t.Error("the handled event should be correct:", saga.event)

--- a/eventhorizon_test.go
+++ b/eventhorizon_test.go
@@ -17,6 +17,7 @@ package eventhorizon
 import (
 	"context"
 	"errors"
+	"time"
 )
 
 func init() {
@@ -68,7 +69,7 @@ func (a *TestAggregate) HandleCommand(ctx context.Context, cmd Command) error {
 	}
 	switch cmd := cmd.(type) {
 	case *TestCommand:
-		a.StoreEvent(TestEventType, &TestEventData{cmd.Content})
+		a.StoreEvent(TestEventType, &TestEventData{cmd.Content}, time.Now())
 		return nil
 	}
 	return errors.New("couldn't handle command")
@@ -109,7 +110,7 @@ func (a *TestAggregate2) HandleCommand(ctx context.Context, cmd Command) error {
 	}
 	switch cmd := cmd.(type) {
 	case *TestCommand2:
-		a.StoreEvent(TestEventType, &TestEvent2Data{cmd.Content})
+		a.StoreEvent(TestEventType, &TestEvent2Data{cmd.Content}, time.Now())
 		return nil
 	}
 	return errors.New("couldn't handle command")

--- a/eventstore/trace/eventstore_test.go
+++ b/eventstore/trace/eventstore_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"reflect"
 	"testing"
+	"time"
 
 	eh "github.com/looplab/eventhorizon"
 	"github.com/looplab/eventhorizon/eventstore/memory"
@@ -61,8 +62,9 @@ func TestEventStore(t *testing.T) {
 	ctx := context.Background()
 
 	t.Log("save event, version 7")
-	event7 := eh.NewEventForAggregate(mocks.EventType, &mocks.EventData{"event1"},
-		mocks.AggregateType, event1.AggregateID(), 7)
+	timestamp := time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)
+	event7 := eh.NewEventForAggregate(mocks.EventType, &mocks.EventData{Content: "event1"},
+		timestamp, mocks.AggregateType, event1.AggregateID(), 7)
 	err := store.Save(ctx, []eh.Event{event7}, 6)
 	if err != nil {
 		t.Error("there should be no error:", err)

--- a/examples/domain/aggregate.go
+++ b/examples/domain/aggregate.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"time"
 
 	eh "github.com/looplab/eventhorizon"
 )
@@ -65,6 +66,7 @@ func (a *InvitationAggregate) HandleCommand(ctx context.Context, cmd eh.Command)
 				cmd.Name,
 				cmd.Age,
 			},
+			time.Now(),
 		)
 		return nil
 
@@ -81,7 +83,7 @@ func (a *InvitationAggregate) HandleCommand(ctx context.Context, cmd eh.Command)
 			return nil
 		}
 
-		a.StoreEvent(InviteAcceptedEvent, nil)
+		a.StoreEvent(InviteAcceptedEvent, nil, time.Now())
 		return nil
 
 	case *DeclineInvite:
@@ -97,7 +99,7 @@ func (a *InvitationAggregate) HandleCommand(ctx context.Context, cmd eh.Command)
 			return nil
 		}
 
-		a.StoreEvent(InviteDeclinedEvent, nil)
+		a.StoreEvent(InviteDeclinedEvent, nil, time.Now())
 		return nil
 
 	case *ConfirmInvite:
@@ -109,7 +111,7 @@ func (a *InvitationAggregate) HandleCommand(ctx context.Context, cmd eh.Command)
 			return fmt.Errorf("only accepted invites can be confirmed")
 		}
 
-		a.StoreEvent(InviteConfirmedEvent, nil)
+		a.StoreEvent(InviteConfirmedEvent, nil, time.Now())
 		return nil
 
 	case *DenyInvite:
@@ -121,7 +123,7 @@ func (a *InvitationAggregate) HandleCommand(ctx context.Context, cmd eh.Command)
 			return fmt.Errorf("only accepted invites can be denied")
 		}
 
-		a.StoreEvent(InviteDeniedEvent, nil)
+		a.StoreEvent(InviteDeniedEvent, nil, time.Now())
 		return nil
 	}
 	return fmt.Errorf("couldn't handle command")

--- a/publisher/testutil/common_tests.go
+++ b/publisher/testutil/common_tests.go
@@ -17,6 +17,7 @@ package testutil
 import (
 	"context"
 	"testing"
+	"time"
 
 	eh "github.com/looplab/eventhorizon"
 	"github.com/looplab/eventhorizon/mocks"
@@ -35,7 +36,9 @@ func EventPublisherCommonTests(t *testing.T, publisher1, publisher2 eh.EventPubl
 
 	t.Log("publish event")
 	id, _ := eh.ParseUUID("c1138e5f-f6fb-4dd0-8e79-255c6c8d3756")
-	event1 := eh.NewEventForAggregate(mocks.EventType, &mocks.EventData{"event1"},
+	timestamp := time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)
+	event1 := eh.NewEventForAggregate(mocks.EventType, &mocks.EventData{Content: "event1"},
+		timestamp,
 		mocks.AggregateType, id, 1)
 	if err := publisher1.PublishEvent(ctx, event1); err != nil {
 		t.Error("there should be no error:", err)
@@ -65,7 +68,7 @@ func EventPublisherCommonTests(t *testing.T, publisher1, publisher2 eh.EventPubl
 	}
 
 	t.Log("publish another event")
-	event2 := eh.NewEventForAggregate(mocks.EventOtherType, nil,
+	event2 := eh.NewEventForAggregate(mocks.EventOtherType, nil, timestamp,
 		mocks.AggregateType, id, 2)
 	if err := publisher1.PublishEvent(ctx, event2); err != nil {
 		t.Error("there should be no error:", err)

--- a/repo/version/repo.go
+++ b/repo/version/repo.go
@@ -79,12 +79,6 @@ func (r *Repo) Find(ctx context.Context, id eh.UUID) (interface{}, error) {
 			return nil, ctx.Err()
 		}
 	}
-
-	// Should never get here.
-	return nil, eh.RepoError{
-		Err:       eh.ErrModelNotFound,
-		Namespace: eh.NamespaceFromContext(ctx),
-	}
 }
 
 // findMinVersion finds an item if it has a version and it is at least minVersion.

--- a/repo/version/repo_test.go
+++ b/repo/version/repo_test.go
@@ -116,7 +116,9 @@ func extraRepoTests(t *testing.T, ctx context.Context, repo *Repo) {
 		t.Error("there should be no error:", err)
 	}
 	ctxVersion = eh.NewContextWithMinVersion(ctx, 4)
-	ctxVersion, _ = context.WithTimeout(ctxVersion, time.Second)
+	var cancel func()
+	ctxVersion, cancel = context.WithTimeout(ctxVersion, time.Second)
+	defer cancel()
 	model, err = repo.Find(ctxVersion, modelMinVersion.ID)
 	if err != nil {
 		t.Error("there should be no error:", err)
@@ -134,7 +136,8 @@ func extraRepoTests(t *testing.T, ctx context.Context, repo *Repo) {
 		}
 	}()
 	ctxVersion = eh.NewContextWithMinVersion(ctx, 5)
-	ctxVersion, _ = context.WithTimeout(ctxVersion, time.Second)
+	ctxVersion, cancel = context.WithTimeout(ctxVersion, time.Second)
+	defer cancel()
 	model, err = repo.Find(ctxVersion, modelMinVersion.ID)
 	if err != nil {
 		t.Error("there should be no error:", err)
@@ -154,7 +157,8 @@ func extraRepoTests(t *testing.T, ctx context.Context, repo *Repo) {
 		t.Error("there should be no error:", err)
 	}
 	ctxVersion = eh.NewContextWithMinVersion(ctx, 1)
-	ctxVersion, _ = context.WithTimeout(ctxVersion, time.Second)
+	ctxVersion, cancel = context.WithTimeout(ctxVersion, time.Second)
+	defer cancel()
 	// Meassure the time it takes, it should not wait > 100ms (the first retry).
 	t1 := time.Now()
 	model, err = repo.Find(ctxVersion, modelMinVersion.ID)
@@ -183,7 +187,8 @@ func extraRepoTests(t *testing.T, ctx context.Context, repo *Repo) {
 		}
 	}()
 	ctxVersion = eh.NewContextWithMinVersion(ctx, 1)
-	ctxVersion, _ = context.WithTimeout(ctxVersion, time.Second)
+	ctxVersion, cancel = context.WithTimeout(ctxVersion, time.Second)
+	defer cancel()
 	model, err = repo.Find(ctxVersion, modelMinVersion.ID)
 	if err != nil {
 		t.Error("there should be no error:", err)
@@ -201,7 +206,8 @@ func extraRepoTests(t *testing.T, ctx context.Context, repo *Repo) {
 		}
 	}()
 	ctxVersion = eh.NewContextWithMinVersion(ctx, 6)
-	ctxVersion, _ = context.WithTimeout(ctxVersion, 10*time.Millisecond)
+	ctxVersion, cancel = context.WithTimeout(ctxVersion, 10*time.Millisecond)
+	defer cancel()
 	model, err = repo.Find(ctxVersion, modelMinVersion.ID)
 	if err != context.DeadlineExceeded {
 		t.Error("there should be a deadline exceeded error:", err)
@@ -221,7 +227,8 @@ func extraRepoTests(t *testing.T, ctx context.Context, repo *Repo) {
 		}
 	}()
 	ctxVersion = eh.NewContextWithMinVersion(ctx, 4)
-	ctxVersion, _ = context.WithTimeout(ctxVersion, time.Second)
+	ctxVersion, cancel = context.WithTimeout(ctxVersion, time.Second)
+	defer cancel()
 	model, err = repo.Find(ctxVersion, modelMinVersion.ID)
 	if err != nil {
 		t.Error("there should be no error:", err)

--- a/utils/eventwaiter_test.go
+++ b/utils/eventwaiter_test.go
@@ -29,7 +29,9 @@ func TestEventWaiter(t *testing.T) {
 	w := NewEventWaiter()
 
 	// Event should match when waiting.
-	expectedEvent := eh.NewEventForAggregate(mocks.EventType, nil, mocks.AggregateType, eh.NewUUID(), 1)
+	timestamp := time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)
+	expectedEvent := eh.NewEventForAggregate(mocks.EventType, nil, timestamp,
+		mocks.AggregateType, eh.NewUUID(), 1)
 	go func() {
 		time.Sleep(time.Millisecond)
 		if err := w.Notify(context.Background(), expectedEvent); err != nil {
@@ -56,7 +58,8 @@ func TestEventWaiter(t *testing.T) {
 	}
 
 	// Other events should not match.
-	otherEvent := eh.NewEventForAggregate(mocks.EventOtherType, nil, mocks.AggregateType, eh.NewUUID(), 1)
+	otherEvent := eh.NewEventForAggregate(mocks.EventOtherType, nil, timestamp,
+		mocks.AggregateType, eh.NewUUID(), 1)
 	go func() {
 		time.Sleep(time.Millisecond)
 		if err := w.Notify(context.Background(), otherEvent); err != nil {


### PR DESCRIPTION
Removes the use of time.Now() when creating events, instead let the client code supply the time stamp. This will make it easier to test client code in for example a table driven test.

Fixes #129.