### PR TITLE
ISSUE-204 / Fix event publisher in aggregatestore/model

### DIFF
--- a/aggregatestore/model/aggregatestore.go
+++ b/aggregatestore/model/aggregatestore.go
@@ -75,7 +75,9 @@ func (r *AggregateStore) Save(ctx context.Context, aggregate eh.Aggregate) error
 
 	// Publish events if supported by the aggregate.
 	if publisher, ok := aggregate.(EventPublisher); ok && r.bus != nil {
-		for _, e := range publisher.EventsToPublish() {
+		events := publisher.EventsToPublish()
+		publisher.ClearEvents()
+		for _, e := range events {
 			if err := r.bus.PublishEvent(ctx, e); err != nil {
 				return err
 			}

--- a/aggregatestore/model/aggregatestore_test.go
+++ b/aggregatestore/model/aggregatestore_test.go
@@ -139,11 +139,15 @@ func TestAggregateStore_SaveWithPublish(t *testing.T) {
 	store, repo, bus := createStore(t)
 
 	ctx := context.Background()
-
 	id := eh.NewUUID()
 	agg := NewAggregate(id)
 	event := eh.NewEvent("test", nil, time.Now())
+
+	// Normal publish should publish events on the bus.
 	agg.PublishEvent(event)
+	if len(agg.SliceEventPublisher) != 1 {
+		t.Error("there should be one event to publish")
+	}
 	err := store.Save(ctx, agg)
 	if err != nil {
 		t.Error("there should be no error:", err)
@@ -154,12 +158,19 @@ func TestAggregateStore_SaveWithPublish(t *testing.T) {
 	if !reflect.DeepEqual(bus.Events, []eh.Event{event}) {
 		t.Error("there should be an event on the bus:", bus.Events)
 	}
+	if len(agg.SliceEventPublisher) != 0 {
+		t.Error("there should be no events to publish")
+	}
 
-	// Bus error.
+	// Simulate a bus error.
 	bus.Err = errors.New("bus error")
+	agg.PublishEvent(event)
 	err = store.Save(ctx, agg)
 	if err == nil || err.Error() != "bus error" {
 		t.Error("there should be an error named 'error':", err)
+	}
+	if len(agg.SliceEventPublisher) != 0 {
+		t.Error("there should be no events to publish")
 	}
 }
 

--- a/aggregatestore/model/eventpublisher.go
+++ b/aggregatestore/model/eventpublisher.go
@@ -23,6 +23,8 @@ import (
 type EventPublisher interface {
 	// EventsToPublish returns all events to publish.
 	EventsToPublish() []eh.Event
+	// ClearEvents clears all events after a publish.
+	ClearEvents()
 }
 
 // SliceEventPublisher is an EventPublisher using a slice to store events.
@@ -37,4 +39,9 @@ func (a *SliceEventPublisher) PublishEvent(e eh.Event) {
 // EventsToPublish implements the EventsToPublish method of the EventPublisher interface.
 func (a *SliceEventPublisher) EventsToPublish() []eh.Event {
 	return *a
+}
+
+// ClearEvents implements the ClearEvents method of the EventPublisher interface.
+func (a *SliceEventPublisher) ClearEvents() {
+	*a = nil
 }


### PR DESCRIPTION
# Summary
The events that have been published should be cleared in the aggregatestore/model EventPublisher.

# How to test

# Issue

Fixes #204.

# Notes
