### PR TITLE
 Add the ability to wait for all the channels to be closed before exiting the main thread.

### DIFF
--- a/eventbus/acceptance_testing.go
+++ b/eventbus/acceptance_testing.go
@@ -115,7 +115,6 @@ func AcceptanceTest(t *testing.T, bus1, bus2 eh.EventBus, timeout time.Duration)
 		}
 		if len(handlerBus2.Events) == 1 {
 			t.Log(pretty.Sprint(handlerBus2.Events[0]))
-			// t.Logf("%#v", handlerBus2.Events[0])
 		}
 	}
 	if mocks.EqualEvents(handlerBus1.Events, handlerBus2.Events) {

--- a/eventbus/local/eventbus.go
+++ b/eventbus/local/eventbus.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2014 - The Event Horizon authors.
+// Copyright (c) 2018 - The Event Horizon authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/eventbus/local/eventbus_test.go
+++ b/eventbus/local/eventbus_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2014 - The Event Horizon authors.
+// Copyright (c) 2018 - The Event Horizon authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/eventbus/local/eventbus_test.go
+++ b/eventbus/local/eventbus_test.go
@@ -39,4 +39,8 @@ func TestEventBus(t *testing.T) {
 
 	eventbus.AcceptanceTest(t, bus1, bus2, time.Second)
 
+	bus1.Close()
+	bus2.Close()
+	bus1.Wait()
+	bus2.Wait()
 }


### PR DESCRIPTION
# Summary
This is to solve an issue where the processing of some events wouldn't be complete when the main process exited
# How to test
- Add an event handler (projector) and add a long task in the find method (example sleep for a few seconds)
- Send a command immediately after the setup of the command & event buses.
- See that the event handler didn't complete it's task before the main process exits
# Notes
This is only relevant if event horizon isn't used as a long running process or if you want to be sure your event listeners are done before you shut down the application. In our case we're running in AWS Lambda which make it very short lived.

I'm open to suggestions if you have a better way to achieve this :)