### PR TITLE
fix typo after copy / paste in comment / docs

### DIFF
--- a/examples/guestlist/domain/commands.go
+++ b/examples/guestlist/domain/commands.go
@@ -74,7 +74,7 @@ func (c ConfirmInvite) AggregateID() eh.UUID            { return c.ID }
 func (c ConfirmInvite) AggregateType() eh.AggregateType { return InvitationAggregateType }
 func (c ConfirmInvite) CommandType() eh.CommandType     { return ConfirmInviteCommand }
 
-// DenyInvite is a command for confirming invites.
+// DenyInvite is a command for denying invites.
 type DenyInvite struct {
 	ID eh.UUID
 }


### PR DESCRIPTION
# Summary

typo after author was copying and pasting too quickly ;)

# Notes

nice work keep it up