### PR TITLE
Issue 126 / Add Async eventhandler, remove EventHandlingStrategy

### DIFF
--- a/eventbus.go
+++ b/eventbus.go
@@ -56,5 +56,5 @@ type EventPublisher interface {
 // All observers will receive an event.
 type EventObserver interface {
 	// Notify is notifed about an event.
-	Notify(context.Context, Event) error
+	Notify(context.Context, Event)
 }

--- a/eventbus.go
+++ b/eventbus.go
@@ -41,9 +41,6 @@ type EventBus interface {
 	// SetPublisher sets the publisher to use for publishing the event after all
 	// handlers have been run.
 	SetPublisher(EventPublisher)
-
-	// SetHandlingStrategy will set the strategy to use for handling events.
-	SetHandlingStrategy(EventHandlingStrategy)
 }
 
 // EventPublisher is a publisher of events to observers.
@@ -53,9 +50,6 @@ type EventPublisher interface {
 
 	// AddObserver adds an observer.
 	AddObserver(EventObserver)
-
-	// SetHandlingStrategy will set the strategy to use for handling events.
-	SetHandlingStrategy(EventHandlingStrategy)
 }
 
 // EventObserver is an observer of events.
@@ -64,15 +58,3 @@ type EventObserver interface {
 	// Notify is notifed about an event.
 	Notify(context.Context, Event) error
 }
-
-// EventHandlingStrategy is the strategy to use when handling events.
-type EventHandlingStrategy int
-
-const (
-	// SimpleEventHandlingStrategy will handle events in the same goroutine and
-	// wait for them to complete before handling the next.
-	SimpleEventHandlingStrategy EventHandlingStrategy = iota
-	// AsyncEventHandlingStrategy will handle events concurrently in their own
-	// goroutines and not wait for them to finish.
-	AsyncEventHandlingStrategy
-)

--- a/eventbus/local/eventbus_test.go
+++ b/eventbus/local/eventbus_test.go
@@ -24,22 +24,9 @@ import (
 )
 
 func TestEventBus(t *testing.T) {
-	EventBusCommonTests(t, false)
-}
-
-func TestEventBusAsync(t *testing.T) {
-	EventBusCommonTests(t, true)
-}
-
-// EventBusCommonTests are test cases that are common to all implementations
-// of event busses.
-func EventBusCommonTests(t *testing.T, async bool) {
 	bus := NewEventBus()
 	if bus == nil {
 		t.Fatal("there should be a bus")
-	}
-	if async {
-		bus.SetHandlingStrategy(eh.AsyncEventHandlingStrategy)
 	}
 
 	publisher := mocks.NewEventPublisher()
@@ -135,21 +122,19 @@ func EventBusCommonTests(t *testing.T, async bool) {
 		t.Error("the context should be correct:", publisher.Context)
 	}
 
-	// Event handler order, only important for non-async mode.
-	if !async {
-		handler2 := mocks.NewEventHandler("testHandler2")
-		bus.AddHandler(handler2, mocks.EventType)
-		if err := bus.HandleEvent(ctx, event1); err != nil {
-			t.Error("there should be no error:", err)
-		}
-		if err := handler.WaitForEvent(); err != nil {
-			t.Error("did not receive event in time:", err)
-		}
-		if err := handler2.WaitForEvent(); err != nil {
-			t.Error("did not receive event in time:", err)
-		}
-		if handler2.Time.Before(handler.Time) {
-			t.Error("the first handler shoud be run first")
-		}
+	// Event handler order.
+	handler2 := mocks.NewEventHandler("testHandler2")
+	bus.AddHandler(handler2, mocks.EventType)
+	if err := bus.HandleEvent(ctx, event1); err != nil {
+		t.Error("there should be no error:", err)
+	}
+	if err := handler.WaitForEvent(); err != nil {
+		t.Error("did not receive event in time:", err)
+	}
+	if err := handler2.WaitForEvent(); err != nil {
+		t.Error("did not receive event in time:", err)
+	}
+	if handler2.Time.Before(handler.Time) {
+		t.Error("the first handler shoud be run first")
 	}
 }

--- a/eventhandler/async/async.go
+++ b/eventhandler/async/async.go
@@ -1,0 +1,65 @@
+// Copyright (c) 2017 - Max Ekman <max@looplab.se>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package async
+
+import (
+	"context"
+	"fmt"
+
+	eh "github.com/looplab/eventhorizon"
+)
+
+// EventHandler is an async event handler middleware. It will run the event in
+// a new go routine and report any errors to the error channel obtained by Errors().
+type EventHandler struct {
+	eh.EventHandler
+	errCh chan Error
+}
+
+// NewEventHandler creates a new EventHandler.
+func NewEventHandler(h eh.EventHandler) *EventHandler {
+	return &EventHandler{
+		EventHandler: h,
+		errCh:        make(chan Error, 20),
+	}
+}
+
+// HandleEvent implements the HandleEvent method of the EventHandler interface.
+func (h *EventHandler) HandleEvent(ctx context.Context, event eh.Event) error {
+	go func() {
+		if err := h.EventHandler.HandleEvent(ctx, event); err != nil {
+			// Always try to deliver errors.
+			h.errCh <- Error{err, ctx, event}
+		}
+	}()
+	return nil
+}
+
+// Errors returns an error channel where async handling errors are sent.
+func (h *EventHandler) Errors() <-chan Error {
+	return h.errCh
+}
+
+// Error is an async error containing the error and the event.
+type Error struct {
+	Err   error
+	Ctx   context.Context
+	Event eh.Event
+}
+
+// Error implements the Error method of the error interface.
+func (e Error) Error() string {
+	return fmt.Sprintf("%s: %s", e.Event.String(), e.Err.Error())
+}

--- a/eventhandler/async/async_test.go
+++ b/eventhandler/async/async_test.go
@@ -1,0 +1,74 @@
+// Copyright (c) 2017 - Max Ekman <max@looplab.se>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package async
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+
+	eh "github.com/looplab/eventhorizon"
+	"github.com/looplab/eventhorizon/mocks"
+)
+
+func TestEventHandler(t *testing.T) {
+	id := eh.NewUUID()
+	eventData := &mocks.EventData{Content: "event1"}
+	timestamp := time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)
+	event := eh.NewEventForAggregate(mocks.EventType, eventData, timestamp,
+		mocks.AggregateType, id, 1)
+
+	inner := mocks.NewEventHandler("TestHandler")
+	h := NewEventHandler(inner)
+	if err := h.HandleEvent(context.Background(), event); err != nil {
+		t.Error("there should never be an error:", err)
+	}
+	select {
+	case err := <-h.Errors():
+		t.Error("there should not be an error:", err)
+	case <-time.After(time.Millisecond):
+	}
+	if !reflect.DeepEqual(inner.Events, []eh.Event{event}) {
+		t.Error("the event shoud have been handeled:", inner.Events)
+	}
+
+	inner = mocks.NewEventHandler("TestHandler")
+	h = NewEventHandler(inner)
+	handlingErr := errors.New("handling error")
+	inner.Err = handlingErr
+	ctx := context.Background()
+	if err := h.HandleEvent(ctx, event); err != nil {
+		t.Error("there should never be an error:", err)
+	}
+	select {
+	case err := <-h.Errors():
+		if err.Err != handlingErr {
+			t.Error("the error should be correct:", err.Err)
+		}
+		if err.Ctx != ctx {
+			t.Error("the context should be correct:", err.Ctx)
+		}
+		if err.Event != event {
+			t.Error("the event should be correct:", err.Event)
+		}
+	case <-time.After(time.Millisecond):
+		t.Error("there should be an error")
+	}
+	if !reflect.DeepEqual(inner.Events, []eh.Event{}) {
+		t.Error("the event shoud not have been handeled:", inner.Events)
+	}
+}

--- a/examples/guestlist/domain/logger.go
+++ b/examples/guestlist/domain/logger.go
@@ -25,7 +25,6 @@ import (
 type Logger struct{}
 
 // Notify implements the Notify method of the EventObserver interface.
-func (l *Logger) Notify(ctx context.Context, event eh.Event) error {
+func (l *Logger) Notify(ctx context.Context, event eh.Event) {
 	log.Println("event:", event)
-	return nil
 }

--- a/examples/todomvc/handler.go
+++ b/examples/todomvc/handler.go
@@ -49,9 +49,8 @@ type Handler struct {
 type Logger struct{}
 
 // Notify implements the Notify method of the EventObserver interface.
-func (l *Logger) Notify(ctx context.Context, event eh.Event) error {
+func (l *Logger) Notify(ctx context.Context, event eh.Event) {
 	log.Printf("EVENT %s", event)
-	return nil
 }
 
 // NewHandler sets up the full Event Horizon domain for the TodoMVC app and

--- a/httputils/eventbus.go
+++ b/httputils/eventbus.go
@@ -31,13 +31,12 @@ type Observer struct {
 }
 
 // Notify implements the Notify method of the EventObserver interface.
-func (o *Observer) Notify(ctx context.Context, event eh.Event) error {
+func (o *Observer) Notify(ctx context.Context, event eh.Event) {
 	select {
 	case o.EventCh <- event:
 	default:
 		log.Println("missed event:", event)
 	}
-	return nil
 }
 
 // EventBusHandler is a Websocket handler for eventhorizon.Events. Events will

--- a/mocks/mocks.go
+++ b/mocks/mocks.go
@@ -276,10 +276,6 @@ func (m *EventPublisher) AddObserver(o eh.EventObserver) {
 	m.Observers = append(m.Observers, o)
 }
 
-// SetHandlingStrategy implements the SetHandlingStrategy method of the
-// eventhorizon.EventBus interface.
-func (m *EventPublisher) SetHandlingStrategy(strategy eh.EventHandlingStrategy) {}
-
 // WaitForEvent is a helper to wait until an event has been notified, it timeouts
 // after 1 second.
 func (m *EventPublisher) WaitForEvent() error {
@@ -436,10 +432,6 @@ func (m *EventBus) AddHandler(handler eh.EventHandler, event eh.EventType) {}
 // SetPublisher implements the SetPublisher method of the
 // eventhorizon.EventBus interface.
 func (m *EventBus) SetPublisher(publisher eh.EventPublisher) {}
-
-// SetHandlingStrategy implements the SetHandlingStrategy method of the
-// eventhorizon.EventBus interface.
-func (m *EventBus) SetHandlingStrategy(strategy eh.EventHandlingStrategy) {}
 
 // Repo is a mocked eventhorizon.ReadRepo, useful in testing.
 type Repo struct {

--- a/mocks/mocks.go
+++ b/mocks/mocks.go
@@ -292,8 +292,6 @@ type EventObserver struct {
 	Events  []eh.Event
 	Context context.Context
 	Recv    chan eh.Event
-	// Used to simulate errors in HandleCommand.
-	Err error
 }
 
 var _ = eh.EventObserver(&EventObserver{})
@@ -308,14 +306,10 @@ func NewEventObserver() *EventObserver {
 }
 
 // Notify implements the Notify method of the eventhorizon.EventHandler interface.
-func (m *EventObserver) Notify(ctx context.Context, event eh.Event) error {
-	if m.Err != nil {
-		return m.Err
-	}
+func (m *EventObserver) Notify(ctx context.Context, event eh.Event) {
 	m.Events = append(m.Events, event)
 	m.Context = ctx
 	m.Recv <- event
-	return nil
 }
 
 // WaitForEvent is a helper to wait until an event has been notified, it timeouts

--- a/publisher/gcp/publisher_test.go
+++ b/publisher/gcp/publisher_test.go
@@ -20,7 +20,6 @@ import (
 	"os"
 	"testing"
 
-	eh "github.com/looplab/eventhorizon"
 	"github.com/looplab/eventhorizon/publisher/testutil"
 )
 
@@ -36,28 +35,6 @@ func TestEventBus(t *testing.T) {
 		t.Fatal("there should be no error:", err)
 	}
 	defer publisher2.Close()
-
-	// Wait for subscriptions to be ready.
-	<-publisher1.ready
-	<-publisher2.ready
-
-	testutil.EventPublisherCommonTests(t, publisher1, publisher2)
-}
-
-func TestEventBusAsync(t *testing.T) {
-	publisher1, err := setUpEventPublisher("test")
-	if err != nil {
-		t.Fatal("there should be no error:", err)
-	}
-	defer publisher1.Close()
-	publisher1.SetHandlingStrategy(eh.AsyncEventHandlingStrategy)
-
-	publisher2, err := setUpEventPublisher("test")
-	if err != nil {
-		t.Fatal("there should be no error:", err)
-	}
-	defer publisher2.Close()
-	publisher2.SetHandlingStrategy(eh.AsyncEventHandlingStrategy)
 
 	// Wait for subscriptions to be ready.
 	<-publisher1.ready

--- a/publisher/local/publisher.go
+++ b/publisher/local/publisher.go
@@ -27,10 +27,6 @@ import (
 type EventPublisher struct {
 	observers   map[eh.EventObserver]bool
 	observersMu sync.RWMutex
-
-	// handlingStrategy is the strategy to use when publishing event, for example
-	// to handle the asynchronously.
-	handlingStrategy eh.EventHandlingStrategy
 }
 
 // NewEventPublisher creates a EventPublisher.
@@ -46,41 +42,6 @@ func NewEventPublisher() *EventPublisher {
 func (b *EventPublisher) PublishEvent(ctx context.Context, event eh.Event) error {
 	b.observersMu.RLock()
 	defer b.observersMu.RUnlock()
-
-	// Async event publishing.
-	if b.handlingStrategy == eh.AsyncEventHandlingStrategy {
-		wg := sync.WaitGroup{}
-		errc := make(chan error)
-
-		// Notify all observers about the event.
-		for o := range b.observers {
-			wg.Add(1)
-			go func(o eh.EventObserver) {
-				defer wg.Done()
-				if err := o.Notify(ctx, event); err != nil {
-					// Try to report the error. Only the first error is
-					// taken care of.
-					select {
-					case errc <- err:
-					default:
-					}
-				}
-			}(o)
-		}
-
-		// Wait for notifying to finish, but only care about the first error.
-		go func() {
-			wg.Wait()
-			close(errc)
-		}()
-		go func() {
-			if err := <-errc; err != nil {
-				log.Println("eventpublisher: error publishing:", err)
-			}
-		}()
-
-		return nil
-	}
 
 	// Notify all observers about the event.
 	for o := range b.observers {
@@ -98,10 +59,4 @@ func (b *EventPublisher) AddObserver(observer eh.EventObserver) {
 	b.observersMu.Lock()
 	defer b.observersMu.Unlock()
 	b.observers[observer] = true
-}
-
-// SetHandlingStrategy implements the SetHandlingStrategy method of the
-// eventhorizon.EventPublisher interface.
-func (b *EventPublisher) SetHandlingStrategy(strategy eh.EventHandlingStrategy) {
-	b.handlingStrategy = strategy
 }

--- a/publisher/local/publisher.go
+++ b/publisher/local/publisher.go
@@ -16,7 +16,6 @@ package local
 
 import (
 	"context"
-	"log"
 	"sync"
 
 	eh "github.com/looplab/eventhorizon"
@@ -45,9 +44,7 @@ func (b *EventPublisher) PublishEvent(ctx context.Context, event eh.Event) error
 
 	// Notify all observers about the event.
 	for o := range b.observers {
-		if err := o.Notify(ctx, event); err != nil {
-			log.Println("eventpublisher: error publishing:", err)
-		}
+		o.Notify(ctx, event)
 	}
 
 	return nil

--- a/publisher/local/publisher_test.go
+++ b/publisher/local/publisher_test.go
@@ -17,7 +17,6 @@ package local
 import (
 	"testing"
 
-	eh "github.com/looplab/eventhorizon"
 	"github.com/looplab/eventhorizon/publisher/testutil"
 )
 
@@ -26,16 +25,6 @@ func TestEventPublisher(t *testing.T) {
 	if publisher == nil {
 		t.Fatal("there should be a publisher")
 	}
-
-	testutil.EventPublisherCommonTests(t, publisher, publisher)
-}
-
-func TestEventPublisherAsync(t *testing.T) {
-	publisher := NewEventPublisher()
-	if publisher == nil {
-		t.Fatal("there should be a publisher")
-	}
-	publisher.SetHandlingStrategy(eh.AsyncEventHandlingStrategy)
 
 	testutil.EventPublisherCommonTests(t, publisher, publisher)
 }

--- a/publisher/redis/publisher_test.go
+++ b/publisher/redis/publisher_test.go
@@ -18,7 +18,6 @@ import (
 	"os"
 	"testing"
 
-	eh "github.com/looplab/eventhorizon"
 	"github.com/looplab/eventhorizon/publisher/testutil"
 )
 
@@ -44,38 +43,6 @@ func TestEventPublisher(t *testing.T) {
 		t.Fatal("there should be no error:", err)
 	}
 	defer publisher2.Close()
-
-	// Wait for subscriptions to be ready.
-	<-publisher1.ready
-	<-publisher2.ready
-
-	testutil.EventPublisherCommonTests(t, publisher1, publisher2)
-}
-
-func TestEventPublisherAsync(t *testing.T) {
-	// Support Wercker testing with MongoDB.
-	host := os.Getenv("REDIS_PORT_6379_TCP_ADDR")
-	port := os.Getenv("REDIS_PORT_6379_TCP_PORT")
-
-	url := ":6379"
-	if host != "" && port != "" {
-		url = host + ":" + port
-	}
-
-	publisher1, err := NewEventPublisher("test", url, "")
-	if err != nil {
-		t.Fatal("there should be no error:", err)
-	}
-	defer publisher1.Close()
-	publisher1.SetHandlingStrategy(eh.AsyncEventHandlingStrategy)
-
-	// Another bus to test the observer.
-	publisher2, err := NewEventPublisher("test", url, "")
-	if err != nil {
-		t.Fatal("there should be no error:", err)
-	}
-	defer publisher2.Close()
-	publisher2.SetHandlingStrategy(eh.AsyncEventHandlingStrategy)
 
 	// Wait for subscriptions to be ready.
 	<-publisher1.ready

--- a/utils/eventwaiter.go
+++ b/utils/eventwaiter.go
@@ -66,14 +66,8 @@ func (w *EventWaiter) run() {
 
 // Notify implements the eventhorizon.EventObserver.Notify method which forwards
 // events to the waiters so that they can match the events.
-func (w *EventWaiter) Notify(ctx context.Context, event eh.Event) error {
-	select {
-	case w.inbox <- event:
-	case <-ctx.Done():
-		return ctx.Err()
-	}
-
-	return nil
+func (w *EventWaiter) Notify(ctx context.Context, event eh.Event) {
+	w.inbox <- event
 }
 
 // Listen waits unil the match function returns true for an event, or the context
@@ -100,6 +94,7 @@ type EventListener struct {
 	unregister chan *EventListener
 }
 
+// Wait waits for the event to arrive.
 func (l *EventListener) Wait(ctx context.Context) (eh.Event, error) {
 	select {
 	case event := <-l.inbox:
@@ -109,6 +104,7 @@ func (l *EventListener) Wait(ctx context.Context) (eh.Event, error) {
 	}
 }
 
+// Close stops listening for more events.
 func (l *EventListener) Close() {
 	l.unregister <- l
 }

--- a/utils/eventwaiter_test.go
+++ b/utils/eventwaiter_test.go
@@ -35,9 +35,7 @@ func TestEventWaiter(t *testing.T) {
 	)
 	go func() {
 		time.Sleep(time.Millisecond)
-		if err := w.Notify(context.Background(), expectedEvent); err != nil {
-			t.Error(err)
-		}
+		w.Notify(context.Background(), expectedEvent)
 	}()
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
@@ -66,9 +64,7 @@ func TestEventWaiter(t *testing.T) {
 		mocks.AggregateType, eh.NewUUID(), 1)
 	go func() {
 		time.Sleep(time.Millisecond)
-		if err := w.Notify(context.Background(), otherEvent); err != nil {
-			t.Error(err)
-		}
+		w.Notify(context.Background(), otherEvent)
 	}()
 
 	ctx, cancel = context.WithTimeout(context.Background(), 10*time.Millisecond)


### PR DESCRIPTION
The async.EventHandler is a middleware that can be used to make event handlers asynchronous instead of using the buggy and non-deterministic EventHandlingStrategy flag.

The new middleware is best used for any event handling that is secondary to the command, like sagas and processes, while projections can run right after the command before returning to the client. This approach can simplify many systems where full eventual consistency is not needed. To run all event handling async as when using the removed handling strategy just wrap all handlers in the middleware.

Another added benefit is that some logging from within the toolkit is removed, which is never a good thing to do!

Fixes #126.