### PR TITLE
ISSUE-84 / Add EventMatcher

### DIFF
--- a/aggregatestore/events/aggregatestore.go
+++ b/aggregatestore/events/aggregatestore.go
@@ -150,7 +150,7 @@ func (r *AggregateStore) Save(ctx context.Context, agg eh.Aggregate) error {
 	}
 
 	for _, e := range events {
-		if err := r.bus.HandleEvent(ctx, e); err != nil {
+		if err := r.bus.PublishEvent(ctx, e); err != nil {
 			return err
 		}
 	}

--- a/eventbus.go
+++ b/eventbus.go
@@ -14,7 +14,9 @@
 
 package eventhorizon
 
-import "context"
+import (
+	"context"
+)
 
 // EventHandler is a handler of events.
 // Only one handler of the same type will receive an event.
@@ -33,28 +35,9 @@ type EventHandlerType string
 // EventBus is an event handler that handles events with the correct subhandlers
 // after which it publishes the event using the publisher.
 type EventBus interface {
-	EventHandler
-
-	// AddHandler adds a handler for an event.
-	AddHandler(EventHandler, EventType)
-
-	// SetPublisher sets the publisher to use for publishing the event after all
-	// handlers have been run.
-	SetPublisher(EventPublisher)
-}
-
-// EventPublisher is a publisher of events to observers.
-type EventPublisher interface {
-	// PublishEvent publishes the event to all observers.
 	PublishEvent(context.Context, Event) error
 
-	// AddObserver adds an observer.
-	AddObserver(EventObserver)
-}
-
-// EventObserver is an observer of events.
-// All observers will receive an event.
-type EventObserver interface {
-	// Notify is notifed about an event.
-	Notify(context.Context, Event)
+	// AddHandler adds a handler for an event. Panics if either the matcher
+	// or handler is nil.
+	AddHandler(EventMatcher, EventHandler)
 }

--- a/eventbus/local/eventbus_test.go
+++ b/eventbus/local/eventbus_test.go
@@ -16,6 +16,7 @@ package local
 
 import (
 	"context"
+	"reflect"
 	"testing"
 	"time"
 
@@ -29,128 +30,65 @@ func TestEventBus(t *testing.T) {
 		t.Fatal("there should be a bus")
 	}
 
-	publisher := mocks.NewEventPublisher()
-	bus.SetPublisher(publisher)
-
 	ctx := mocks.WithContextOne(context.Background(), "testval")
 
-	// Publish event without handler.
+	// Without handler.
 	id, _ := eh.ParseUUID("c1138e5f-f6fb-4dd0-8e79-255c6c8d3756")
 	timestamp := time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)
 	event1 := eh.NewEventForAggregate(mocks.EventType, &mocks.EventData{Content: "event1"}, timestamp,
 		mocks.AggregateType, id, 1)
-	if err := bus.HandleEvent(ctx, event1); err != nil {
+	if err := bus.PublishEvent(ctx, event1); err != nil {
+		t.Error("there should be no error:", err)
+	}
+
+	// Add handler.
+	handler := mocks.NewEventHandler("testHandler")
+	func() {
+		defer func() {
+			if r := recover(); r == nil {
+				t.Errorf("adding a nil matcher should panic")
+			}
+		}()
+		bus.AddHandler(nil, handler)
+	}()
+	func() {
+		defer func() {
+			if r := recover(); r == nil {
+				t.Errorf("adding a nil handler should panic")
+			}
+		}()
+		bus.AddHandler(eh.MatchAny(), nil)
+	}()
+	bus.AddHandler(eh.MatchEvent(mocks.EventType), handler)
+
+	// One handler.
+	if err := bus.PublishEvent(ctx, event1); err != nil {
 		t.Error("there should be no error:", err)
 	}
 	expectedEvents := []eh.Event{event1}
-	if err := publisher.WaitForEvent(); err != nil {
-		t.Error("did not receive event in time:", err)
-	}
-	for i, event := range publisher.Events {
-		if err := mocks.CompareEvents(event, expectedEvents[i]); err != nil {
-			t.Error("the event was incorrect:", err)
-		}
-	}
-	if val, ok := mocks.ContextOne(publisher.Context); !ok || val != "testval" {
-		t.Error("the context should be correct:", publisher.Context)
-	}
-
-	// Publish event.
-	handler := mocks.NewEventHandler("testHandler")
-	bus.AddHandler(handler, mocks.EventType)
-	if err := bus.HandleEvent(ctx, event1); err != nil {
-		t.Error("there should be no error:", err)
-	}
-	if err := handler.WaitForEvent(); err != nil {
-		t.Error("did not receive event in time:", err)
-	}
-	expectedEvents = []eh.Event{event1}
-	for i, event := range handler.Events {
-		if err := mocks.CompareEvents(event, expectedEvents[i]); err != nil {
-			t.Error("the event was incorrect:", i, err)
-			t.Log(handler.Events)
-		}
+	if !reflect.DeepEqual(handler.Events, expectedEvents) {
+		t.Error("the events were incorrect:")
+		t.Log(handler.Events)
 	}
 	if val, ok := mocks.ContextOne(handler.Context); !ok || val != "testval" {
 		t.Error("the context should be correct:", handler.Context)
 	}
 	expectedEvents = []eh.Event{event1, event1}
-	if err := publisher.WaitForEvent(); err != nil {
-		t.Error("did not receive event in time:", err)
-	}
-	for i, event := range publisher.Events {
-		if err := mocks.CompareEvents(event, expectedEvents[i]); err != nil {
-			t.Error("the event was incorrect:", i, err)
-			t.Log(handler.Events)
-		}
-	}
-	if val, ok := mocks.ContextOne(publisher.Context); !ok || val != "testval" {
-		t.Error("the context should be correct:", publisher.Context)
-	}
 
-	// Publish another event.
-	bus.AddHandler(handler, mocks.EventOtherType)
-	event2 := eh.NewEventForAggregate(mocks.EventOtherType, nil, timestamp,
-		mocks.AggregateType, id, 1)
-	if err := bus.HandleEvent(ctx, event2); err != nil {
-		t.Error("there should be no error:", err)
-	}
-	if err := handler.WaitForEvent(); err != nil {
-		t.Error("did not receive event in time:", err)
-	}
-	expectedEvents = []eh.Event{event1, event2}
-	for i, event := range handler.Events {
-		if err := mocks.CompareEvents(event, expectedEvents[i]); err != nil {
-			t.Error("the event was incorrect:", i, err)
-			t.Log(handler.Events)
-		}
-	}
-	if val, ok := mocks.ContextOne(handler.Context); !ok || val != "testval" {
-		t.Error("the context should be correct:", handler.Context)
-	}
-	expectedEvents = []eh.Event{event1, event1, event2}
-	if err := publisher.WaitForEvent(); err != nil {
-		t.Error("did not receive event in time:", err)
-	}
-	for i, event := range publisher.Events {
-		if err := mocks.CompareEvents(event, expectedEvents[i]); err != nil {
-			t.Error("the event was incorrect:", i, err)
-			t.Log(handler.Events)
-		}
-	}
-	if val, ok := mocks.ContextOne(publisher.Context); !ok || val != "testval" {
-		t.Error("the context should be correct:", publisher.Context)
-	}
-
-	// Event handler order.
+	// Two handlers for the same event.
 	handler2 := mocks.NewEventHandler("testHandler2")
-	bus.AddHandler(handler2, mocks.EventType)
-	if err := bus.HandleEvent(ctx, event1); err != nil {
+	bus.AddHandler(eh.MatchEvent(mocks.EventType), handler2)
+	handler.Reset()
+	if err := bus.PublishEvent(ctx, event1); err != nil {
 		t.Error("there should be no error:", err)
 	}
-	if err := handler.WaitForEvent(); err != nil {
-		t.Error("did not receive event in time:", err)
+	expectedEvents = []eh.Event{event1}
+	if !reflect.DeepEqual(handler.Events, expectedEvents) {
+		t.Error("the events were incorrect:")
+		t.Log(handler.Events)
 	}
-	if err := handler2.WaitForEvent(); err != nil {
-		t.Error("did not receive event in time:", err)
+	if !reflect.DeepEqual(handler2.Events, expectedEvents) {
+		t.Error("the events were incorrect:")
+		t.Log(handler2.Events)
 	}
-	if handler2.Time.Before(handler.Time) {
-		t.Error("the first handler shoud be run first")
-	}
-}
-
-// Although most cases will publish events to other parts
-// of a system when you're running tests you may not need
-// an event publisher for ease of setup.
-func TestEventBusWithNilPublisher(t *testing.T) {
-	eb := NewEventBus()
-	mockEvent := eh.NewEventForAggregate(
-		mocks.EventType,
-		&mocks.EventData{Content: "event1"},
-		time.Now(),
-		mocks.AggregateType,
-		eh.UUID("c1138e5f-f6fb-4dd0-8e79-255c6c8d3756"),
-		1,
-	)
-	eb.HandleEvent(context.Background(), mockEvent)
 }

--- a/examples/guestlist/memory/memory_test.go
+++ b/examples/guestlist/memory/memory_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/looplab/eventhorizon/commandhandler/bus"
 	eventbus "github.com/looplab/eventhorizon/eventbus/local"
 	eventstore "github.com/looplab/eventhorizon/eventstore/memory"
-	eventpublisher "github.com/looplab/eventhorizon/publisher/local"
 	repo "github.com/looplab/eventhorizon/repo/memory"
 
 	"github.com/looplab/eventhorizon/examples/guestlist/domain"
@@ -37,8 +36,6 @@ func Example() {
 
 	// Create the event bus that distributes events.
 	eventBus := eventbus.NewEventBus()
-	eventPublisher := eventpublisher.NewEventPublisher()
-	eventBus.SetPublisher(eventPublisher)
 
 	// Create the command bus.
 	commandBus := bus.NewCommandHandler()
@@ -52,7 +49,6 @@ func Example() {
 	domain.Setup(
 		eventStore,
 		eventBus,
-		eventPublisher,
 		commandBus,
 		invitationRepo, guestListRepo,
 		eventID,

--- a/examples/guestlist/mongodb/mongodb_test.go
+++ b/examples/guestlist/mongodb/mongodb_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/looplab/eventhorizon/commandhandler/bus"
 	eventbus "github.com/looplab/eventhorizon/eventbus/local"
 	eventstore "github.com/looplab/eventhorizon/eventstore/mongodb"
-	eventpublisher "github.com/looplab/eventhorizon/publisher/local"
 	repo "github.com/looplab/eventhorizon/repo/mongodb"
 	"github.com/looplab/eventhorizon/repo/version"
 
@@ -51,8 +50,6 @@ func Example() {
 
 	// Create the event bus that distributes events.
 	eventBus := eventbus.NewEventBus()
-	eventPublisher := eventpublisher.NewEventPublisher()
-	eventBus.SetPublisher(eventPublisher)
 
 	// Create the command bus.
 	commandBus := bus.NewCommandHandler()
@@ -76,7 +73,6 @@ func Example() {
 	domain.Setup(
 		eventStore,
 		eventBus,
-		eventPublisher,
 		commandBus,
 		invitationVersionRepo, guestListRepo,
 		eventID,

--- a/matcher.go
+++ b/matcher.go
@@ -1,0 +1,63 @@
+// Copyright (c) 2018 - Max Ekman <max@looplab.se>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package eventhorizon
+
+// EventMatcher is a func that can match event to a criteria.
+type EventMatcher func(Event) bool
+
+// MatchAny matches any event.
+func MatchAny() EventMatcher {
+	return func(e Event) bool {
+		return true
+	}
+}
+
+// MatchEvent matches a specific event type, nil events never match.
+func MatchEvent(t EventType) EventMatcher {
+	return func(e Event) bool {
+		return e != nil && e.EventType() == t
+	}
+}
+
+// MatchAggregate matches a specific aggregate type, nil events never match.
+func MatchAggregate(t AggregateType) EventMatcher {
+	return func(e Event) bool {
+		return e != nil && e.AggregateType() == t
+	}
+}
+
+// MatchAnyOf matches if any of several matchers matches.
+func MatchAnyOf(matchers ...EventMatcher) EventMatcher {
+	return func(e Event) bool {
+		for _, m := range matchers {
+			if m(e) {
+				return true
+			}
+		}
+		return false
+	}
+}
+
+// MatchAnyEventOf matches if any of several matchers matches.
+func MatchAnyEventOf(types ...EventType) EventMatcher {
+	return func(e Event) bool {
+		for _, t := range types {
+			if MatchEvent(t)(e) {
+				return true
+			}
+		}
+		return false
+	}
+}

--- a/matcher_test.go
+++ b/matcher_test.go
@@ -1,0 +1,107 @@
+// Copyright (c) 2018 - Max Ekman <max@looplab.se>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package eventhorizon
+
+import (
+	"testing"
+	"time"
+)
+
+func TestMatchAny(t *testing.T) {
+	m := MatchAny()
+
+	if !m(nil) {
+		t.Error("match any should always match")
+	}
+
+	e := NewEvent("test", nil, time.Now())
+	if !m(e) {
+		t.Error("match any should always match")
+	}
+}
+func TestMatchEvent(t *testing.T) {
+	et := EventType("test")
+	m := MatchEvent(et)
+
+	if m(nil) {
+		t.Error("match event should not match nil event")
+	}
+
+	e := NewEvent(et, nil, time.Now())
+	if !m(e) {
+		t.Error("match event should match the event")
+	}
+
+	e = NewEvent("other", nil, time.Now())
+	if m(e) {
+		t.Error("match event should not match the event")
+	}
+}
+
+func TestMatchAggregate(t *testing.T) {
+	at := AggregateType("test")
+	m := MatchAggregate(at)
+
+	if m(nil) {
+		t.Error("match aggregate should not match nil event")
+	}
+
+	e := NewEventForAggregate("test", nil, time.Now(), at, "", 0)
+	if !m(e) {
+		t.Error("match aggregate should match the event")
+	}
+
+	e = NewEventForAggregate("test", nil, time.Now(), "other", "", 0)
+	if m(e) {
+		t.Error("match aggregate should not match the event")
+	}
+}
+
+func TestMatchAnyOf(t *testing.T) {
+	et1 := EventType("et1")
+	et2 := EventType("et2")
+	m := MatchAnyOf(
+		MatchEvent(et1),
+		MatchEvent(et2),
+	)
+
+	e := NewEvent(et1, nil, time.Now())
+	if !m(e) {
+		t.Error("match any of should match the first event")
+	}
+	e = NewEvent(et2, nil, time.Now())
+	if !m(e) {
+		t.Error("match any of should match the last event")
+	}
+}
+
+func TestMatchAnyEventOf(t *testing.T) {
+	et1 := EventType("test")
+	et2 := EventType("test")
+	m := MatchAnyEventOf(et1, et2)
+
+	if m(nil) {
+		t.Error("match any event of should not match nil event")
+	}
+
+	e1 := NewEvent(et1, nil, time.Now())
+	if !m(e1) {
+		t.Error("match any event of should match the first event")
+	}
+	e2 := NewEvent(et2, nil, time.Now())
+	if !m(e2) {
+		t.Error("match any event of should match the second event")
+	}
+}

--- a/publisher.go
+++ b/publisher.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 - Max Ekman <max@looplab.se>
+// Copyright (c) 2014 - Max Ekman <max@looplab.se>
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,23 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package mocks
+package eventhorizon
 
-import (
-	"context"
-	"testing"
+import "context"
 
-	eh "github.com/looplab/eventhorizon"
-)
+// EventPublisher is a publisher of events to observers.
+type EventPublisher interface {
+	EventHandler
 
-func TestMockContext(t *testing.T) {
-	ctx := WithContextOne(context.Background(), "string")
-	if val, ok := ContextOne(ctx); !ok || val != "string" {
-		t.Error("the context value should exist")
-	}
-	vals := eh.MarshalContext(ctx)
-	ctx = eh.UnmarshalContext(vals)
-	if val, ok := ContextOne(ctx); !ok || val != "string" {
-		t.Error("the context marshalling should work")
-	}
+	// AddObserver adds an observer.
+	AddObserver(EventObserver)
+}
+
+// EventObserver is an observer of events.
+// All observers will receive an event.
+type EventObserver interface {
+	// Notify is notifed about an event.
+	Notify(context.Context, Event)
 }

--- a/publisher/local/publisher.go
+++ b/publisher/local/publisher.go
@@ -21,6 +21,8 @@ import (
 	eh "github.com/looplab/eventhorizon"
 )
 
+var _ = eh.EventPublisher(&EventPublisher{})
+
 // EventPublisher is an event publisher that notifies registered EventHandlers
 // of published events. It will use the SimpleEventHandlingStrategy by default.
 type EventPublisher struct {
@@ -36,9 +38,14 @@ func NewEventPublisher() *EventPublisher {
 	return b
 }
 
-// PublishEvent implements the PublishEvent method of the eventhorizon.EventPublisher
+// HandlerType implements the HandlerType method of the eventhorizon.EventHandler interface.
+func (b *EventPublisher) HandlerType() eh.EventHandlerType {
+	return "LocalEventPublisher"
+}
+
+// HandleEvent implements the HandleEvent method of the eventhorizon.EventPublisher
 // interface.
-func (b *EventPublisher) PublishEvent(ctx context.Context, event eh.Event) error {
+func (b *EventPublisher) HandleEvent(ctx context.Context, event eh.Event) error {
 	b.observersMu.RLock()
 	defer b.observersMu.RUnlock()
 

--- a/publisher/testutil/common_tests.go
+++ b/publisher/testutil/common_tests.go
@@ -40,7 +40,7 @@ func EventPublisherCommonTests(t *testing.T, publisher1, publisher2 eh.EventPubl
 	event1 := eh.NewEventForAggregate(mocks.EventType, &mocks.EventData{Content: "event1"},
 		timestamp,
 		mocks.AggregateType, id, 1)
-	if err := publisher1.PublishEvent(ctx, event1); err != nil {
+	if err := publisher1.HandleEvent(ctx, event1); err != nil {
 		t.Error("there should be no error:", err)
 	}
 	expectedEvents := []eh.Event{event1}
@@ -70,7 +70,7 @@ func EventPublisherCommonTests(t *testing.T, publisher1, publisher2 eh.EventPubl
 	t.Log("publish another event")
 	event2 := eh.NewEventForAggregate(mocks.EventOtherType, nil, timestamp,
 		mocks.AggregateType, id, 2)
-	if err := publisher1.PublishEvent(ctx, event2); err != nil {
+	if err := publisher1.HandleEvent(ctx, event2); err != nil {
 		t.Error("there should be no error:", err)
 	}
 	expectedEvents = []eh.Event{event1, event2}


### PR DESCRIPTION
The EventMatcher allows for a more flexible and simpler handler setup. This PR also turns the EventPublishers into ordinary EventHandlers, which is a step towards a fully distributed event bus.

Fixes #84.