### PR TITLE
ISSUE-185 / Add publishing of events in the model aggregate

### DIFF
--- a/aggregatestore/events/aggregatestore_test.go
+++ b/aggregatestore/events/aggregatestore_test.go
@@ -208,7 +208,7 @@ func TestAggregateStore_SaveEvents(t *testing.T) {
 	}
 	agg.err = nil
 
-	// Aggregate error.
+	// Bus error.
 	event1 = agg.StoreEvent(mocks.EventType, &mocks.EventData{Content: "event"}, timestamp)
 	bus.Err = errors.New("bus error")
 	err = store.Save(ctx, agg)

--- a/aggregatestore/model/eventpublisher.go
+++ b/aggregatestore/model/eventpublisher.go
@@ -1,0 +1,40 @@
+// Copyright (c) 2017 - Max Ekman <max@looplab.se>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+import (
+	eh "github.com/looplab/eventhorizon"
+)
+
+// EventPublisher is an optional event publisher that can be implemented by
+// aggregates to allow for publishing of events on a successful save.
+type EventPublisher interface {
+	// EventsToPublish returns all events to publish.
+	EventsToPublish() []eh.Event
+}
+
+// SliceEventPublisher is an EventPublisher using a slice to store events.
+type SliceEventPublisher []eh.Event
+
+// PublishEvent registers an event to be published after the aggregate
+// has been successfully saved.
+func (a *SliceEventPublisher) PublishEvent(e eh.Event) {
+	*a = append(*a, e)
+}
+
+// EventsToPublish implements the EventsToPublish method of the EventPublisher interface.
+func (a *SliceEventPublisher) EventsToPublish() []eh.Event {
+	return *a
+}


### PR DESCRIPTION
The model aggregate can now optionally publish events on the bus if it implements the new model.EventPublisher interface. The SliceEventPublisher provides a basic embeddable implementation, see the test case for usage.

@superchalupa I got reason enough to need this myself, hope it solves your use case also!

Fixes #185.