### PR TITLE
Add RemoveObserver on EventBus interface, allows for httputils to remove once handled.

### DIFF
--- a/eventbus.go
+++ b/eventbus.go
@@ -50,6 +50,9 @@ type EventPublisher interface {
 
 	// AddObserver adds an observer.
 	AddObserver(EventObserver)
+
+	// RemoveObserver removes an observer.
+	RemoveObserver(EventObserver)
 }
 
 // EventObserver is an observer of events.

--- a/httputils/eventbus.go
+++ b/httputils/eventbus.go
@@ -55,6 +55,7 @@ func EventBusHandler(eventPublisher eh.EventPublisher) http.Handler {
 			EventCh: make(chan eh.Event, 10),
 		}
 		eventPublisher.AddObserver(observer)
+		defer eventPublisher.RemoveObserver(observer)
 
 		for event := range observer.EventCh {
 			if err := c.WriteMessage(websocket.TextMessage, []byte(event.String())); err != nil {

--- a/publisher/local/publisher.go
+++ b/publisher/local/publisher.go
@@ -57,3 +57,11 @@ func (b *EventPublisher) AddObserver(observer eh.EventObserver) {
 	defer b.observersMu.Unlock()
 	b.observers[observer] = true
 }
+
+// RemoveObserver removes the observer.
+func (b *EventPublisher) RemoveObserver(observer eh.EventObserver) {
+	b.observersMu.Lock()
+	defer b.observersMu.Unlock()
+
+	delete(b.observers, observer)
+}

--- a/publisher/local/publisher_test.go
+++ b/publisher/local/publisher_test.go
@@ -17,6 +17,7 @@ package local
 import (
 	"testing"
 
+	"github.com/looplab/eventhorizon/mocks"
 	"github.com/looplab/eventhorizon/publisher/testutil"
 )
 
@@ -27,4 +28,21 @@ func TestEventPublisher(t *testing.T) {
 	}
 
 	testutil.EventPublisherCommonTests(t, publisher, publisher)
+}
+
+func TestEventPublisherRemoveObserver(t *testing.T) {
+	publisher := NewEventPublisher()
+	observer1 := mocks.NewEventObserver()
+
+	publisher.AddObserver(observer1)
+
+	if v := len(publisher.observers); v != 1 {
+		t.Fatalf("expected 1 observer got %d", v)
+	}
+
+	publisher.RemoveObserver(observer1)
+
+	if v := len(publisher.observers); v != 0 {
+		t.Fatalf("expected no observer got %d", v)
+	}
 }


### PR DESCRIPTION
Fixes #187 