### PR TITLE
Fix / Ignore old/duplicates events in projector

### DIFF
--- a/eventhandler/projector/eventhandler.go
+++ b/eventhandler/projector/eventhandler.go
@@ -124,6 +124,11 @@ func (h *EventHandler) HandleEvent(ctx context.Context, event eh.Event) error {
 
 	// The entity should be one version behind the event.
 	if entity, ok := entity.(eh.Versionable); ok {
+		// Ignore old/duplicate events.
+		if entity.AggregateVersion() >= event.Version() {
+			return nil
+		}
+
 		if entity.AggregateVersion()+1 != event.Version() {
 			return Error{
 				Err:       eh.ErrIncorrectEntityVersion,

--- a/eventhandler/projector/eventhandler_test.go
+++ b/eventhandler/projector/eventhandler_test.go
@@ -99,6 +99,11 @@ func TestEventHandler_UpdateModel(t *testing.T) {
 	if repo.Entity != projector.newEntity {
 		t.Error("the new entity should be correct:", repo.Entity)
 	}
+
+	// Handle event again, should be a no-op.
+	if err := handler.HandleEvent(ctx, event); err != nil {
+		t.Error("there shoud be no error:", err)
+	}
 }
 
 func TestEventHandler_UpdateModelWithVersion(t *testing.T) {
@@ -136,6 +141,11 @@ func TestEventHandler_UpdateModelWithVersion(t *testing.T) {
 	}
 	if repo.Entity != projector.newEntity {
 		t.Error("the new entity should be correct:", repo.Entity)
+	}
+
+	// Handle event again, should be a no-op.
+	if err := handler.HandleEvent(ctx, event); err != nil {
+		t.Error("there shoud be no error:", err)
 	}
 }
 


### PR DESCRIPTION
### Description

Ignore old/duplicates events in projector. Sometimes with message buses that retries events too fast, before the first handling could ack, would cause false errors where models had already been projected (between the second event being sent and received).

### Affected Components

- Projector

### Related Issues

### Solution and Design

Ignore projecting on aggregates with same or newer version. Before it errored if the version was not exactly one behind, causing false errors for entities being projected already or even being ahead.

### Steps to test and verify

1. ...
