### PR TITLE
Fix Command.isZero() to handle a Command with array field #226

### DIFF
--- a/command.go
+++ b/command.go
@@ -144,8 +144,15 @@ func isZero(v reflect.Value) bool {
 		// Types that are not allowed at all.
 		// NOTE: Would be better with its own error for this.
 		return true
-	case reflect.Map, reflect.Array, reflect.Slice:
+	case reflect.Map, reflect.Slice:
 		return v.IsNil()
+	case reflect.Array:
+		for i := 0; i < v.Len(); i++ {
+			if !isZero(v.Index(i)) {
+				return false
+			}
+		}
+		return true
 	case reflect.Interface, reflect.String:
 		z := reflect.Zero(v.Type())
 		return v.Interface() == z.Interface()

--- a/command_test.go
+++ b/command_test.go
@@ -150,6 +150,18 @@ func TestCheckCommand(t *testing.T) {
 	if err != nil {
 		t.Error("there should be no error:", err)
 	}
+
+	// Check all array fields.
+	err = CheckCommand(&TestCommandArray{NewUUID(), [1]string{"string"}, [1]int{0}, [1]struct{ Test string }{struct{ Test string }{"struct"}}})
+	if err != nil {
+		t.Error("there should be no error:", err)
+	}
+
+	// Empty array field.
+	err = CheckCommand(&TestCommandArray{NewUUID(), [1]string{""}, [1]int{0}, [1]struct{ Test string }{struct{ Test string }{"struct"}}})
+	if err == nil || err.Error() != "missing field: StringArray" {
+		t.Error("there should be a missing field error:", err)
+	}
 }
 
 // Mocks for Register/Unregister.
@@ -332,3 +344,18 @@ var _ = Command(TestCommandPrivate{})
 func (t TestCommandPrivate) AggregateID() UUID            { return t.TestID }
 func (t TestCommandPrivate) AggregateType() AggregateType { return AggregateType("Test") }
 func (t TestCommandPrivate) CommandType() CommandType     { return CommandType("TestCommandPrivate") }
+
+type TestCommandArray struct {
+	TestID      UUID
+	StringArray [1]string
+	IntArray    [1]int
+	StructArray [1]struct {
+		Test string
+	}
+}
+
+var _ = Command(TestCommandArray{})
+
+func (t TestCommandArray) AggregateID() UUID            { return t.TestID }
+func (t TestCommandArray) AggregateType() AggregateType { return AggregateType("Test") }
+func (t TestCommandArray) CommandType() CommandType     { return CommandType("TestCommandArray") }


### PR DESCRIPTION
# Summary
`reflect.IsNil()` doesn't accept an array type as an argument.
This PR makes `Command.isZero()` to handle a command with array field.

# How to test
just simple `go test ./...`. see `command_test.go` file.

# Issue

Fixes #226

# Notes
This PR is separated from PR #227. PR #227 should be revised after this PR accepted.