### PR TITLE
implemented the Cause method on the Errors that have a cause

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -18,3 +18,4 @@ David Högborg
 Michael E Brown
 Oleg Yashchuk
 Bradley Weston
+Johannes Kolata

--- a/aggregatestore/events/aggregatestore.go
+++ b/aggregatestore/events/aggregatestore.go
@@ -56,6 +56,11 @@ func (a ApplyEventError) Error() string {
 	return "failed to apply event " + a.Event.String() + ": " + a.Err.Error()
 }
 
+// Cause returns the cause of this error.
+func (a ApplyEventError) Cause() error {
+	return a.Err
+}
+
 // NewAggregateStore creates a aggregate store with an event store and an event
 // handler that will handle resulting events (for example by publishing them
 // on an event bus).

--- a/command.go
+++ b/command.go
@@ -118,6 +118,7 @@ type CommandFieldError struct {
 	Field string
 }
 
+// Error implements the Error method of the error interface.
 func (c CommandFieldError) Error() string {
 	return "missing field: " + c.Field
 }

--- a/eventbus.go
+++ b/eventbus.go
@@ -51,6 +51,11 @@ func (e EventBusError) Error() string {
 	return fmt.Sprintf("%s: (%s)", e.Err, e.Event)
 }
 
+// Cause returns the cause of this error.
+func (e EventBusError) Cause() error {
+	return e.Err
+}
+
 // ErrMissingMatcher is returned when adding a handler without a matcher.
 var ErrMissingMatcher = errors.New("missing matcher")
 

--- a/eventstore.go
+++ b/eventstore.go
@@ -62,6 +62,11 @@ func (e EventStoreError) Error() string {
 	return errStr + " (" + e.Namespace + ")"
 }
 
+// Cause returns the cause of this error.
+func (e EventStoreError) Cause() error {
+	return e.Err
+}
+
 // ErrNoEventsToAppend is when no events are available to append.
 var ErrNoEventsToAppend = errors.New("no events to append")
 

--- a/repo.go
+++ b/repo.go
@@ -86,6 +86,11 @@ func (e RepoError) Error() string {
 	return errStr + " (" + e.Namespace + ")"
 }
 
+// Cause returns the cause of this error.
+func (e RepoError) Cause() error {
+	return e.Err
+}
+
 // ErrEntityNotFound is when a entity could not be found.
 var ErrEntityNotFound = errors.New("could not find entity")
 


### PR DESCRIPTION
### Description

I implemented a `Cause() error` function in all Errors, that had an Err field for ease of check, when using the `github.com/pkg/errors` errors package.

When handling errors you had to validate them in a way something like that:

```
		eErr, ok := err.(events.ApplyEventError)
		if ok && errors.Is(eErr.Err, MyCustomError) {
			// Handle your error here
		}
```

Now you can validate them like this (without having to know the exact error):

```
		if errors.Is(err, MyCustomError) {
			// Handle your error here
		}
```

### Affected Components

- Errors in various packages
  - AggregateStore
    - ApplyEventError
  - EventStore
    - EventStoreError
  - Repo
    - EventStoreError

### Solution and Design

The solution was to introduce a new function (`Cause() error`) for ease of access without a type cast, when using the `github.com/pkg/errors` errors package.


I wasn't to sure, how to handle the `BaseErr` in `RepoError` and `EventStoreError` so I decided to use the `Err` field as well, as that is what I would expect. Maybe it would be a better solution to check, if the `Err` field is `nil` and return the `BaseErr` when that is the case, but I leave it to you to decide on that.

### Steps to test and verify

1. provoke an error in any handler
2. validate in one of the following ways
  a. call errors.Is(err, \<expectedError\>) and check for result to be true
  b. call errors.Cause(err) and the result should be the error contained in the Err field
