### PR TITLE
Add alternative MongoDB EventStore in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,9 @@ There are simple in memory implementations of an event store and entity repo. Th
 ### MongoDB
 
 Fairly mature, used in production.
-_Warning: Default MongoDB eventstore could lead to MongoDB errors while saving aggregates exceeding 16MB in size._
+_Note: This implementation has a document size limit of 16Mb, which could lead to errors for large aggregates. If needed use the alternative version below_
 
-### MongoDB (Improved eventStore)
+### MongoBD-DPE (supporting larger aggregates)
 
 MongoDB-DPE (stands for **D**ocument **P**er **E**vent) is a fork of the MongoDB driver mentioned above. In the MongoDB-DPE driver the max size of a mongo-document is taken into account so big aggregates with many events can be saved without exceeding the [16MB limit](https://docs.mongodb.com/manual/reference/limits/) by MongoDB .
 [https://github.com/gjongenelen/eh-mongodb](https://github.com/gjongenelen/eh-mongodb)

--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@ There are simple in memory implementations of an event store and entity repo. Th
 ### MongoDB
 
 Fairly mature, used in production.
+_Warning: Default MongoDB eventstore could lead to MongoDB errors while saving aggregates exceeding 16MB in size._
+
+### MongoDB (Improved eventStore)
+
+MongoDB-DPE (stands for **D**ocument **P**er **E**vent) is a fork of the MongoDB driver mentioned above. In the MongoDB-DPE driver the max size of a mongo-document is taken into account so big aggregates with many events can be saved without exceeding the [16MB limit](https://docs.mongodb.com/manual/reference/limits/) by MongoDB .
+[https://github.com/gjongenelen/eh-mongodb](https://github.com/gjongenelen/eh-mongodb)
 
 ### AWS DynamoDB
 


### PR DESCRIPTION
### Description

This fixes https://github.com/looplab/eventhorizon/issues/255
Because of breaking changes (different structure of storing events) this is placed in its own package, as it would need a migration otherwise. 

### Affected Components

- Event Store

### Related Issues

#255

### Solution and Design

Instead of storing events in one big document (per aggregate), this package stores events each in its own document, preventing the documents from reaching sizes above 16MB.
