### PR TITLE
Add ClientOptions for GCP pubsub clients

### DIFF
--- a/eventbus/gcp/eventbus.go
+++ b/eventbus/gcp/eventbus.go
@@ -23,6 +23,7 @@ import (
 
 	"cloud.google.com/go/pubsub"
 	"github.com/globalsign/mgo/bson"
+	"google.golang.org/api/option"
 
 	eh "github.com/looplab/eventhorizon"
 )
@@ -54,9 +55,9 @@ func (e Error) Error() string {
 }
 
 // NewEventBus creates a EventBus.
-func NewEventBus(projectID, appID string) (*EventBus, error) {
+func NewEventBus(projectID, appID string, opts ...option.ClientOption) (*EventBus, error) {
 	ctx := context.Background()
-	client, err := pubsub.NewClient(ctx, projectID)
+	client, err := pubsub.NewClient(ctx, projectID, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/eventbus/gcp/eventbus.go
+++ b/eventbus/gcp/eventbus.go
@@ -54,7 +54,7 @@ func (e Error) Error() string {
 	return fmt.Sprintf("%s: (%s)", e.Err, e.Event.String())
 }
 
-// NewEventBus creates a EventBus.
+// NewEventBus creates an EventBus.
 func NewEventBus(projectID, appID string, opts ...option.ClientOption) (*EventBus, error) {
 	ctx := context.Background()
 	client, err := pubsub.NewClient(ctx, projectID, opts...)

--- a/eventbus/gcp/eventbus.go
+++ b/eventbus/gcp/eventbus.go
@@ -54,7 +54,7 @@ func (e Error) Error() string {
 	return fmt.Sprintf("%s: (%s)", e.Err, e.Event.String())
 }
 
-// NewEventBus creates an EventBus.
+// NewEventBus creates an EventBus, with optional GCP connection settings.
 func NewEventBus(projectID, appID string, opts ...option.ClientOption) (*EventBus, error) {
 	ctx := context.Background()
 	client, err := pubsub.NewClient(ctx, projectID, opts...)

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f // indirect
 	golang.org/x/sys v0.0.0-20180903190138-2b024373dcd9 // indirect
 	golang.org/x/text v0.3.0 // indirect
-	google.golang.org/api v0.0.0-20180904000447-0ad5a633fea1 // indirect
+	google.golang.org/api v0.0.0-20180904000447-0ad5a633fea1
 	google.golang.org/appengine v1.1.0 // indirect
 	google.golang.org/genproto v0.0.0-20180831171423-11092d34479b // indirect
 	google.golang.org/grpc v1.14.0 // indirect


### PR DESCRIPTION
# Summary
By default, Cloud Pub/sub connects through an environment variable. There are a few cases in which this is unergonomic or unworkable, including:
1. If the service is _not_ running on a hosted GCE service, then the environment variable isn't already set.
2. If the service needs to connect to multiple GCP projects from one application, the environment variable will get in the way of having multiple credentials.

In combination with  [`option.WithCredentialsFile`](https://cloud.google.com/docs/authentication/production#passing_the_path_to_the_service_account_key_in_code), this PR lets us initialize a Cloud Pub/sub client with any credentials we like. It's also backwards-compatible with current usages of the GCP Pub/sub `EventBus`.

# How to test

- [x] Deploy to a non-GCP environment and connect to GCP Pub/sub using credentials in a `ClientOption` (I'm working on this now).

# Issue

No issue opened.

# Notes
