### PR TITLE
ISSUE-232 / Change some EventBus panics to errors

### DIFF
--- a/eventbus.go
+++ b/eventbus.go
@@ -42,12 +42,14 @@ type EventBus interface {
 	PublishEvent(context.Context, Event) error
 
 	// AddHandler adds a handler for an event. Panics if either the matcher
-	// or handler is nil or the handler is already added.
-	AddHandler(EventMatcher, EventHandler)
+	// or handler is nil or the handler is already added. Returns an error if
+	// there was some other error adding the handler.
+	AddHandler(EventMatcher, EventHandler) error
 
 	// AddObserver adds an observer. Panics if the observer is nil or the observer
-	// is already added.
-	AddObserver(EventMatcher, EventHandler)
+	// is already added. Returns an error if there was some other error adding
+	// the observer.
+	AddObserver(EventMatcher, EventHandler) error
 
 	// Errors returns an error channel where async handling errors are sent.
 	Errors() <-chan EventBusError

--- a/eventbus/acceptance_testing.go
+++ b/eventbus/acceptance_testing.go
@@ -90,11 +90,26 @@ func AcceptanceTest(t *testing.T, bus1, bus2 eh.EventBus, timeout time.Duration)
 	anotherHandlerBus2 := mocks.NewEventHandler("another_handler")
 	observerBus1 := mocks.NewEventHandler(observerName)
 	observerBus2 := mocks.NewEventHandler(observerName)
-	bus1.AddHandler(eh.MatchAny(), handlerBus1)
-	bus2.AddHandler(eh.MatchAny(), handlerBus2)
-	bus2.AddHandler(eh.MatchAny(), anotherHandlerBus2)
-	bus1.AddObserver(eh.MatchAny(), observerBus1)
-	bus2.AddObserver(eh.MatchAny(), observerBus2)
+	err := bus1.AddHandler(eh.MatchAny(), handlerBus1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = bus2.AddHandler(eh.MatchAny(), handlerBus2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = bus2.AddHandler(eh.MatchAny(), anotherHandlerBus2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = bus1.AddObserver(eh.MatchAny(), observerBus1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = bus2.AddObserver(eh.MatchAny(), observerBus2)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	if err := bus1.PublishEvent(ctx, event1); err != nil {
 		t.Error("there should be no error:", err)
@@ -173,7 +188,10 @@ func AcceptanceTest(t *testing.T, bus1, bus2 eh.EventBus, timeout time.Duration)
 	// Test async errors from handlers.
 	errorHandler := mocks.NewEventHandler("error_handler")
 	errorHandler.Err = errors.New("handler error")
-	bus1.AddHandler(eh.MatchAny(), errorHandler)
+	err = bus1.AddHandler(eh.MatchAny(), errorHandler)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if err := bus1.PublishEvent(ctx, event1); err != nil {
 		t.Error("there should be no error:", err)
 	}

--- a/eventbus/local/eventbus.go
+++ b/eventbus/local/eventbus.go
@@ -54,15 +54,17 @@ func (b *EventBus) PublishEvent(ctx context.Context, event eh.Event) error {
 }
 
 // AddHandler implements the AddHandler method of the eventhorizon.EventBus interface.
-func (b *EventBus) AddHandler(m eh.EventMatcher, h eh.EventHandler) {
+func (b *EventBus) AddHandler(m eh.EventMatcher, h eh.EventHandler) error {
 	ch := b.channel(m, h, false)
 	go b.handle(m, h, ch)
+	return nil
 }
 
 // AddObserver implements the AddObserver method of the eventhorizon.EventBus interface.
-func (b *EventBus) AddObserver(m eh.EventMatcher, h eh.EventHandler) {
+func (b *EventBus) AddObserver(m eh.EventMatcher, h eh.EventHandler) error {
 	ch := b.channel(m, h, true)
 	go b.handle(m, h, ch)
+	return nil
 }
 
 // Errors implements the Errors method of the eventhorizon.EventBus interface.

--- a/mocks/mocks.go
+++ b/mocks/mocks.go
@@ -336,10 +336,14 @@ func (b *EventBus) PublishEvent(ctx context.Context, event eh.Event) error {
 }
 
 // AddHandler implements the AddHandler method of the eventhorizon.EventBus interface.
-func (b *EventBus) AddHandler(m eh.EventMatcher, h eh.EventHandler) {}
+func (b *EventBus) AddHandler(m eh.EventMatcher, h eh.EventHandler) error {
+	return nil
+}
 
 // AddObserver implements the AddObserver method of the eventhorizon.EventBus interface.
-func (b *EventBus) AddObserver(m eh.EventMatcher, h eh.EventHandler) {}
+func (b *EventBus) AddObserver(m eh.EventMatcher, h eh.EventHandler) error {
+	return nil
+}
 
 // Errors implements the Error method of the eventhorizon.EventBus interface.
 func (b *EventBus) Errors() <-chan eh.EventBusError {


### PR DESCRIPTION
# Summary

This PR changes to return errors from `AddHandler` and `AddObserver` on the `EventBus` interface. The reason for this is that for the GCP pub/sub implementation, there are some operations, specifically checking if a subscription exists and creating a subscription, that may error because of gRPC network issues communicating with GCP. Ideally any network errors would be bubbled up to the application so that we can log and alert on them, rather than paying attention to panics (and potentially losing data when services restart).

# How to test

I added tests to be sure that `AddObserver` and `AddHandler` return `nil` when used normally. They should only return errors in network failure cases.

# Issue

Fixes #232.

# Notes

This will cause a problem for existing implementations if they expect `AddHandler` and `AddObserver` to panic when there is a network failure. Any existing implementations will now have to catch the errors.