### PR TITLE
Fix nil dereference panic in EventBusError when Event is nil

### DIFF
--- a/eventbus.go
+++ b/eventbus.go
@@ -29,7 +29,7 @@ type EventBusError struct {
 
 // Error implements the Error method of the error interface.
 func (e EventBusError) Error() string {
-	return fmt.Sprintf("%s: (%s)", e.Err, e.Event.String())
+	return fmt.Sprintf("%s: (%s)", e.Err, e.Event)
 }
 
 // EventBus sends published events to one of each handler type and all observers.

--- a/eventbus/acceptance_testing.go
+++ b/eventbus/acceptance_testing.go
@@ -180,7 +180,10 @@ func AcceptanceTest(t *testing.T, bus1, bus2 eh.EventBus, timeout time.Duration)
 	select {
 	case <-time.After(time.Second):
 		t.Error("there should be an async error")
-	case <-bus1.Errors():
+	case err := <-bus1.Errors():
 		// Good case.
+		if err.Error() != "could not handle event (error_handler): handler error: (Event@1)" {
+			t.Error(err, "wrong error sent on event bus")
+		}
 	}
 }

--- a/eventbus_test.go
+++ b/eventbus_test.go
@@ -1,0 +1,72 @@
+// Copyright (c) 2018 - The Event Horizon authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package eventhorizon
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestEventBusError(t *testing.T) {
+	var testCases = []struct {
+		name              string
+		err               error
+		event             Event
+		expectedErrorText string
+	}{
+		{
+			"both non-nil",
+			errors.New("some error"),
+			NewEvent("some event type", nil, time.Time{}),
+			"some error: (some event type@0)",
+		},
+		{
+			"error nil",
+			nil,
+			NewEvent("some event type", nil, time.Time{}),
+			"%!s(<nil>): (some event type@0)",
+		},
+		{
+			"event nil",
+			errors.New("some error"),
+			nil,
+			"some error: (%!s(<nil>))",
+		},
+
+		{
+			"both nil",
+			nil,
+			nil,
+			"%!s(<nil>): (%!s(<nil>))",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			busError := EventBusError{
+				Err:   tc.err,
+				Event: tc.event,
+			}
+
+			if busError.Error() != tc.expectedErrorText {
+				t.Errorf(
+					"expected '%s', got '%s'",
+					tc.expectedErrorText,
+					busError.Error())
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Summary
Some async errors from the event bus may not contain an `Event`, e.g. [when a subscription fails in Cloud Pub/Sub](https://github.com/looplab/eventhorizon/blob/master/eventbus/gcp/eventbus.go#L175-L180). If that's the case, then calling `e.Event.String()` in the `Error` method of `EventBusError` will cause a nil dereference error.

Since the `fmt` package already handles calling `String` methods, we don't need to explicitly call `String`. Instead, we can pass `e.Event` to `fmt.Errorf` and it will handle turning it to a string

# How to test
Added `TestEventBusError` which creates errors with `Err` and `Event` set to nil and calls `Error()` on the resulting struct. I ran this test with the original code and it panicked, and with the change it no longer panics.

# Issue

No issue created.

# Notes
Also improved `EventBus` acceptance testing by checking error string rather than just checking that there is an error.