### PR TITLE
Aggregate Builder

### DIFF
--- a/configure/builder.go
+++ b/configure/builder.go
@@ -1,0 +1,63 @@
+package configure
+
+import (
+	eh "github.com/looplab/eventhorizon"
+)
+
+// CommandHandlerMiddleware for supporting middleware registration
+type CommandHandlerMiddleware func(eh.CommandHandler) eh.CommandHandler
+
+// AggregateConfig building aggregates
+type AggregateConfig interface {
+	SetFactory(func(eh.UUID) eh.Aggregate) AggregateConfig
+	AddAggregateType(eh.AggregateType) AggregateConfig
+	AddCommandType(...eh.CommandType) AggregateConfig
+	AddMiddleware(...CommandHandlerMiddleware) AggregateConfig
+
+	Factory() func(eh.UUID) eh.Aggregate
+	AggregateType() eh.AggregateType
+	CommandTypes() []eh.CommandType
+	Middleware() []CommandHandlerMiddleware
+}
+
+// NewAggregateConfig create a new AggregateConfig
+func NewAggregateConfig() AggregateConfig {
+	return &config{}
+}
+
+type config struct {
+	factory       func(eh.UUID) eh.Aggregate
+	aggregateType eh.AggregateType
+	commandTypes  []eh.CommandType
+	middleware    []CommandHandlerMiddleware
+}
+
+func (c *config) SetFactory(factory func(eh.UUID) eh.Aggregate) AggregateConfig {
+	c.factory = factory
+	return c
+}
+func (c *config) AddAggregateType(aggregateType eh.AggregateType) AggregateConfig {
+	c.aggregateType = aggregateType
+	return c
+}
+func (c *config) AddCommandType(commandTypes ...eh.CommandType) AggregateConfig {
+	c.commandTypes = append(c.commandTypes, commandTypes...)
+	return c
+}
+func (c *config) AddMiddleware(middleware ...CommandHandlerMiddleware) AggregateConfig {
+	c.middleware = append(c.middleware, middleware...)
+	return c
+}
+
+func (c *config) Factory() func(eh.UUID) eh.Aggregate {
+	return c.factory
+}
+func (c *config) AggregateType() eh.AggregateType {
+	return c.aggregateType
+}
+func (c *config) CommandTypes() []eh.CommandType {
+	return c.commandTypes
+}
+func (c *config) Middleware() []CommandHandlerMiddleware {
+	return c.middleware
+}

--- a/configure/builder_test.go
+++ b/configure/builder_test.go
@@ -1,0 +1,85 @@
+package configure
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/kr/pretty"
+	eh "github.com/looplab/eventhorizon"
+	"github.com/looplab/eventhorizon/aggregatestore/events"
+)
+
+type TestAggregate struct {
+	*events.AggregateBase
+}
+
+func (a *TestAggregate) HandleCommand(ctx context.Context, cmd eh.Command) error {
+	return nil
+}
+
+func NewTestAggregate(id eh.UUID) eh.Aggregate {
+	return &TestAggregate{
+		AggregateBase: events.NewAggregateBase("Test", id),
+	}
+}
+
+func TestAggregateBuilder(t *testing.T) {
+	cases := map[string]struct {
+		fact      func(eh.UUID) eh.Aggregate
+		aggType   eh.AggregateType
+		commTypes []eh.CommandType
+	}{
+		"A1 with 2 Commands": {
+			NewTestAggregate,
+			"A1",
+			[]eh.CommandType{"Test2", "Test3"},
+		},
+		"A2 with 3 Commands commands": {
+			NewTestAggregate,
+			"A2",
+			[]eh.CommandType{"Test2", "Test3", "Test4"},
+		},
+	}
+
+	for name, tc := range cases {
+		name, tc := name, tc
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			// build it.
+			b := NewAggregateConfig().
+				SetFactory(tc.fact).
+				AddAggregateType(tc.aggType)
+
+			for _, t := range tc.commTypes {
+				b = b.AddCommandType(t)
+			}
+
+			cfg, ok := b.(*config)
+			if !ok {
+				t.Errorf("test case '%s': Wrong builder type", name)
+				t.Log("exp:", "*config")
+				t.Log("got:", cfg)
+			}
+
+			sf1 := reflect.ValueOf(cfg.factory)
+			sf2 := reflect.ValueOf(tc.fact)
+			if sf1.Pointer() != sf2.Pointer() {
+				t.Errorf("test case '%s': Wrong factory", name)
+			}
+
+			if cfg.aggregateType != tc.aggType {
+				t.Errorf("test case '%s': Wrong aggregate type", name)
+				t.Log("exp:", tc.aggType)
+				t.Log("got:", cfg.aggregateType)
+			}
+
+			if !reflect.DeepEqual(cfg.commandTypes, tc.commTypes) {
+				t.Errorf("test case '%s': CommandTypes are wrong", name)
+				t.Log("exp:\n", pretty.Sprint(tc.commTypes))
+				t.Log("got:\n", pretty.Sprint(cfg.commandTypes))
+			}
+		})
+	}
+}

--- a/configure/container.go
+++ b/configure/container.go
@@ -1,0 +1,66 @@
+package configure
+
+import (
+	"fmt"
+
+	eh "github.com/looplab/eventhorizon"
+	"github.com/looplab/eventhorizon/commandhandler/aggregate"
+	"github.com/looplab/eventhorizon/commandhandler/bus"
+)
+
+// Container used to configure aggregates
+type Container interface {
+	RegisterAggregates(...AggregateConfig) Container
+}
+
+// NewContainer creates a new container
+func NewContainer(store eh.AggregateStore, bus *bus.CommandHandler) Container {
+	return &container{
+		store: store,
+		bus:   bus,
+	}
+}
+
+type container struct {
+	store            eh.AggregateStore
+	bus              *bus.CommandHandler
+	aggregateConfigs []AggregateConfig
+}
+
+func (c *container) RegisterAggregates(cfgs ...AggregateConfig) Container {
+	for _, cfg := range cfgs {
+
+		// TODO validate the cfg.
+
+		// Register with EH.
+		factory := cfg.Factory()
+		if factory != nil {
+			eh.RegisterAggregate(cfg.Factory())
+		}
+
+		at := cfg.AggregateType()
+
+		// create the handler.
+		var h eh.CommandHandler
+		h, err := aggregate.NewCommandHandler(at, c.store)
+		if err != nil {
+			panic("Could not register aggregate")
+		}
+
+		// hook up middleware?
+		for _, m := range cfg.Middleware() {
+			h = m(h)
+		}
+
+		// add handler to the bus.
+		for _, cmdType := range cfg.CommandTypes() {
+			e := c.bus.SetHandler(h, cmdType)
+			if e != nil {
+				panic(fmt.Sprintf("Could not register command type: %s", err))
+			}
+		}
+
+		c.aggregateConfigs = append(c.aggregateConfigs, cfg)
+	}
+	return c
+}

--- a/configure/container_test.go
+++ b/configure/container_test.go
@@ -1,0 +1,69 @@
+package configure
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/kr/pretty"
+
+	"github.com/looplab/eventhorizon/aggregatestore/events"
+	"github.com/looplab/eventhorizon/commandhandler/bus"
+	eventbus "github.com/looplab/eventhorizon/eventbus/local"
+	eventstore "github.com/looplab/eventhorizon/eventstore/memory"
+	eventpublisher "github.com/looplab/eventhorizon/publisher/local"
+)
+
+func TestContainer(t *testing.T) {
+	cases := map[string]struct {
+		configs []AggregateConfig
+	}{
+		"test1": {
+			configs: []AggregateConfig{
+				NewAggregateConfig().SetFactory(NewTestAggregate).AddAggregateType("A1").AddCommandType("C1", "C2"),
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		name, tc := name, tc
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			eventStore := eventstore.NewEventStore()
+			eventPublisher := eventpublisher.NewEventPublisher()
+			eventBus := eventbus.NewEventBus()
+			eventBus.SetPublisher(eventPublisher)
+
+			as, err := events.NewAggregateStore(eventStore, eventBus)
+			if err != nil {
+				t.Error("Could not create aggregateStore")
+				return
+			}
+			b := bus.NewCommandHandler()
+
+			ic := NewContainer(as, b)
+			if ic == nil {
+				t.Errorf("test case '%s': NewContainer", name)
+				t.Log("exp:", "{}")
+				t.Log("got:", "nil")
+			}
+
+			for _, cfg := range tc.configs {
+				ic = ic.RegisterAggregates(cfg)
+			}
+
+			c, ok := ic.(*container)
+			if !ok {
+				t.Errorf("test case '%s': Wrong container type", name)
+				t.Log("exp:", "*container")
+				t.Log("got:", c)
+			}
+
+			if !reflect.DeepEqual(c.aggregateConfigs, tc.configs) {
+				t.Errorf("test case '%s': AggregateConfigs are wrong", name)
+				t.Log("exp:\n", pretty.Sprint(tc.configs))
+				t.Log("got:\n", pretty.Sprint(c.aggregateConfigs))
+			}
+		})
+	}
+}

--- a/examples/domain/aggregate.go
+++ b/examples/domain/aggregate.go
@@ -24,12 +24,6 @@ import (
 	"github.com/looplab/eventhorizon/aggregatestore/events"
 )
 
-func init() {
-	eh.RegisterAggregate(func(id eh.UUID) eh.Aggregate {
-		return NewInvitationAggregate(id)
-	})
-}
-
 // InvitationAggregateType is the type name of the aggregate.
 const InvitationAggregateType eh.AggregateType = "Invitation"
 
@@ -54,7 +48,7 @@ type InvitationAggregate struct {
 var _ = eh.Aggregate(&InvitationAggregate{})
 
 // NewInvitationAggregate creates a new InvitationAggregate with an ID.
-func NewInvitationAggregate(id eh.UUID) *InvitationAggregate {
+func NewInvitationAggregate(id eh.UUID) eh.Aggregate {
 	return &InvitationAggregate{
 		AggregateBase: events.NewAggregateBase(InvitationAggregateType, id),
 	}


### PR DESCRIPTION
Introduce builder pattern to configure Aggregates to CommandBus

SetFactory is not a required field. 
No breaking changes

Example usage:
```
	container := configure.NewContainer(aggregateStore, commandBus)
	container.RegisterAggregates(
		configure.NewAggregateConfig().
			SetFactory(NewInvitationAggregate).
			AddMiddleware(loggingHandler).
			AddAggregateType(InvitationAggregateType).
			AddCommandType(CreateInviteCommand, AcceptInviteCommand, DeclineInviteCommand).
			AddCommandType(ConfirmInviteCommand, DenyInviteCommand),
	)
```