### PR TITLE
Add Errors function to EventBus interface

### DIFF
--- a/eventbus.go
+++ b/eventbus.go
@@ -34,4 +34,7 @@ type EventBus interface {
 	// AddObserver adds an observer. Panics if the observer is nil or the observer
 	// is already added.
 	AddObserver(EventMatcher, EventHandler)
+
+	// Errors returns an error channel where async handling errors are sent.
+	Errors() <-chan error
 }

--- a/eventbus/acceptance_testing.go
+++ b/eventbus/acceptance_testing.go
@@ -16,6 +16,7 @@ package eventbus
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -168,5 +169,21 @@ func AcceptanceTest(t *testing.T, bus1, bus2 eh.EventBus, timeout time.Duration)
 	}
 	if val, ok := mocks.ContextOne(observerBus2.Context); !ok || val != "testval" {
 		t.Error("the context should be correct:", observerBus2.Context)
+	}
+
+	// Test async errors from handlers.
+	errorHandler := mocks.NewEventHandler("error_handler")
+	errorHandler.Err = errors.New("handler error")
+	bus1.AddHandler(eh.MatchAny(), errorHandler)
+	if err := bus1.PublishEvent(ctx, event1); err != nil {
+		t.Error("there should be no error:", err)
+	}
+	select {
+	case <-time.After(time.Second):
+		t.Error("there should be an async error")
+	case err := <-bus1.Errors():
+		if err == nil {
+			t.Error("there should have been a non-nil async error")
+		}
 	}
 }

--- a/eventbus/gcp/eventbus.go
+++ b/eventbus/gcp/eventbus.go
@@ -132,7 +132,7 @@ func (b *EventBus) AddObserver(m eh.EventMatcher, h eh.EventHandler) {
 	go b.handle(m, h, sub)
 }
 
-// Errors returns an error channel where async handling errors are sent.
+// Errors implements the Errors method of the eventhorizon.EventBus interface.
 func (b *EventBus) Errors() <-chan error {
 	return b.errCh
 }

--- a/eventbus/gcp/eventbus.go
+++ b/eventbus/gcp/eventbus.go
@@ -38,7 +38,7 @@ type EventBus struct {
 	topic        *pubsub.Topic
 	registered   map[eh.EventHandlerType]struct{}
 	registeredMu sync.RWMutex
-	errCh        chan Error
+	errCh        chan error
 }
 
 // Error is an async error containing the error and the event.
@@ -77,7 +77,7 @@ func NewEventBus(projectID, appID string) (*EventBus, error) {
 		client:     client,
 		topic:      topic,
 		registered: map[eh.EventHandlerType]struct{}{},
-		errCh:      make(chan Error, 100),
+		errCh:      make(chan error, 100),
 	}, nil
 }
 
@@ -133,7 +133,7 @@ func (b *EventBus) AddObserver(m eh.EventMatcher, h eh.EventHandler) {
 }
 
 // Errors returns an error channel where async handling errors are sent.
-func (b *EventBus) Errors() <-chan Error {
+func (b *EventBus) Errors() <-chan error {
 	return b.errCh
 }
 

--- a/eventbus/local/eventbus.go
+++ b/eventbus/local/eventbus.go
@@ -76,7 +76,7 @@ func (b *EventBus) AddObserver(m eh.EventMatcher, h eh.EventHandler) {
 	go b.handle(m, h, ch)
 }
 
-// Errors returns an error channel where async handling errors are sent.
+// Errors implements the Errors method of the eventhorizon.EventBus interface.
 func (b *EventBus) Errors() <-chan error {
 	return b.errCh
 }

--- a/eventbus/local/eventbus.go
+++ b/eventbus/local/eventbus.go
@@ -31,7 +31,7 @@ type EventBus struct {
 	group        *Group
 	registered   map[eh.EventHandlerType]struct{}
 	registeredMu sync.RWMutex
-	errCh        chan Error
+	errCh        chan error
 }
 
 // Error is an async error containing the error and the event.
@@ -54,7 +54,7 @@ func NewEventBus(g *Group) *EventBus {
 	return &EventBus{
 		group:      g,
 		registered: map[eh.EventHandlerType]struct{}{},
-		errCh:      make(chan Error, 100),
+		errCh:      make(chan error, 100),
 	}
 }
 
@@ -77,7 +77,7 @@ func (b *EventBus) AddObserver(m eh.EventMatcher, h eh.EventHandler) {
 }
 
 // Errors returns an error channel where async handling errors are sent.
-func (b *EventBus) Errors() <-chan Error {
+func (b *EventBus) Errors() <-chan error {
 	return b.errCh
 }
 

--- a/mocks/mocks.go
+++ b/mocks/mocks.go
@@ -341,6 +341,11 @@ func (b *EventBus) AddHandler(m eh.EventMatcher, h eh.EventHandler) {}
 // AddObserver implements the AddObserver method of the eventhorizon.EventBus interface.
 func (b *EventBus) AddObserver(m eh.EventMatcher, h eh.EventHandler) {}
 
+// Errors implements the Error method of the eventhorizon.EventBus interface.
+func (b *EventBus) Errors() <-chan error {
+	return make(chan error)
+}
+
 // Repo is a mocked eventhorizon.ReadRepo, useful in testing.
 type Repo struct {
 	ParentRepo eh.ReadWriteRepo


### PR DESCRIPTION
# Summary
1. Add `Errors` function to `EventBus` interface, since it's present in both current implementations of `EventBus`.
2. Generalize `Errors` to return a `chan error` instead of a `chan local.Error` or `chan gcp.Error`. That way the `EventBus` implementation can be swapped out easily.

# How to test
Run acceptance tests for GCP and local `EventBus` implementations with `make test_docker`.

# Issue
No issue created for this.