### PR TITLE
ISSUE-71 / Add formal mechanism for validating commands

### DIFF
--- a/middleware/commandhandler/validator/commandhandler.go
+++ b/middleware/commandhandler/validator/commandhandler.go
@@ -46,3 +46,19 @@ type Command interface {
 	// Validate returns the error when validating the command.
 	Validate() error
 }
+
+// CommandWithValidation returns a wrapped command with a validation method.
+func CommandWithValidation(cmd eh.Command, v func() error) Command {
+	return &command{Command: cmd, validate: v}
+}
+
+// private implementation to wrap ordinary commands and add a validation method.
+type command struct {
+	eh.Command
+	validate func() error
+}
+
+// Validate implements the Validate method of the Command interface
+func (c *command) Validate() error {
+	return c.validate()
+}

--- a/middleware/commandhandler/validator/commandhandler.go
+++ b/middleware/commandhandler/validator/commandhandler.go
@@ -1,0 +1,48 @@
+// Copyright (c) 2018 - The Event Horizon authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validator
+
+import (
+	"context"
+
+	eh "github.com/looplab/eventhorizon"
+)
+
+// NewMiddleware returns a new async handling middleware that validate commands
+// with its own validation method.
+func NewMiddleware() eh.CommandHandlerMiddleware {
+	return eh.CommandHandlerMiddleware(func(h eh.CommandHandler) eh.CommandHandler {
+		return eh.CommandHandlerFunc(func(ctx context.Context, cmd eh.Command) error {
+			// Call the validation method if it exists
+			if c, ok := cmd.(Command); ok {
+				err := c.Validate()
+				if err != nil {
+					return err
+				}
+			}
+
+			// Immediate command execution.
+			return h.HandleCommand(ctx, cmd)
+		})
+	})
+}
+
+// Command is a command with its own validation method.
+type Command interface {
+	eh.Command
+
+	// Validate returns the error when validating the command.
+	Validate() error
+}

--- a/middleware/commandhandler/validator/commandhandler_test.go
+++ b/middleware/commandhandler/validator/commandhandler_test.go
@@ -1,0 +1,76 @@
+// Copyright (c) 2017 - The Event Horizon authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validator
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/apterf/eventhorizon/mocks"
+	eh "github.com/looplab/eventhorizon"
+)
+
+func TestCommandHandler_Immediate(t *testing.T) {
+	inner := &mocks.CommandHandler{}
+	m := NewMiddleware()
+	h := eh.UseCommandHandlerMiddleware(inner, m)
+	cmd := mocks.Command{
+		ID:      eh.NewUUID(),
+		Content: "content",
+	}
+	if err := h.HandleCommand(context.Background(), cmd); err != nil {
+		t.Error("there should be no error:", err)
+	}
+	if !reflect.DeepEqual(inner.Commands, []eh.Command{cmd}) {
+		t.Error("the command should have been handled:", inner.Commands)
+	}
+}
+
+func TestCommandHandler_WithValidationError(t *testing.T) {
+	inner := &mocks.CommandHandler{}
+	m := NewMiddleware()
+	h := eh.UseCommandHandlerMiddleware(inner, m)
+	cmd := &mocks.Command{
+		ID:      eh.NewUUID(),
+		Content: "content",
+	}
+	e := errors.New("a validation error")
+	c := CommandWithValidation(cmd, func() error { return e })
+	if err := h.HandleCommand(context.Background(), c); err != e {
+		t.Error("there should be an error:", e)
+	}
+	if len(inner.Commands) != 0 {
+		t.Error("the command should not have been handled yet:", inner.Commands)
+	}
+}
+
+func TestCommandHandler_WithValidationNoError(t *testing.T) {
+	inner := &mocks.CommandHandler{}
+	m := NewMiddleware()
+	h := eh.UseCommandHandlerMiddleware(inner, m)
+	cmd := &mocks.Command{
+		ID:      eh.NewUUID(),
+		Content: "content",
+	}
+	c := CommandWithValidation(cmd, func() error { return nil })
+	if err := h.HandleCommand(context.Background(), c); err != nil {
+		t.Error("there should be no error:", err)
+	}
+	if !reflect.DeepEqual(inner.Commands, []eh.Command{c}) {
+		t.Error("the command should have been handled:", inner.Commands)
+	}
+}


### PR DESCRIPTION
# Summary

Add validation `CommandHandler` middleware for handling flexible command validation.

# How to test

Run `go test` with related test file.

# Issue

Fixes #71 .

# Notes
