### PR TITLE
Remove redis from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,10 +58,6 @@ These are the drivers for messaging, currently only publishers.
 
 Fully synchrounos. Useful for testing/experimentation.
 
-### Redis
-
-Fairly mature, used in production.
-
 ### GCP Cloud Pub/Sub
 
 Experimental driver.


### PR DESCRIPTION
This one is just a minor thing, but it was right there on the front page.

Just a minor clean-up for https://github.com/looplab/eventhorizon/pull/223