### PR TITLE
EventListener don't need a for loop

### DIFF
--- a/utils/eventwaiter.go
+++ b/utils/eventwaiter.go
@@ -101,13 +101,11 @@ type EventListener struct {
 }
 
 func (l *EventListener) Wait(ctx context.Context) (eh.Event, error) {
-	for {
-		select {
-		case event := <-l.inbox:
-			return event, nil
-		case <-ctx.Done():
-			return nil, ctx.Err()
-		}
+	select {
+	case event := <-l.inbox:
+		return event, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
 	}
 }
 


### PR DESCRIPTION
An old remain from when matching was done inside Wait().

@maxekman 