### PR TITLE
Iterative gets

### DIFF
--- a/repo.go
+++ b/repo.go
@@ -87,3 +87,14 @@ type Versionable interface {
 	// AggregateVersion returns the version of the item.
 	AggregateVersion() int
 }
+
+// Iter is a stateful iterator object that when called Next() readies the next
+// value that can be retrieved from Value(). Enables incremental object retrieval
+// from repos that support it. You must call Close() on each Iter even when
+// results were delivered without apparent error.
+type Iter interface {
+	Next() bool
+	Value() interface{}
+	// Close must be called after the last Next() to retrieve error if any
+	Close() error
+}

--- a/repo/mongodb/repo_test.go
+++ b/repo/mongodb/repo_test.go
@@ -140,6 +140,29 @@ func extraRepoTests(t *testing.T, ctx context.Context, repo *Repo) {
 	if !reflect.DeepEqual(model, modelCustom2) {
 		t.Error("the item should be correct:", model)
 	}
+
+	// FindCustomIter by content.
+	iter, err := repo.FindCustomIter(ctx, func(c *mgo.Collection) *mgo.Query {
+		return c.Find(bson.M{"content": "modelCustom"})
+	})
+	if err != nil {
+		t.Error("there should be no error:", err)
+	}
+
+	if iter.Next() != true {
+		t.Error("the iterator should have results")
+	}
+	if !reflect.DeepEqual(iter.Value(), modelCustom) {
+		t.Error("the item should be correct:", modelCustom)
+	}
+	if iter.Next() == true {
+		t.Error("the iterator should have no results")
+	}
+	err = iter.Close()
+	if err != nil {
+		t.Error("there should be no error:", err)
+	}
+
 }
 
 func TestRepository(t *testing.T) {


### PR DESCRIPTION
Support for large datasets where the set can't be held in memory at once. `FindCustomIter` will return an Iter object that can be used to retrieve one object at a time.

The Iter interface is agnostic towards what type of results is returned from the query, doesn't have to be a Entity.