### PR TITLE
Support concurrent exception handling

### DIFF
--- a/commandhandler/aggregate/commandhandler_test.go
+++ b/commandhandler/aggregate/commandhandler_test.go
@@ -171,3 +171,17 @@ func createAggregateAndHandler(t *testing.T) (*mocks.Aggregate, *CommandHandler,
 	}
 	return a, h, store
 }
+
+func TestCommandHandler_ErrorErrConcurrentException(t *testing.T) {
+	a, h, store := createAggregateAndHandler(t)
+
+	store.Err = eh.ErrConcurrentException
+	cmd := &mocks.Command{
+		ID:      a.EntityID(),
+		Content: "command1",
+	}
+	err := h.handle(context.Background(), cmd)
+	if err == nil || err.Error() != eh.ErrConcurrentException.Error() {
+		t.Error("there should be a command error:", err)
+	}
+}

--- a/eventstore.go
+++ b/eventstore.go
@@ -47,6 +47,9 @@ var ErrInvalidEvent = errors.New("invalid event")
 // ErrIncorrectEventVersion is when an event is for an other version of the aggregate.
 var ErrIncorrectEventVersion = errors.New("mismatching event version")
 
+// ErrConcurrentException is when an event has old version because other event was stored before it
+var ErrConcurrentException = errors.New("other event was stored before the event")
+
 // EventStore is an interface for an event sourcing event store.
 type EventStore interface {
 	// Save appends all events in the event stream to the store.

--- a/eventstore/acceptanece_testing.go
+++ b/eventstore/acceptanece_testing.go
@@ -54,6 +54,15 @@ func AcceptanceTest(t *testing.T, ctx context.Context, store eh.EventStore) []eh
 	if err != nil {
 		t.Error("there should be no error:", err)
 	}
+
+	t.Log("try to insert second time event - concurrent exception 1")
+	eventConcExcep1 := eh.NewEventForAggregate(mocks.EventType, &mocks.EventData{Content: "eventConcExcep1"},
+		timestamp, mocks.AggregateType, id, 1)
+	err = store.Save(ctx, []eh.Event{eventConcExcep1}, 0)
+	if esErr, ok := err.(eh.EventStoreError); !ok || esErr.Err != eh.ErrConcurrentException {
+		t.Error("there should be error:", err)
+	}
+
 	savedEvents = append(savedEvents, event1)
 	// if val, ok := agg.Context.Value("testkey").(string); !ok || val != "testval" {
 	// 	t.Error("the context should be correct:", agg.Context)
@@ -72,7 +81,16 @@ func AcceptanceTest(t *testing.T, ctx context.Context, store eh.EventStore) []eh
 	if err != nil {
 		t.Error("there should be no error:", err)
 	}
+
 	savedEvents = append(savedEvents, event2)
+
+	t.Log("try to insert second time event - concurrent exception 2")
+	eventConcExcep2 := eh.NewEventForAggregate(mocks.EventType, &mocks.EventData{Content: "eventConcExcep2"},
+		timestamp, mocks.AggregateType, id, 2)
+	err = store.Save(ctx, []eh.Event{eventConcExcep2}, 1)
+	if esErr, ok := err.(eh.EventStoreError); !ok || esErr.Err != eh.ErrConcurrentException {
+		t.Error("there should be error:", err)
+	}
 
 	t.Log("save event without data, version 3")
 	event3 := eh.NewEventForAggregate(mocks.EventOtherType, nil, timestamp,


### PR DESCRIPTION
# Summary
Add concurrent exception handling when two commands store event in the same time. 

# How to test
Extended acceptance test and test it against mongo/memory

# Notes
