### PR TITLE
added configuration options for EventStore and Repo

### DIFF
--- a/eventstore/mongodb/eventstore.go
+++ b/eventstore/mongodb/eventstore.go
@@ -76,6 +76,7 @@ func NewEventStore(uri, dbPrefix string, config ...EventStoreOptionSetter) (*Eve
 	return NewEventStoreWithClient(client, dbPrefix, config...)
 }
 
+// EventStoreOptionSetter is for convenient use with optional functions
 type EventStoreOptionSetter func(*EventStore) error
 
 // NewEventStoreWithClient creates a new EventStore with a client.
@@ -104,6 +105,7 @@ func NewEventStoreWithClient(client *mongo.Client, dbPrefix string, config ...Ev
 	return s, nil
 }
 
+// DBNameNoPrefix overrides the dbName function to return the dbPrefix as is
 func DBNameNoPrefix() EventStoreOptionSetter {
 	return func(store *EventStore) error {
 		store.dbName = func(context.Context) string {
@@ -113,6 +115,7 @@ func DBNameNoPrefix() EventStoreOptionSetter {
 	}
 }
 
+// WithDBName overrides the dbName function with a custom implementation
 func WithDBName(dbName func(context.Context) string) EventStoreOptionSetter {
 	return func(store *EventStore) error {
 		store.dbName = dbName

--- a/repo/mongodb/repo.go
+++ b/repo/mongodb/repo.go
@@ -57,6 +57,7 @@ type Repo struct {
 	dbName     func(context.Context) string
 }
 
+// RepoOptionSetter is for convenient use with optional functions
 type RepoOptionSetter func(*Repo) error
 
 // NewRepo creates a new Repo.
@@ -100,6 +101,7 @@ func NewRepoWithClient(client *mongo.Client, dbPrefix, collection string, config
 	return r, nil
 }
 
+// DBNameNoPrefix overrides the dbName function to return the dbPrefix as is
 func DBNameNoPrefix() RepoOptionSetter {
 	return func(r *Repo) error {
 		r.dbName = func(context.Context) string {
@@ -109,6 +111,7 @@ func DBNameNoPrefix() RepoOptionSetter {
 	}
 }
 
+// WithDBName overrides the dbName function with a custom implementation
 func WithDBName(dbName func(context.Context) string) RepoOptionSetter {
 	return func(r *Repo) error {
 		r.dbName = dbName

--- a/repo/mongodb/repo.go
+++ b/repo/mongodb/repo.go
@@ -17,6 +17,7 @@ package mongodb
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/google/uuid"
 	"go.mongodb.org/mongo-driver/bson"
@@ -53,10 +54,13 @@ type Repo struct {
 	dbPrefix   string
 	collection string
 	factoryFn  func() eh.Entity
+	dbName     func(context.Context) string
 }
 
+type RepoOptionSetter func(*Repo) error
+
 // NewRepo creates a new Repo.
-func NewRepo(uri, dbPrefix, collection string) (*Repo, error) {
+func NewRepo(uri, dbPrefix, collection string, config ...RepoOptionSetter) (*Repo, error) {
 	opts := options.Client().ApplyURI(uri)
 	opts.SetWriteConcern(writeconcern.New(writeconcern.WMajority()))
 	opts.SetReadConcern(readconcern.Majority())
@@ -66,11 +70,11 @@ func NewRepo(uri, dbPrefix, collection string) (*Repo, error) {
 		return nil, ErrCouldNotDialDB
 	}
 
-	return NewRepoWithClient(client, dbPrefix, collection)
+	return NewRepoWithClient(client, dbPrefix, collection, config...)
 }
 
 // NewRepoWithClient creates a new Repo with a client.
-func NewRepoWithClient(client *mongo.Client, dbPrefix, collection string) (*Repo, error) {
+func NewRepoWithClient(client *mongo.Client, dbPrefix, collection string, config ...RepoOptionSetter) (*Repo, error) {
 	if client == nil {
 		return nil, ErrNoDBClient
 	}
@@ -81,7 +85,35 @@ func NewRepoWithClient(client *mongo.Client, dbPrefix, collection string) (*Repo
 		collection: collection,
 	}
 
+	r.dbName = func(ctx context.Context) string {
+		ns := eh.NamespaceFromContext(ctx)
+		return dbPrefix + "_" + ns
+	}
+
+	for _, option := range config {
+		err := option(r)
+		if err != nil {
+			return nil, fmt.Errorf("error while applying option: %v", err)
+		}
+	}
+
 	return r, nil
+}
+
+func DBNameNoPrefix() RepoOptionSetter {
+	return func(r *Repo) error {
+		r.dbName = func(context.Context) string {
+			return r.dbPrefix
+		}
+		return nil
+	}
+}
+
+func WithDBName(dbName func(context.Context) string) RepoOptionSetter {
+	return func(r *Repo) error {
+		r.dbName = dbName
+		return nil
+	}
 }
 
 // Parent implements the Parent method of the eventhorizon.ReadRepo interface.
@@ -357,13 +389,6 @@ func (r *Repo) Clear(ctx context.Context) error {
 // Close closes a database session.
 func (r *Repo) Close(ctx context.Context) {
 	r.client.Disconnect(ctx)
-}
-
-// dbName appends the namespace, if one is set, to the DB prefix to
-// get the name of the DB to use.
-func (r *Repo) dbName(ctx context.Context) string {
-	ns := eh.NamespaceFromContext(ctx)
-	return r.dbPrefix + "_" + ns
 }
 
 // Repository returns a parent ReadRepo if there is one.


### PR DESCRIPTION
added option for using the dbName instead of the prefix stuff

### Description

With the current implementation the dbName set when creating the client will be used as a template/prefix name.
My Changes added the possibility to just use the name as is, when desired. this will not break existing implementations.

### Affected Components

-Event Store and Repo
No breaking changes, just added optional parameters

### Related Issues

none

### Solution and Design

using optional functions as an additional optional argument when creating the EventStore or the Repo to override the dbName function (with the default value still being the "_" + namespace implementation)

### Steps to test and verify

1. Create a new Instance of the Repo 
2. Pass `repo.DBNameNoPrefix()` as additional parameter.

```
	repo, err := repo.NewRepoWithClient(client, repoConfig.Database, repoConfig.Collection, repo.DBNameNoPrefix())
```

same for the eventStore