### PR TITLE
Allow for no event publisher on event bus.

### DIFF
--- a/eventbus/local/eventbus.go
+++ b/eventbus/local/eventbus.go
@@ -53,6 +53,10 @@ func (b *EventBus) HandleEvent(ctx context.Context, event eh.Event) error {
 		}
 	}
 
+	if b.publisher == nil {
+		return nil
+	}
+
 	// Publish the event.
 	return b.publisher.PublishEvent(ctx, event)
 }

--- a/eventbus/local/eventbus_test.go
+++ b/eventbus/local/eventbus_test.go
@@ -138,3 +138,19 @@ func TestEventBus(t *testing.T) {
 		t.Error("the first handler shoud be run first")
 	}
 }
+
+// Although most cases will publish events to other parts
+// of a system when you're running tests you may not need
+// an event publisher for ease of setup.
+func TestEventBusWithNilPublisher(t *testing.T) {
+	eb := NewEventBus()
+	mockEvent := eh.NewEventForAggregate(
+		mocks.EventType,
+		&mocks.EventData{Content: "event1"},
+		time.Now(),
+		mocks.AggregateType,
+		eh.UUID("c1138e5f-f6fb-4dd0-8e79-255c6c8d3756"),
+		1,
+	)
+	eb.HandleEvent(context.Background(), mockEvent)
+}


### PR DESCRIPTION
This is more of a utility for testing, prior to just returning on `nil` a `panic` occurred.

```
--- FAIL: TestEventBusWithNilPublisher (0.00s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x28 pc=0x503c2d]

goroutine 6 [running]:
testing.tRunner.func1(0xc4200b40f0)
	/usr/local/go/src/testing/testing.go:711 +0x2d2
panic(0x52cba0, 0x607c90)
	/usr/local/go/src/runtime/panic.go:491 +0x283
github.com/looplab/eventhorizon/eventbus/local.(*EventBus).HandleEvent(0xc42000e510, 0x5f86a0, 0xc420014150, 0x5f9240, 0xc42005a180, 0x0, 0x0)
	/workspace/src/github.com/looplab/eventhorizon/eventbus/local/eventbus.go:56 +0x17d
github.com/looplab/eventhorizon/eventbus/local.TestEventBusWithNilPublisher(0xc4200b40f0)
	/workspace/src/github.com/looplab/eventhorizon/eventbus/local/eventbus_test.go:155 +0x1cd
testing.tRunner(0xc4200b40f0, 0x55d2a8)
	/usr/local/go/src/testing/testing.go:746 +0xd0
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:789 +0x2de
FAIL	github.com/looplab/eventhorizon/eventbus/local	0.003s
Error: Tests failed.
```