### PR TITLE
Fix / Rename example domain packages

### DIFF
--- a/examples/guestlist/domains/guestlist/aggregate.go
+++ b/examples/guestlist/domains/guestlist/aggregate.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package domain
+package guestlist
 
 import (
 	"context"

--- a/examples/guestlist/domains/guestlist/commands.go
+++ b/examples/guestlist/domains/guestlist/commands.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package domain
+package guestlist
 
 import (
 	"github.com/google/uuid"

--- a/examples/guestlist/domains/guestlist/events.go
+++ b/examples/guestlist/domains/guestlist/events.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package domain
+package guestlist
 
 import (
 	eh "github.com/looplab/eventhorizon"

--- a/examples/guestlist/domains/guestlist/logger.go
+++ b/examples/guestlist/domains/guestlist/logger.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package domain
+package guestlist
 
 import (
 	"context"

--- a/examples/guestlist/domains/guestlist/projectors.go
+++ b/examples/guestlist/domains/guestlist/projectors.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package domain
+package guestlist
 
 import (
 	"context"

--- a/examples/guestlist/domains/guestlist/saga.go
+++ b/examples/guestlist/domains/guestlist/saga.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package domain
+package guestlist
 
 import (
 	"context"

--- a/examples/guestlist/domains/guestlist/setup.go
+++ b/examples/guestlist/domains/guestlist/setup.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package domain
+package guestlist
 
 import (
 	"log"
@@ -27,7 +27,7 @@ import (
 	"github.com/looplab/eventhorizon/middleware/eventhandler/observer"
 )
 
-// Setup configures the domain.
+// Setup configures the guestlist.
 func Setup(
 	eventStore eh.EventStore,
 	eventBus eh.EventBus,

--- a/examples/guestlist/memory/memory_test.go
+++ b/examples/guestlist/memory/memory_test.go
@@ -26,9 +26,8 @@ import (
 	"github.com/looplab/eventhorizon/commandhandler/bus"
 	eventbus "github.com/looplab/eventhorizon/eventbus/local"
 	eventstore "github.com/looplab/eventhorizon/eventstore/memory"
+	"github.com/looplab/eventhorizon/examples/guestlist/domains/guestlist"
 	repo "github.com/looplab/eventhorizon/repo/memory"
-
-	"github.com/looplab/eventhorizon/examples/guestlist/domain"
 )
 
 func Example() {
@@ -50,9 +49,9 @@ func Example() {
 	invitationRepo := repo.NewRepo()
 	guestListRepo := repo.NewRepo()
 
-	// Setup the domain.
+	// Setup the guestlist.
 	eventID := uuid.New()
-	domain.Setup(
+	guestlist.Setup(
 		eventStore,
 		eventBus,
 		commandBus,
@@ -72,16 +71,16 @@ func Example() {
 	poseidonID := uuid.New()
 
 	// Issue some invitations and responses. Error checking omitted here.
-	if err := commandBus.HandleCommand(ctx, &domain.CreateInvite{ID: athenaID, Name: "Athena", Age: 42}); err != nil {
+	if err := commandBus.HandleCommand(ctx, &guestlist.CreateInvite{ID: athenaID, Name: "Athena", Age: 42}); err != nil {
 		log.Println("error:", err)
 	}
-	if err := commandBus.HandleCommand(ctx, &domain.CreateInvite{ID: hadesID, Name: "Hades"}); err != nil {
+	if err := commandBus.HandleCommand(ctx, &guestlist.CreateInvite{ID: hadesID, Name: "Hades"}); err != nil {
 		log.Println("error:", err)
 	}
-	if err := commandBus.HandleCommand(ctx, &domain.CreateInvite{ID: zeusID, Name: "Zeus"}); err != nil {
+	if err := commandBus.HandleCommand(ctx, &guestlist.CreateInvite{ID: zeusID, Name: "Zeus"}); err != nil {
 		log.Println("error:", err)
 	}
-	if err := commandBus.HandleCommand(ctx, &domain.CreateInvite{ID: poseidonID, Name: "Poseidon"}); err != nil {
+	if err := commandBus.HandleCommand(ctx, &guestlist.CreateInvite{ID: poseidonID, Name: "Poseidon"}); err != nil {
 		log.Println("error:", err)
 	}
 	time.Sleep(100 * time.Millisecond)
@@ -90,24 +89,24 @@ func Example() {
 	// Note that Athena tries to decline the event after first accepting, but
 	// that is not allowed by the domain logic in InvitationAggregate. The
 	// result is that she is still accepted.
-	if err := commandBus.HandleCommand(ctx, &domain.AcceptInvite{ID: athenaID}); err != nil {
+	if err := commandBus.HandleCommand(ctx, &guestlist.AcceptInvite{ID: athenaID}); err != nil {
 		log.Println("error:", err)
 	}
-	if err := commandBus.HandleCommand(ctx, &domain.DeclineInvite{ID: athenaID}); err != nil {
+	if err := commandBus.HandleCommand(ctx, &guestlist.DeclineInvite{ID: athenaID}); err != nil {
 		// NOTE: This error is supposed to be printed!
 		log.Printf("error: %s\n", err)
 	}
-	if err := commandBus.HandleCommand(ctx, &domain.AcceptInvite{ID: hadesID}); err != nil {
+	if err := commandBus.HandleCommand(ctx, &guestlist.AcceptInvite{ID: hadesID}); err != nil {
 		log.Println("error:", err)
 	}
-	if err := commandBus.HandleCommand(ctx, &domain.DeclineInvite{ID: zeusID}); err != nil {
+	if err := commandBus.HandleCommand(ctx, &guestlist.DeclineInvite{ID: zeusID}); err != nil {
 		log.Println("error:", err)
 	}
 
 	// Poseidon is a bit late to the party...
 	// TODO: Remove sleeps.
 	time.Sleep(10 * time.Millisecond)
-	if err := commandBus.HandleCommand(ctx, &domain.AcceptInvite{ID: poseidonID}); err != nil {
+	if err := commandBus.HandleCommand(ctx, &guestlist.AcceptInvite{ID: poseidonID}); err != nil {
 		log.Println("error:", err)
 	}
 
@@ -121,7 +120,7 @@ func Example() {
 		log.Println("error:", err)
 	}
 	for _, i := range invitations {
-		if i, ok := i.(*domain.Invitation); ok {
+		if i, ok := i.(*guestlist.Invitation); ok {
 			invitationStrs = append(invitationStrs, fmt.Sprintf("%s - %s", i.Name, i.Status))
 		}
 	}
@@ -138,7 +137,7 @@ func Example() {
 	if err != nil {
 		log.Println("error:", err)
 	}
-	if l, ok := guestList.(*domain.GuestList); ok {
+	if l, ok := guestList.(*guestlist.GuestList); ok {
 		log.Printf("guest list: %d invited - %d accepted, %d declined - %d confirmed, %d denied\n",
 			l.NumGuests, l.NumAccepted, l.NumDeclined, l.NumConfirmed, l.NumDenied)
 		fmt.Printf("guest list: %d invited - %d accepted, %d declined - %d confirmed, %d denied\n",

--- a/examples/todomvc/domains/todo/aggregate.go
+++ b/examples/todomvc/domains/todo/aggregate.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package domain
+package todo
 
 import (
 	"context"

--- a/examples/todomvc/domains/todo/aggregate_test.go
+++ b/examples/todomvc/domains/todo/aggregate_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package domain
+package todo
 
 import (
 	"context"

--- a/examples/todomvc/domains/todo/commands.go
+++ b/examples/todomvc/domains/todo/commands.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package domain
+package todo
 
 import (
 	"github.com/google/uuid"

--- a/examples/todomvc/domains/todo/events.go
+++ b/examples/todomvc/domains/todo/events.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package domain
+package todo
 
 import (
 	eh "github.com/looplab/eventhorizon"

--- a/examples/todomvc/domains/todo/model.go
+++ b/examples/todomvc/domains/todo/model.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package domain
+package todo
 
 import (
 	"time"

--- a/examples/todomvc/domains/todo/model_test.go
+++ b/examples/todomvc/domains/todo/model_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package domain
+package todo
 
 import (
 	"bytes"

--- a/examples/todomvc/domains/todo/projector.go
+++ b/examples/todomvc/domains/todo/projector.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package domain
+package todo
 
 import (
 	"context"

--- a/examples/todomvc/domains/todo/projector_test.go
+++ b/examples/todomvc/domains/todo/projector_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package domain
+package todo
 
 import (
 	"context"

--- a/examples/todomvc/handler.go
+++ b/examples/todomvc/handler.go
@@ -34,7 +34,7 @@ import (
 	repo "github.com/looplab/eventhorizon/repo/mongodb"
 	"github.com/looplab/eventhorizon/repo/version"
 
-	"github.com/looplab/eventhorizon/examples/todomvc/internal/domain"
+	"github.com/looplab/eventhorizon/examples/todomvc/domains/todo"
 )
 
 // Handler is a http.Handler for the TodoMVC app.
@@ -95,7 +95,7 @@ func NewHandler() (*Handler, error) {
 	}
 
 	// Create the aggregate command handler.
-	aggregateCommandHandler, err := aggregate.NewCommandHandler(domain.AggregateType, aggregateStore)
+	aggregateCommandHandler, err := aggregate.NewCommandHandler(todo.AggregateType, aggregateStore)
 	if err != nil {
 		return nil, fmt.Errorf("could not create command handler: %s", err)
 	}
@@ -114,33 +114,33 @@ func NewHandler() (*Handler, error) {
 	if err != nil {
 		return nil, fmt.Errorf("could not create invitation repository: %s", err)
 	}
-	repo.SetEntityFactory(func() eh.Entity { return &domain.TodoList{} })
+	repo.SetEntityFactory(func() eh.Entity { return &todo.TodoList{} })
 	todoRepo := version.NewRepo(repo)
 
 	// Create the read model projector.
-	projector := projector.NewEventHandler(&domain.Projector{}, todoRepo)
-	projector.SetEntityFactory(func() eh.Entity { return &domain.TodoList{} })
+	projector := projector.NewEventHandler(&todo.Projector{}, todoRepo)
+	projector.SetEntityFactory(func() eh.Entity { return &todo.TodoList{} })
 	eventBus.AddHandler(eh.MatchAnyEventOf(
-		domain.Created,
-		domain.Deleted,
-		domain.ItemAdded,
-		domain.ItemRemoved,
-		domain.ItemDescriptionSet,
-		domain.ItemChecked,
+		todo.Created,
+		todo.Deleted,
+		todo.ItemAdded,
+		todo.ItemRemoved,
+		todo.ItemDescriptionSet,
+		todo.ItemChecked,
 	), projector)
 
 	// Handle the API.
 	h := http.NewServeMux()
 	h.Handle("/api/events/", httputils.EventBusHandler(eventBus, eh.MatchAny(), "any"))
 	h.Handle("/api/todos/", httputils.QueryHandler(todoRepo))
-	h.Handle("/api/todos/create", httputils.CommandHandler(commandHandler, domain.CreateCommand))
-	h.Handle("/api/todos/delete", httputils.CommandHandler(commandHandler, domain.DeleteCommand))
-	h.Handle("/api/todos/add_item", httputils.CommandHandler(commandHandler, domain.AddItemCommand))
-	h.Handle("/api/todos/remove_item", httputils.CommandHandler(commandHandler, domain.RemoveItemCommand))
-	h.Handle("/api/todos/remove_completed", httputils.CommandHandler(commandHandler, domain.RemoveCompletedItemsCommand))
-	h.Handle("/api/todos/set_item_desc", httputils.CommandHandler(commandHandler, domain.SetItemDescriptionCommand))
-	h.Handle("/api/todos/check_item", httputils.CommandHandler(commandHandler, domain.CheckItemCommand))
-	h.Handle("/api/todos/check_all_items", httputils.CommandHandler(commandHandler, domain.CheckAllItemsCommand))
+	h.Handle("/api/todos/create", httputils.CommandHandler(commandHandler, todo.CreateCommand))
+	h.Handle("/api/todos/delete", httputils.CommandHandler(commandHandler, todo.DeleteCommand))
+	h.Handle("/api/todos/add_item", httputils.CommandHandler(commandHandler, todo.AddItemCommand))
+	h.Handle("/api/todos/remove_item", httputils.CommandHandler(commandHandler, todo.RemoveItemCommand))
+	h.Handle("/api/todos/remove_completed", httputils.CommandHandler(commandHandler, todo.RemoveCompletedItemsCommand))
+	h.Handle("/api/todos/set_item_desc", httputils.CommandHandler(commandHandler, todo.SetItemDescriptionCommand))
+	h.Handle("/api/todos/check_item", httputils.CommandHandler(commandHandler, todo.CheckItemCommand))
+	h.Handle("/api/todos/check_all_items", httputils.CommandHandler(commandHandler, todo.CheckAllItemsCommand))
 
 	// Proxy to elm-reactor, which must be running. For development.
 	elmReactorURL, err := url.Parse("http://localhost:8000")

--- a/examples/todomvc/handler_test.go
+++ b/examples/todomvc/handler_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/looplab/eventhorizon/middleware/eventhandler/observer"
 	"github.com/looplab/eventhorizon/repo/mongodb"
 
-	"github.com/looplab/eventhorizon/examples/todomvc/internal/domain"
+	"github.com/looplab/eventhorizon/examples/todomvc/domains/todo"
 )
 
 func TestStaticFiles(t *testing.T) {
@@ -47,7 +47,7 @@ func TestStaticFiles(t *testing.T) {
 }
 
 func TestGetAll(t *testing.T) {
-	domain.TimeNow = func() time.Time {
+	todo.TimeNow = func() time.Time {
 		return time.Date(2017, time.July, 10, 23, 0, 0, 0, time.UTC)
 	}
 
@@ -74,12 +74,12 @@ func TestGetAll(t *testing.T) {
 	}
 
 	id := uuid.New()
-	if err := h.CommandHandler.HandleCommand(context.Background(), &domain.Create{
+	if err := h.CommandHandler.HandleCommand(context.Background(), &todo.Create{
 		ID: id,
 	}); err != nil {
 		t.Error("there should be no error:", err)
 	}
-	if err := h.CommandHandler.HandleCommand(context.Background(), &domain.AddItem{
+	if err := h.CommandHandler.HandleCommand(context.Background(), &todo.AddItem{
 		ID:          id,
 		Description: "desc",
 	}); err != nil {
@@ -87,7 +87,7 @@ func TestGetAll(t *testing.T) {
 	}
 
 	waiter := waiter.NewEventHandler()
-	h.EventBus.AddHandler(eh.MatchEvent(domain.ItemAdded),
+	h.EventBus.AddHandler(eh.MatchEvent(todo.ItemAdded),
 		eh.UseEventHandlerMiddleware(waiter, observer.Middleware))
 	l := waiter.Listen(nil)
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
@@ -99,13 +99,13 @@ func TestGetAll(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Error("the status should be correct:", w.Code)
 	}
-	if string(w.Body.Bytes()) != `[{"id":"`+id.String()+`","version":2,"items":[{"id":0,"desc":"desc","completed":false}],"created_at":"`+domain.TimeNow().Format(time.RFC3339Nano)+`","updated_at":"`+domain.TimeNow().Format(time.RFC3339Nano)+`"}]` {
+	if string(w.Body.Bytes()) != `[{"id":"`+id.String()+`","version":2,"items":[{"id":0,"desc":"desc","completed":false}],"created_at":"`+todo.TimeNow().Format(time.RFC3339Nano)+`","updated_at":"`+todo.TimeNow().Format(time.RFC3339Nano)+`"}]` {
 		t.Error("the body should be correct:", string(w.Body.Bytes()))
 	}
 }
 
 func TestCreate(t *testing.T) {
-	domain.TimeNow = func() time.Time {
+	todo.TimeNow = func() time.Time {
 		return time.Date(2017, time.July, 10, 23, 0, 0, 0, time.UTC)
 	}
 
@@ -134,7 +134,7 @@ func TestCreate(t *testing.T) {
 	}
 
 	waiter := waiter.NewEventHandler()
-	h.EventBus.AddHandler(eh.MatchEvent(domain.Created),
+	h.EventBus.AddHandler(eh.MatchEvent(todo.Created),
 		eh.UseEventHandlerMiddleware(waiter, observer.Middleware))
 	l := waiter.Listen(nil)
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
@@ -145,25 +145,25 @@ func TestCreate(t *testing.T) {
 	if err != nil {
 		t.Error("there should be no error:", err)
 	}
-	todo, ok := m.(*domain.TodoList)
+	list, ok := m.(*todo.TodoList)
 	if !ok {
 		t.Error("the item should be a todo list")
 	}
-	expected := &domain.TodoList{
+	expected := &todo.TodoList{
 		ID:        id,
 		Version:   1,
-		Items:     []*domain.TodoItem{},
-		CreatedAt: domain.TimeNow(),
-		UpdatedAt: domain.TimeNow(),
+		Items:     []*todo.TodoItem{},
+		CreatedAt: todo.TimeNow(),
+		UpdatedAt: todo.TimeNow(),
 	}
-	if !reflect.DeepEqual(todo, expected) {
-		t.Error("the item should be correct:", todo)
+	if !reflect.DeepEqual(list, expected) {
+		t.Error("the item should be correct:", list)
 		t.Log("expected:", expected)
 	}
 }
 
 func TestDelete(t *testing.T) {
-	domain.TimeNow = func() time.Time {
+	todo.TimeNow = func() time.Time {
 		return time.Date(2017, time.July, 10, 23, 0, 0, 0, time.UTC)
 	}
 
@@ -180,7 +180,7 @@ func TestDelete(t *testing.T) {
 	}
 
 	id := uuid.New()
-	if err := h.CommandHandler.HandleCommand(context.Background(), &domain.Create{
+	if err := h.CommandHandler.HandleCommand(context.Background(), &todo.Create{
 		ID: id,
 	}); err != nil {
 		t.Error("there should be no error:", err)
@@ -198,7 +198,7 @@ func TestDelete(t *testing.T) {
 	}
 
 	waiter := waiter.NewEventHandler()
-	h.EventBus.AddHandler(eh.MatchEvent(domain.Deleted),
+	h.EventBus.AddHandler(eh.MatchEvent(todo.Deleted),
 		eh.UseEventHandlerMiddleware(waiter, observer.Middleware))
 	l := waiter.Listen(nil)
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
@@ -212,7 +212,7 @@ func TestDelete(t *testing.T) {
 }
 
 func TestAddItem(t *testing.T) {
-	domain.TimeNow = func() time.Time {
+	todo.TimeNow = func() time.Time {
 		return time.Date(2017, time.July, 10, 23, 0, 0, 0, time.UTC)
 	}
 
@@ -229,7 +229,7 @@ func TestAddItem(t *testing.T) {
 	}
 
 	id := uuid.New()
-	if err := h.CommandHandler.HandleCommand(context.Background(), &domain.Create{
+	if err := h.CommandHandler.HandleCommand(context.Background(), &todo.Create{
 		ID: id,
 	}); err != nil {
 		t.Error("there should be no error:", err)
@@ -247,7 +247,7 @@ func TestAddItem(t *testing.T) {
 	}
 
 	waiter := waiter.NewEventHandler()
-	h.EventBus.AddHandler(eh.MatchEvent(domain.ItemAdded),
+	h.EventBus.AddHandler(eh.MatchEvent(todo.ItemAdded),
 		eh.UseEventHandlerMiddleware(waiter, observer.Middleware))
 	l := waiter.Listen(nil)
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
@@ -258,30 +258,30 @@ func TestAddItem(t *testing.T) {
 	if err != nil {
 		t.Error("there should be no error:", err)
 	}
-	todo, ok := m.(*domain.TodoList)
+	list, ok := m.(*todo.TodoList)
 	if !ok {
 		t.Error("the item should be a todo list")
 	}
-	expected := &domain.TodoList{
+	expected := &todo.TodoList{
 		ID:      id,
 		Version: 2,
-		Items: []*domain.TodoItem{
+		Items: []*todo.TodoItem{
 			{
 				ID:          0,
 				Description: "desc",
 			},
 		},
-		CreatedAt: domain.TimeNow(),
-		UpdatedAt: domain.TimeNow(),
+		CreatedAt: todo.TimeNow(),
+		UpdatedAt: todo.TimeNow(),
 	}
-	if !reflect.DeepEqual(todo, expected) {
-		t.Error("the item should be correct:", todo)
+	if !reflect.DeepEqual(list, expected) {
+		t.Error("the item should be correct:", list)
 		t.Log("expected:", expected)
 	}
 }
 
 func TestRemoveItem(t *testing.T) {
-	domain.TimeNow = func() time.Time {
+	todo.TimeNow = func() time.Time {
 		return time.Date(2017, time.July, 10, 23, 0, 0, 0, time.UTC)
 	}
 
@@ -298,12 +298,12 @@ func TestRemoveItem(t *testing.T) {
 	}
 
 	id := uuid.New()
-	if err := h.CommandHandler.HandleCommand(context.Background(), &domain.Create{
+	if err := h.CommandHandler.HandleCommand(context.Background(), &todo.Create{
 		ID: id,
 	}); err != nil {
 		t.Error("there should be no error:", err)
 	}
-	if err := h.CommandHandler.HandleCommand(context.Background(), &domain.AddItem{
+	if err := h.CommandHandler.HandleCommand(context.Background(), &todo.AddItem{
 		ID:          id,
 		Description: "desc",
 	}); err != nil {
@@ -322,7 +322,7 @@ func TestRemoveItem(t *testing.T) {
 	}
 
 	waiter := waiter.NewEventHandler()
-	h.EventBus.AddHandler(eh.MatchEvent(domain.ItemRemoved),
+	h.EventBus.AddHandler(eh.MatchEvent(todo.ItemRemoved),
 		eh.UseEventHandlerMiddleware(waiter, observer.Middleware))
 	l := waiter.Listen(nil)
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
@@ -333,25 +333,25 @@ func TestRemoveItem(t *testing.T) {
 	if err != nil {
 		t.Error("there should be no error:", err)
 	}
-	todo, ok := m.(*domain.TodoList)
+	list, ok := m.(*todo.TodoList)
 	if !ok {
 		t.Error("the item should be a todo list")
 	}
-	expected := &domain.TodoList{
+	expected := &todo.TodoList{
 		ID:        id,
 		Version:   3,
-		Items:     []*domain.TodoItem{},
-		CreatedAt: domain.TimeNow(),
-		UpdatedAt: domain.TimeNow(),
+		Items:     []*todo.TodoItem{},
+		CreatedAt: todo.TimeNow(),
+		UpdatedAt: todo.TimeNow(),
 	}
-	if !reflect.DeepEqual(todo, expected) {
-		t.Error("the item should be correct:", todo)
+	if !reflect.DeepEqual(list, expected) {
+		t.Error("the item should be correct:", list)
 		t.Log("expected:", expected)
 	}
 }
 
 func TestRemoveCompleted(t *testing.T) {
-	domain.TimeNow = func() time.Time {
+	todo.TimeNow = func() time.Time {
 		return time.Date(2017, time.July, 10, 23, 0, 0, 0, time.UTC)
 	}
 
@@ -368,24 +368,24 @@ func TestRemoveCompleted(t *testing.T) {
 	}
 
 	id := uuid.New()
-	if err := h.CommandHandler.HandleCommand(context.Background(), &domain.Create{
+	if err := h.CommandHandler.HandleCommand(context.Background(), &todo.Create{
 		ID: id,
 	}); err != nil {
 		t.Error("there should be no error:", err)
 	}
-	if err := h.CommandHandler.HandleCommand(context.Background(), &domain.AddItem{
+	if err := h.CommandHandler.HandleCommand(context.Background(), &todo.AddItem{
 		ID:          id,
 		Description: "desc",
 	}); err != nil {
 		t.Error("there should be no error:", err)
 	}
-	if err := h.CommandHandler.HandleCommand(context.Background(), &domain.AddItem{
+	if err := h.CommandHandler.HandleCommand(context.Background(), &todo.AddItem{
 		ID:          id,
 		Description: "completed",
 	}); err != nil {
 		t.Error("there should be no error:", err)
 	}
-	if err := h.CommandHandler.HandleCommand(context.Background(), &domain.CheckItem{
+	if err := h.CommandHandler.HandleCommand(context.Background(), &todo.CheckItem{
 		ID:      id,
 		ItemID:  1,
 		Checked: true,
@@ -405,7 +405,7 @@ func TestRemoveCompleted(t *testing.T) {
 	}
 
 	waiter := waiter.NewEventHandler()
-	h.EventBus.AddHandler(eh.MatchEvent(domain.ItemRemoved),
+	h.EventBus.AddHandler(eh.MatchEvent(todo.ItemRemoved),
 		eh.UseEventHandlerMiddleware(waiter, observer.Middleware))
 	l := waiter.Listen(func(e eh.Event) bool {
 		return e.Version() == 5
@@ -418,30 +418,30 @@ func TestRemoveCompleted(t *testing.T) {
 	if err != nil {
 		t.Error("there should be no error:", err)
 	}
-	todo, ok := m.(*domain.TodoList)
+	list, ok := m.(*todo.TodoList)
 	if !ok {
 		t.Error("the item should be a todo list")
 	}
-	expected := &domain.TodoList{
+	expected := &todo.TodoList{
 		ID:      id,
 		Version: 5,
-		Items: []*domain.TodoItem{
+		Items: []*todo.TodoItem{
 			{
 				ID:          0,
 				Description: "desc",
 			},
 		},
-		CreatedAt: domain.TimeNow(),
-		UpdatedAt: domain.TimeNow(),
+		CreatedAt: todo.TimeNow(),
+		UpdatedAt: todo.TimeNow(),
 	}
-	if !reflect.DeepEqual(todo, expected) {
-		t.Error("the item should be correct:", todo)
+	if !reflect.DeepEqual(list, expected) {
+		t.Error("the item should be correct:", list)
 		t.Log("expected:", expected)
 	}
 }
 
 func TestSetItemDesc(t *testing.T) {
-	domain.TimeNow = func() time.Time {
+	todo.TimeNow = func() time.Time {
 		return time.Date(2017, time.July, 10, 23, 0, 0, 0, time.UTC)
 	}
 
@@ -458,12 +458,12 @@ func TestSetItemDesc(t *testing.T) {
 	}
 
 	id := uuid.New()
-	if err := h.CommandHandler.HandleCommand(context.Background(), &domain.Create{
+	if err := h.CommandHandler.HandleCommand(context.Background(), &todo.Create{
 		ID: id,
 	}); err != nil {
 		t.Error("there should be no error:", err)
 	}
-	if err := h.CommandHandler.HandleCommand(context.Background(), &domain.AddItem{
+	if err := h.CommandHandler.HandleCommand(context.Background(), &todo.AddItem{
 		ID:          id,
 		Description: "desc",
 	}); err != nil {
@@ -482,7 +482,7 @@ func TestSetItemDesc(t *testing.T) {
 	}
 
 	waiter := waiter.NewEventHandler()
-	h.EventBus.AddHandler(eh.MatchEvent(domain.ItemDescriptionSet),
+	h.EventBus.AddHandler(eh.MatchEvent(todo.ItemDescriptionSet),
 		eh.UseEventHandlerMiddleware(waiter, observer.Middleware))
 	l := waiter.Listen(nil)
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
@@ -493,30 +493,30 @@ func TestSetItemDesc(t *testing.T) {
 	if err != nil {
 		t.Error("there should be no error:", err)
 	}
-	todo, ok := m.(*domain.TodoList)
+	list, ok := m.(*todo.TodoList)
 	if !ok {
 		t.Error("the item should be a todo list")
 	}
-	expected := &domain.TodoList{
+	expected := &todo.TodoList{
 		ID:      id,
 		Version: 3,
-		Items: []*domain.TodoItem{
+		Items: []*todo.TodoItem{
 			{
 				ID:          0,
 				Description: "new desc",
 			},
 		},
-		CreatedAt: domain.TimeNow(),
-		UpdatedAt: domain.TimeNow(),
+		CreatedAt: todo.TimeNow(),
+		UpdatedAt: todo.TimeNow(),
 	}
-	if !reflect.DeepEqual(todo, expected) {
-		t.Error("the item should be correct:", todo)
+	if !reflect.DeepEqual(list, expected) {
+		t.Error("the item should be correct:", list)
 		t.Log("expected:", expected)
 	}
 }
 
 func TestCheckItem(t *testing.T) {
-	domain.TimeNow = func() time.Time {
+	todo.TimeNow = func() time.Time {
 		return time.Date(2017, time.July, 10, 23, 0, 0, 0, time.UTC)
 	}
 
@@ -533,18 +533,18 @@ func TestCheckItem(t *testing.T) {
 	}
 
 	id := uuid.New()
-	if err := h.CommandHandler.HandleCommand(context.Background(), &domain.Create{
+	if err := h.CommandHandler.HandleCommand(context.Background(), &todo.Create{
 		ID: id,
 	}); err != nil {
 		t.Error("there should be no error:", err)
 	}
-	if err := h.CommandHandler.HandleCommand(context.Background(), &domain.AddItem{
+	if err := h.CommandHandler.HandleCommand(context.Background(), &todo.AddItem{
 		ID:          id,
 		Description: "desc",
 	}); err != nil {
 		t.Error("there should be no error:", err)
 	}
-	if err := h.CommandHandler.HandleCommand(context.Background(), &domain.AddItem{
+	if err := h.CommandHandler.HandleCommand(context.Background(), &todo.AddItem{
 		ID:          id,
 		Description: "completed",
 	}); err != nil {
@@ -563,7 +563,7 @@ func TestCheckItem(t *testing.T) {
 	}
 
 	waiter := waiter.NewEventHandler()
-	h.EventBus.AddHandler(eh.MatchEvent(domain.ItemChecked),
+	h.EventBus.AddHandler(eh.MatchEvent(todo.ItemChecked),
 		eh.UseEventHandlerMiddleware(waiter, observer.Middleware))
 	l := waiter.Listen(nil)
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
@@ -574,14 +574,14 @@ func TestCheckItem(t *testing.T) {
 	if err != nil {
 		t.Error("there should be no error:", err)
 	}
-	todo, ok := m.(*domain.TodoList)
+	list, ok := m.(*todo.TodoList)
 	if !ok {
 		t.Error("the item should be a todo list")
 	}
-	expected := &domain.TodoList{
+	expected := &todo.TodoList{
 		ID:      id,
 		Version: 4,
-		Items: []*domain.TodoItem{
+		Items: []*todo.TodoItem{
 			{
 				ID:          0,
 				Description: "desc",
@@ -592,17 +592,17 @@ func TestCheckItem(t *testing.T) {
 				Completed:   true,
 			},
 		},
-		CreatedAt: domain.TimeNow(),
-		UpdatedAt: domain.TimeNow(),
+		CreatedAt: todo.TimeNow(),
+		UpdatedAt: todo.TimeNow(),
 	}
-	if !reflect.DeepEqual(todo, expected) {
-		t.Error("the item should be correct:", todo)
+	if !reflect.DeepEqual(list, expected) {
+		t.Error("the item should be correct:", list)
 		t.Log("expected:", expected)
 	}
 }
 
 func TestCheckAllItems(t *testing.T) {
-	domain.TimeNow = func() time.Time {
+	todo.TimeNow = func() time.Time {
 		return time.Date(2017, time.July, 10, 23, 0, 0, 0, time.UTC)
 	}
 
@@ -619,18 +619,18 @@ func TestCheckAllItems(t *testing.T) {
 	}
 
 	id := uuid.New()
-	if err := h.CommandHandler.HandleCommand(context.Background(), &domain.Create{
+	if err := h.CommandHandler.HandleCommand(context.Background(), &todo.Create{
 		ID: id,
 	}); err != nil {
 		t.Error("there should be no error:", err)
 	}
-	if err := h.CommandHandler.HandleCommand(context.Background(), &domain.AddItem{
+	if err := h.CommandHandler.HandleCommand(context.Background(), &todo.AddItem{
 		ID:          id,
 		Description: "desc",
 	}); err != nil {
 		t.Error("there should be no error:", err)
 	}
-	if err := h.CommandHandler.HandleCommand(context.Background(), &domain.AddItem{
+	if err := h.CommandHandler.HandleCommand(context.Background(), &todo.AddItem{
 		ID:          id,
 		Description: "completed",
 	}); err != nil {
@@ -649,7 +649,7 @@ func TestCheckAllItems(t *testing.T) {
 	}
 
 	waiter := waiter.NewEventHandler()
-	h.EventBus.AddHandler(eh.MatchEvent(domain.ItemRemoved),
+	h.EventBus.AddHandler(eh.MatchEvent(todo.ItemRemoved),
 		eh.UseEventHandlerMiddleware(waiter, observer.Middleware))
 	l := waiter.Listen(func(e eh.Event) bool {
 		return e.Version() == 5
@@ -662,14 +662,14 @@ func TestCheckAllItems(t *testing.T) {
 	if err != nil {
 		t.Error("there should be no error:", err)
 	}
-	todo, ok := m.(*domain.TodoList)
+	list, ok := m.(*todo.TodoList)
 	if !ok {
 		t.Error("the item should be a todo list")
 	}
-	expected := &domain.TodoList{
+	expected := &todo.TodoList{
 		ID:      id,
 		Version: 5,
-		Items: []*domain.TodoItem{
+		Items: []*todo.TodoItem{
 			{
 				ID:          0,
 				Description: "desc",
@@ -681,11 +681,11 @@ func TestCheckAllItems(t *testing.T) {
 				Completed:   true,
 			},
 		},
-		CreatedAt: domain.TimeNow(),
-		UpdatedAt: domain.TimeNow(),
+		CreatedAt: todo.TimeNow(),
+		UpdatedAt: todo.TimeNow(),
 	}
-	if !reflect.DeepEqual(todo, expected) {
-		t.Error("the item should be correct:", todo)
+	if !reflect.DeepEqual(list, expected) {
+		t.Error("the item should be correct:", list)
 		t.Log("expected:", expected)
 	}
 }

--- a/examples/todomvc/main.go
+++ b/examples/todomvc/main.go
@@ -20,7 +20,7 @@ import (
 	"net/http"
 
 	"github.com/google/uuid"
-	"github.com/looplab/eventhorizon/examples/todomvc/internal/domain"
+	"github.com/looplab/eventhorizon/examples/todomvc/domains/todo"
 	"github.com/looplab/eventhorizon/repo/mongodb"
 )
 
@@ -39,12 +39,12 @@ func main() {
 	}
 
 	id := uuid.New()
-	if err := h.CommandHandler.HandleCommand(context.Background(), &domain.Create{
+	if err := h.CommandHandler.HandleCommand(context.Background(), &todo.Create{
 		ID: id,
 	}); err != nil {
 		log.Fatal("there should be no error:", err)
 	}
-	if err := h.CommandHandler.HandleCommand(context.Background(), &domain.AddItem{
+	if err := h.CommandHandler.HandleCommand(context.Background(), &todo.AddItem{
 		ID:          id,
 		Description: "desc",
 	}); err != nil {


### PR DESCRIPTION
### Description

Renames the example domain packages to be a bit more semantic: todo.Create etc.

### Affected Components

- Examples

### Related Issues


### Solution and Design


### Steps to test and verify

