### PR TITLE
ISSUE-262 / Observer as middleware

### DIFF
--- a/eventbus.go
+++ b/eventbus.go
@@ -45,10 +45,6 @@ type EventBus interface {
 	// or handler is nil or the handler is already added.
 	AddHandler(EventMatcher, EventHandler)
 
-	// AddObserver adds an observer. Panics if the observer is nil or the observer
-	// is already added.
-	AddObserver(EventMatcher, EventHandler)
-
 	// Errors returns an error channel where async handling errors are sent.
 	Errors() <-chan EventBusError
 }

--- a/eventbus/acceptance_testing.go
+++ b/eventbus/acceptance_testing.go
@@ -24,6 +24,7 @@ import (
 	"github.com/kr/pretty"
 
 	eh "github.com/looplab/eventhorizon"
+	"github.com/looplab/eventhorizon/middleware/eventhandler/observer"
 	"github.com/looplab/eventhorizon/mocks"
 )
 
@@ -94,8 +95,9 @@ func AcceptanceTest(t *testing.T, bus1, bus2 eh.EventBus, timeout time.Duration)
 	bus1.AddHandler(eh.MatchAny(), handlerBus1)
 	bus2.AddHandler(eh.MatchAny(), handlerBus2)
 	bus2.AddHandler(eh.MatchAny(), anotherHandlerBus2)
-	bus1.AddObserver(eh.MatchAny(), observerBus1)
-	bus2.AddObserver(eh.MatchAny(), observerBus2)
+	// Add observers using the observer middleware.
+	bus1.AddHandler(eh.MatchAny(), eh.UseEventHandlerMiddleware(observerBus1, observer.Middleware))
+	bus2.AddHandler(eh.MatchAny(), eh.UseEventHandlerMiddleware(observerBus2, observer.Middleware))
 
 	if err := bus1.PublishEvent(ctx, event1); err != nil {
 		t.Error("there should be no error:", err)

--- a/eventhandler_test.go
+++ b/eventhandler_test.go
@@ -16,7 +16,6 @@ package eventhorizon
 
 import (
 	"context"
-	"fmt"
 	"reflect"
 	"testing"
 	"time"
@@ -28,7 +27,7 @@ func TestEventHandlerFunc(t *testing.T) {
 		events = append(events, e)
 		return nil
 	})
-	if h.HandlerType() != EventHandlerType(fmt.Sprintf("handler-func-%v", h)) {
+	if h.HandlerType() != EventHandlerType("eventhorizon-TestEventHandlerFunc-func1") {
 		t.Error("the handler type should be correct:", h.HandlerType())
 	}
 

--- a/examples/guestlist/domain/setup.go
+++ b/examples/guestlist/domain/setup.go
@@ -24,6 +24,7 @@ import (
 	"github.com/looplab/eventhorizon/commandhandler/bus"
 	"github.com/looplab/eventhorizon/eventhandler/projector"
 	"github.com/looplab/eventhorizon/eventhandler/saga"
+	"github.com/looplab/eventhorizon/middleware/eventhandler/observer"
 )
 
 // Setup configures the domain.
@@ -35,7 +36,8 @@ func Setup(
 	eventID uuid.UUID) {
 
 	// Add a logger as an observer.
-	eventBus.AddObserver(eh.MatchAny(), &Logger{})
+	eventBus.AddHandler(eh.MatchAny(),
+		eh.UseEventHandlerMiddleware(&Logger{}, observer.Middleware))
 
 	// Create the aggregate repository.
 	aggregateStore, err := events.NewAggregateStore(eventStore, eventBus)

--- a/examples/todomvc/handler.go
+++ b/examples/todomvc/handler.go
@@ -30,6 +30,7 @@ import (
 	"github.com/looplab/eventhorizon/eventhandler/projector"
 	eventstore "github.com/looplab/eventhorizon/eventstore/mongodb"
 	"github.com/looplab/eventhorizon/httputils"
+	"github.com/looplab/eventhorizon/middleware/eventhandler/observer"
 	repo "github.com/looplab/eventhorizon/repo/mongodb"
 	"github.com/looplab/eventhorizon/repo/version"
 
@@ -84,7 +85,8 @@ func NewHandler() (*Handler, error) {
 	}()
 
 	// Add a logger as an observer.
-	eventBus.AddObserver(eh.MatchAny(), &Logger{})
+	eventBus.AddHandler(eh.MatchAny(),
+		eh.UseEventHandlerMiddleware(&Logger{}, observer.Middleware))
 
 	// Create the aggregate repository.
 	aggregateStore, err := events.NewAggregateStore(eventStore, eventBus)

--- a/examples/todomvc/handler_test.go
+++ b/examples/todomvc/handler_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/google/uuid"
 	eh "github.com/looplab/eventhorizon"
 	"github.com/looplab/eventhorizon/eventhandler/waiter"
+	"github.com/looplab/eventhorizon/middleware/eventhandler/observer"
 	"github.com/looplab/eventhorizon/repo/mongodb"
 
 	"github.com/looplab/eventhorizon/examples/todomvc/internal/domain"
@@ -86,7 +87,8 @@ func TestGetAll(t *testing.T) {
 	}
 
 	waiter := waiter.NewEventHandler()
-	h.EventBus.AddObserver(eh.MatchEvent(domain.ItemAdded), waiter)
+	h.EventBus.AddHandler(eh.MatchEvent(domain.ItemAdded),
+		eh.UseEventHandlerMiddleware(waiter, observer.Middleware))
 	l := waiter.Listen(nil)
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
@@ -132,7 +134,8 @@ func TestCreate(t *testing.T) {
 	}
 
 	waiter := waiter.NewEventHandler()
-	h.EventBus.AddObserver(eh.MatchEvent(domain.Created), waiter)
+	h.EventBus.AddHandler(eh.MatchEvent(domain.Created),
+		eh.UseEventHandlerMiddleware(waiter, observer.Middleware))
 	l := waiter.Listen(nil)
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
@@ -195,7 +198,8 @@ func TestDelete(t *testing.T) {
 	}
 
 	waiter := waiter.NewEventHandler()
-	h.EventBus.AddObserver(eh.MatchEvent(domain.Deleted), waiter)
+	h.EventBus.AddHandler(eh.MatchEvent(domain.Deleted),
+		eh.UseEventHandlerMiddleware(waiter, observer.Middleware))
 	l := waiter.Listen(nil)
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
@@ -243,7 +247,8 @@ func TestAddItem(t *testing.T) {
 	}
 
 	waiter := waiter.NewEventHandler()
-	h.EventBus.AddObserver(eh.MatchEvent(domain.ItemAdded), waiter)
+	h.EventBus.AddHandler(eh.MatchEvent(domain.ItemAdded),
+		eh.UseEventHandlerMiddleware(waiter, observer.Middleware))
 	l := waiter.Listen(nil)
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
@@ -317,7 +322,8 @@ func TestRemoveItem(t *testing.T) {
 	}
 
 	waiter := waiter.NewEventHandler()
-	h.EventBus.AddObserver(eh.MatchEvent(domain.ItemRemoved), waiter)
+	h.EventBus.AddHandler(eh.MatchEvent(domain.ItemRemoved),
+		eh.UseEventHandlerMiddleware(waiter, observer.Middleware))
 	l := waiter.Listen(nil)
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
@@ -399,7 +405,8 @@ func TestRemoveCompleted(t *testing.T) {
 	}
 
 	waiter := waiter.NewEventHandler()
-	h.EventBus.AddObserver(eh.MatchEvent(domain.ItemRemoved), waiter)
+	h.EventBus.AddHandler(eh.MatchEvent(domain.ItemRemoved),
+		eh.UseEventHandlerMiddleware(waiter, observer.Middleware))
 	l := waiter.Listen(func(e eh.Event) bool {
 		return e.Version() == 5
 	})
@@ -475,7 +482,8 @@ func TestSetItemDesc(t *testing.T) {
 	}
 
 	waiter := waiter.NewEventHandler()
-	h.EventBus.AddObserver(eh.MatchEvent(domain.ItemDescriptionSet), waiter)
+	h.EventBus.AddHandler(eh.MatchEvent(domain.ItemDescriptionSet),
+		eh.UseEventHandlerMiddleware(waiter, observer.Middleware))
 	l := waiter.Listen(nil)
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
@@ -555,7 +563,8 @@ func TestCheckItem(t *testing.T) {
 	}
 
 	waiter := waiter.NewEventHandler()
-	h.EventBus.AddObserver(eh.MatchEvent(domain.ItemChecked), waiter)
+	h.EventBus.AddHandler(eh.MatchEvent(domain.ItemChecked),
+		eh.UseEventHandlerMiddleware(waiter, observer.Middleware))
 	l := waiter.Listen(nil)
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
@@ -640,7 +649,8 @@ func TestCheckAllItems(t *testing.T) {
 	}
 
 	waiter := waiter.NewEventHandler()
-	h.EventBus.AddObserver(eh.MatchEvent(domain.ItemRemoved), waiter)
+	h.EventBus.AddHandler(eh.MatchEvent(domain.ItemRemoved),
+		eh.UseEventHandlerMiddleware(waiter, observer.Middleware))
 	l := waiter.Listen(func(e eh.Event) bool {
 		return e.Version() == 5
 	})

--- a/httputils/eventbus.go
+++ b/httputils/eventbus.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/gorilla/websocket"
 	eh "github.com/looplab/eventhorizon"
+	"github.com/looplab/eventhorizon/middleware/eventhandler/observer"
 )
 
 var upgrader = websocket.Upgrader{} // use default options
@@ -63,7 +64,7 @@ func EventBusHandler(eventBus eh.EventBus, m eh.EventMatcher, id string) http.Ha
 			id: id,
 			ch: make(chan eh.Event, 10),
 		}
-		eventBus.AddObserver(m, h)
+		eventBus.AddHandler(m, eh.UseEventHandlerMiddleware(h, observer.Middleware))
 
 		for event := range h.ch {
 			if err := c.WriteMessage(websocket.TextMessage, []byte(event.String())); err != nil {

--- a/middleware/eventhandler/observer/eventhandler.go
+++ b/middleware/eventhandler/observer/eventhandler.go
@@ -1,0 +1,40 @@
+// Copyright (c) 2020 - The Event Horizon authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package observer
+
+import (
+	"fmt"
+
+	"github.com/google/uuid"
+	eh "github.com/looplab/eventhorizon"
+)
+
+type eventHandler struct {
+	eh.EventHandler
+	handlerType eh.EventHandlerType
+}
+
+// HandlerType implements the HandlerType method of the EventHandler.
+func (h *eventHandler) HandlerType() eh.EventHandlerType {
+	return h.handlerType
+}
+
+// Middleware is middleware that sets a unique handler name using UUID:
+// "HandlerTypeA-1123987-114871-124124-9187784"
+// This is useful for implementing observer handlers where multiple handlers of
+// the same type should receive an event.
+func Middleware(h eh.EventHandler) eh.EventHandler {
+	return &eventHandler{h, h.HandlerType() + eh.EventHandlerType(fmt.Sprintf("-%s", uuid.New()))}
+}

--- a/middleware/eventhandler/observer/eventhandler_test.go
+++ b/middleware/eventhandler/observer/eventhandler_test.go
@@ -1,0 +1,50 @@
+// Copyright (c) 2020 - The Event Horizon authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package observer
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	eh "github.com/looplab/eventhorizon"
+	"github.com/looplab/eventhorizon/mocks"
+)
+
+func TestEventHandler(t *testing.T) {
+	id := uuid.New()
+	eventData := &mocks.EventData{Content: "event1"}
+	timestamp := time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)
+	event := eh.NewEventForAggregate(mocks.EventType, eventData, timestamp,
+		mocks.AggregateType, id, 1)
+
+	inner := mocks.NewEventHandler("test")
+
+	// Create a middleware, which should give a unique name.
+	h1 := eh.UseEventHandlerMiddleware(inner, Middleware)
+	if err := h1.HandleEvent(context.Background(), event); err != nil {
+		t.Error("there should be no error:", err)
+	}
+	if h1.HandlerType() == inner.HandlerType() {
+		t.Error("the handler type should not be the original:", h1.HandlerType())
+	}
+
+	// Create another middleware, which should give a new unique name.
+	h2 := eh.UseEventHandlerMiddleware(inner, Middleware)
+	if h2.HandlerType() == h1.HandlerType() {
+		t.Error("the handler type should be unique:", h2.HandlerType())
+	}
+}

--- a/mocks/mocks.go
+++ b/mocks/mocks.go
@@ -339,9 +339,6 @@ func (b *EventBus) PublishEvent(ctx context.Context, event eh.Event) error {
 // AddHandler implements the AddHandler method of the eventhorizon.EventBus interface.
 func (b *EventBus) AddHandler(m eh.EventMatcher, h eh.EventHandler) {}
 
-// AddObserver implements the AddObserver method of the eventhorizon.EventBus interface.
-func (b *EventBus) AddObserver(m eh.EventMatcher, h eh.EventHandler) {}
-
 // Errors implements the Error method of the eventhorizon.EventBus interface.
 func (b *EventBus) Errors() <-chan eh.EventBusError {
 	return make(chan eh.EventBusError)


### PR DESCRIPTION
### Description

Removes `AddObserver()` from the EventHandler interface, replaces observer functionality with a middleware to create the observer behviour by giving each handler a unique handler type dynamically when adding.

### Affected Components

- EventBus
- EventHandler middleware

### Related Issues

#262

### Solution and Design

Currently the unique name is composed by a UUID, just as the behaviour was previously in the local and GCP EventBus.

### Steps to test and verify

1. Run tests, look at examples.
