### PR TITLE
117 / Metadata for events

### DIFF
--- a/aggregatestore/events/aggregatebase.go
+++ b/aggregatestore/events/aggregatebase.go
@@ -99,10 +99,13 @@ func (a *AggregateBase) Events() []eh.Event {
 }
 
 // AppendEvent appends an event for later retrieval by Events().
-func (a *AggregateBase) AppendEvent(t eh.EventType, data eh.EventData, timestamp time.Time) eh.Event {
-	e := eh.NewEventForAggregate(t, data, timestamp,
-		a.AggregateType(), a.EntityID(),
-		a.Version()+len(a.events)+1)
+func (a *AggregateBase) AppendEvent(t eh.EventType, data eh.EventData, timestamp time.Time, options ...eh.EventOption) eh.Event {
+	options = append(options, eh.ForAggregate(
+		a.AggregateType(),
+		a.EntityID(),
+		a.Version()+len(a.events)+1),
+	)
+	e := eh.NewEvent(t, data, timestamp, options...)
 	a.events = append(a.events, e)
 	return e
 }

--- a/command.go
+++ b/command.go
@@ -53,6 +53,12 @@ func (ct CommandType) String() string {
 	return string(ct)
 }
 
+// CommandIDer provides a unique command ID to be used for request tracking etc.
+type CommandIDer interface {
+	// CommandID returns the ID of the command instance being handled.
+	CommandID() uuid.UUID
+}
+
 // ErrCommandNotRegistered is when no command factory was registered.
 var ErrCommandNotRegistered = errors.New("command not registered")
 

--- a/event.go
+++ b/event.go
@@ -96,6 +96,19 @@ func WithMetadata(metadata map[string]interface{}) EventOption {
 	}
 }
 
+// FromCommand adds metadat for the originating command when crating an event.
+// Currently it adds the command type and optionally a command ID (if the
+// CommandIDer interface is implemented).
+func FromCommand(cmd Command) EventOption {
+	md := map[string]interface{}{
+		"command_type": cmd.CommandType().String(),
+	}
+	if c, ok := cmd.(CommandIDer); ok {
+		md["command_id"] = c.CommandID().String()
+	}
+	return WithMetadata(md)
+}
+
 // NewEvent creates a new event with a type and data, setting its timestamp.
 func NewEvent(eventType EventType, data EventData, timestamp time.Time, options ...EventOption) Event {
 	e := &event{

--- a/event_test.go
+++ b/event_test.go
@@ -42,8 +42,8 @@ func TestNewEvent(t *testing.T) {
 	}
 
 	id := uuid.New()
-	event = NewEventForAggregate(TestEventType, &TestEventData{"event1"}, timestamp,
-		TestAggregateType, id, 3)
+	event = NewEvent(TestEventType, &TestEventData{"event1"}, timestamp,
+		ForAggregate(TestAggregateType, id, 3))
 	if event.EventType() != TestEventType {
 		t.Error("the event type should be correct:", event.EventType())
 	}

--- a/event_test.go
+++ b/event_test.go
@@ -43,7 +43,9 @@ func TestNewEvent(t *testing.T) {
 
 	id := uuid.New()
 	event = NewEvent(TestEventType, &TestEventData{"event1"}, timestamp,
-		ForAggregate(TestAggregateType, id, 3))
+		ForAggregate(TestAggregateType, id, 3),
+		WithMetadata(map[string]interface{}{"meta": "data", "num": 42}),
+	)
 	if event.EventType() != TestEventType {
 		t.Error("the event type should be correct:", event.EventType())
 	}
@@ -61,6 +63,9 @@ func TestNewEvent(t *testing.T) {
 	}
 	if event.Version() != 3 {
 		t.Error("the version should be zero:", event.Version())
+	}
+	if !reflect.DeepEqual(event.Metadata(), map[string]interface{}{"meta": "data", "num": 42}) {
+		t.Error("the metadata should be correct:", event.Metadata())
 	}
 	if event.String() != "TestEvent@3" {
 		t.Error("the string representation should be correct:", event.String())

--- a/eventbus/acceptance_testing.go
+++ b/eventbus/acceptance_testing.go
@@ -67,7 +67,9 @@ func AcceptanceTest(t *testing.T, bus1, bus2 eh.EventBus, timeout time.Duration)
 	id := uuid.New()
 	timestamp := time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)
 	event1 := eh.NewEvent(mocks.EventType, &mocks.EventData{Content: "event1"}, timestamp,
-		eh.ForAggregate(mocks.AggregateType, id, 1))
+		eh.ForAggregate(mocks.AggregateType, id, 1),
+		eh.WithMetadata(map[string]interface{}{"meta": "data", "num": int32(42)}),
+	)
 	if err := bus1.HandleEvent(ctx, event1); err != nil {
 		t.Error("there should be no error:", err)
 	}

--- a/eventbus/acceptance_testing.go
+++ b/eventbus/acceptance_testing.go
@@ -66,8 +66,8 @@ func AcceptanceTest(t *testing.T, bus1, bus2 eh.EventBus, timeout time.Duration)
 	// Without handler.
 	id := uuid.New()
 	timestamp := time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)
-	event1 := eh.NewEventForAggregate(mocks.EventType, &mocks.EventData{Content: "event1"}, timestamp,
-		mocks.AggregateType, id, 1)
+	event1 := eh.NewEvent(mocks.EventType, &mocks.EventData{Content: "event1"}, timestamp,
+		eh.ForAggregate(mocks.AggregateType, id, 1))
 	if err := bus1.HandleEvent(ctx, event1); err != nil {
 		t.Error("there should be no error:", err)
 	}
@@ -80,8 +80,8 @@ func AcceptanceTest(t *testing.T, bus1, bus2 eh.EventBus, timeout time.Duration)
 	// Event without data (tested in its own handler).
 	otherHandler := mocks.NewEventHandler("other-handler")
 	bus1.AddHandler(ctx, eh.MatchEvents{mocks.EventOtherType}, otherHandler)
-	eventWithoutData := eh.NewEventForAggregate(mocks.EventOtherType, nil, timestamp,
-		mocks.AggregateType, uuid.New(), 1)
+	eventWithoutData := eh.NewEvent(mocks.EventOtherType, nil, timestamp,
+		eh.ForAggregate(mocks.AggregateType, uuid.New(), 1))
 	if err := bus1.HandleEvent(ctx, eventWithoutData); err != nil {
 		t.Error("there should be no error:", err)
 	}
@@ -232,9 +232,9 @@ func LoadTest(t *testing.T, bus eh.EventBus) {
 	id := uuid.New()
 	timestamp := time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)
 
-	event1 := eh.NewEventForAggregate(
-		mocks.EventType, &mocks.EventData{Content: "event1"},
-		timestamp, mocks.AggregateType, id, 1)
+	event1 := eh.NewEvent(
+		mocks.EventType, &mocks.EventData{Content: "event1"}, timestamp,
+		eh.ForAggregate(mocks.AggregateType, id, 1))
 	if err := bus.HandleEvent(ctx, event1); err != nil {
 		t.Error("there should be no error:", err)
 	}
@@ -257,9 +257,9 @@ func Benchmark(b *testing.B, bus eh.EventBus) {
 	b.ResetTimer()
 
 	for n := 0; n < b.N; n++ {
-		event1 := eh.NewEventForAggregate(
-			mocks.EventType, &mocks.EventData{Content: "event1"},
-			timestamp, mocks.AggregateType, id, n+1)
+		event1 := eh.NewEvent(
+			mocks.EventType, &mocks.EventData{Content: "event1"}, timestamp,
+			eh.ForAggregate(mocks.AggregateType, id, n+1))
 		if err := bus.HandleEvent(ctx, event1); err != nil {
 			b.Error("there should be no error:", err)
 		}

--- a/eventbus/gcp/eventbus.go
+++ b/eventbus/gcp/eventbus.go
@@ -93,6 +93,7 @@ func (b *EventBus) HandleEvent(ctx context.Context, event eh.Event) error {
 		EventType:     event.EventType(),
 		Version:       event.Version(),
 		Timestamp:     event.Timestamp(),
+		Metadata:      event.Metadata(),
 		Context:       eh.MarshalContext(ctx),
 	}
 
@@ -274,6 +275,7 @@ func (b *EventBus) handler(m eh.EventMatcher, h eh.EventHandler) func(ctx contex
 				aggregateID,
 				e.Version,
 			),
+			eh.WithMetadata(e.Metadata),
 		)
 
 		// Ignore non-matching events.
@@ -340,5 +342,6 @@ type evt struct {
 	AggregateType eh.AggregateType       `bson:"aggregate_type"`
 	AggregateID   string                 `bson:"_id"`
 	Version       int                    `bson:"version"`
+	Metadata      map[string]interface{} `bson:"metadata"`
 	Context       map[string]interface{} `bson:"context"`
 }

--- a/eventbus/gcp/eventbus.go
+++ b/eventbus/gcp/eventbus.go
@@ -265,13 +265,15 @@ func (b *EventBus) handler(m eh.EventMatcher, h eh.EventHandler) func(ctx contex
 		if err != nil {
 			aggregateID = uuid.Nil
 		}
-		event := eh.NewEventForAggregate(
+		event := eh.NewEvent(
 			e.EventType,
 			e.data,
 			e.Timestamp,
-			e.AggregateType,
-			aggregateID,
-			e.Version,
+			eh.ForAggregate(
+				e.AggregateType,
+				aggregateID,
+				e.Version,
+			),
 		)
 
 		// Ignore non-matching events.

--- a/eventbus/local/eventbus.go
+++ b/eventbus/local/eventbus.go
@@ -166,13 +166,15 @@ func (g *Group) publish(ctx context.Context, event eh.Event) error {
 			}
 			copier.Copy(data, event.Data())
 		}
-		eventCopy := eh.NewEventForAggregate(
+		eventCopy := eh.NewEvent(
 			event.EventType(),
 			data,
 			event.Timestamp(),
-			event.AggregateType(),
-			event.AggregateID(),
-			event.Version(),
+			eh.ForAggregate(
+				event.AggregateType(),
+				event.AggregateID(),
+				event.Version(),
+			),
 		)
 		// Marshal and unmarshal the context to both simulate only sending data
 		// that would be sent over a network bus and also break any relationship

--- a/eventbus/local/eventbus.go
+++ b/eventbus/local/eventbus.go
@@ -175,6 +175,7 @@ func (g *Group) publish(ctx context.Context, event eh.Event) error {
 				event.AggregateID(),
 				event.Version(),
 			),
+			eh.WithMetadata(event.Metadata()),
 		)
 		// Marshal and unmarshal the context to both simulate only sending data
 		// that would be sent over a network bus and also break any relationship

--- a/eventhandler/projector/eventhandler_test.go
+++ b/eventhandler/projector/eventhandler_test.go
@@ -41,8 +41,8 @@ func TestEventHandler_CreateModel(t *testing.T) {
 	id := uuid.New()
 	eventData := &mocks.EventData{Content: "event1"}
 	timestamp := time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)
-	event := eh.NewEventForAggregate(mocks.EventType, eventData, timestamp,
-		mocks.AggregateType, id, 1)
+	event := eh.NewEvent(mocks.EventType, eventData, timestamp,
+		eh.ForAggregate(mocks.AggregateType, id, 1))
 	entity := &mocks.SimpleModel{
 		ID: id,
 	}
@@ -77,8 +77,8 @@ func TestEventHandler_UpdateModel(t *testing.T) {
 	id := uuid.New()
 	eventData := &mocks.EventData{Content: "event1"}
 	timestamp := time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)
-	event := eh.NewEventForAggregate(mocks.EventType, eventData, timestamp,
-		mocks.AggregateType, id, 1)
+	event := eh.NewEvent(mocks.EventType, eventData, timestamp,
+		eh.ForAggregate(mocks.AggregateType, id, 1))
 	entity := &mocks.SimpleModel{
 		ID: id,
 	}
@@ -119,8 +119,8 @@ func TestEventHandler_UpdateModelWithVersion(t *testing.T) {
 	id := uuid.New()
 	eventData := &mocks.EventData{Content: "event1"}
 	timestamp := time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)
-	event := eh.NewEventForAggregate(mocks.EventType, eventData, timestamp,
-		mocks.AggregateType, id, 1)
+	event := eh.NewEvent(mocks.EventType, eventData, timestamp,
+		eh.ForAggregate(mocks.AggregateType, id, 1))
 	entity := &mocks.Model{
 		ID: id,
 	}
@@ -164,8 +164,8 @@ func TestEventHandler_UpdateModelWithEventsOutOfOrder(t *testing.T) {
 	id := uuid.New()
 	eventData := &mocks.EventData{Content: "event1"}
 	timestamp := time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)
-	event := eh.NewEventForAggregate(mocks.EventType, eventData, timestamp,
-		mocks.AggregateType, id, 3)
+	event := eh.NewEvent(mocks.EventType, eventData, timestamp,
+		eh.ForAggregate(mocks.AggregateType, id, 3))
 	entity := &mocks.Model{
 		ID:      id,
 		Version: 1,
@@ -215,8 +215,8 @@ func TestEventHandler_DeleteModel(t *testing.T) {
 	id := uuid.New()
 	eventData := &mocks.EventData{Content: "event1"}
 	timestamp := time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)
-	event := eh.NewEventForAggregate(mocks.EventType, eventData, timestamp,
-		mocks.AggregateType, id, 1)
+	event := eh.NewEvent(mocks.EventType, eventData, timestamp,
+		eh.ForAggregate(mocks.AggregateType, id, 1))
 	entity := &mocks.SimpleModel{
 		ID: id,
 	}
@@ -250,8 +250,8 @@ func TestEventHandler_LoadError(t *testing.T) {
 	id := uuid.New()
 	eventData := &mocks.EventData{Content: "event1"}
 	timestamp := time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)
-	event := eh.NewEventForAggregate(mocks.EventType, eventData, timestamp,
-		mocks.AggregateType, id, 1)
+	event := eh.NewEvent(mocks.EventType, eventData, timestamp,
+		eh.ForAggregate(mocks.AggregateType, id, 1))
 	loadErr := errors.New("load error")
 	repo.LoadErr = loadErr
 	expectedErr := Error{
@@ -278,8 +278,8 @@ func TestEventHandler_SaveError(t *testing.T) {
 	id := uuid.New()
 	eventData := &mocks.EventData{Content: "event1"}
 	timestamp := time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)
-	event := eh.NewEventForAggregate(mocks.EventType, eventData, timestamp,
-		mocks.AggregateType, id, 1)
+	event := eh.NewEvent(mocks.EventType, eventData, timestamp,
+		eh.ForAggregate(mocks.AggregateType, id, 1))
 	saveErr := errors.New("save error")
 	repo.SaveErr = saveErr
 	expectedErr := Error{
@@ -306,8 +306,8 @@ func TestEventHandler_ProjectError(t *testing.T) {
 	id := uuid.New()
 	eventData := &mocks.EventData{Content: "event1"}
 	timestamp := time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)
-	event := eh.NewEventForAggregate(mocks.EventType, eventData, timestamp,
-		mocks.AggregateType, id, 1)
+	event := eh.NewEvent(mocks.EventType, eventData, timestamp,
+		eh.ForAggregate(mocks.AggregateType, id, 1))
 	projectErr := errors.New("save error")
 	projector.err = projectErr
 	expectedErr := Error{

--- a/eventhandler/saga/eventhandler_test.go
+++ b/eventhandler/saga/eventhandler_test.go
@@ -37,8 +37,8 @@ func TestEventHandler(t *testing.T) {
 	id := uuid.New()
 	eventData := &mocks.EventData{Content: "event1"}
 	timestamp := time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)
-	event := eh.NewEventForAggregate(mocks.EventType, eventData, timestamp,
-		mocks.AggregateType, id, 1)
+	event := eh.NewEvent(mocks.EventType, eventData, timestamp,
+		eh.ForAggregate(mocks.AggregateType, id, 1))
 	saga.commands = []eh.Command{&mocks.Command{ID: uuid.New(), Content: "content"}}
 	handler.HandleEvent(ctx, event)
 	if saga.event != event {

--- a/eventhandler/waiter/eventhandler_test.go
+++ b/eventhandler/waiter/eventhandler_test.go
@@ -31,9 +31,8 @@ func TestEventHandler(t *testing.T) {
 
 	// Event should match when waiting.
 	timestamp := time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)
-	expectedEvent := eh.NewEventForAggregate(
-		mocks.EventType, nil, timestamp, mocks.AggregateType, uuid.New(), 1,
-	)
+	expectedEvent := eh.NewEvent(mocks.EventType, nil, timestamp,
+		eh.ForAggregate(mocks.AggregateType, uuid.New(), 1))
 	go func() {
 		time.Sleep(time.Millisecond)
 		h.HandleEvent(context.Background(), expectedEvent)
@@ -58,8 +57,8 @@ func TestEventHandler(t *testing.T) {
 	}
 
 	// Other events should not match.
-	otherEvent := eh.NewEventForAggregate(mocks.EventOtherType, nil, timestamp,
-		mocks.AggregateType, uuid.New(), 1)
+	otherEvent := eh.NewEvent(mocks.EventOtherType, nil, timestamp,
+		eh.ForAggregate(mocks.AggregateType, uuid.New(), 1))
 	go func() {
 		time.Sleep(time.Millisecond)
 		h.HandleEvent(context.Background(), otherEvent)

--- a/eventstore/acceptanece_testing.go
+++ b/eventstore/acceptanece_testing.go
@@ -50,8 +50,8 @@ func AcceptanceTest(t *testing.T, ctx context.Context, store eh.EventStore) []eh
 	// Save event, version 1.
 	id := uuid.New()
 	timestamp := time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)
-	event1 := eh.NewEventForAggregate(mocks.EventType, &mocks.EventData{Content: "event1"},
-		timestamp, mocks.AggregateType, id, 1)
+	event1 := eh.NewEvent(mocks.EventType, &mocks.EventData{Content: "event1"}, timestamp,
+		eh.ForAggregate(mocks.AggregateType, id, 1))
 	err = store.Save(ctx, []eh.Event{event1}, 0)
 	if err != nil {
 		t.Error("there should be no error:", err)
@@ -68,8 +68,8 @@ func AcceptanceTest(t *testing.T, ctx context.Context, store eh.EventStore) []eh
 	}
 
 	// Save event, version 2.
-	event2 := eh.NewEventForAggregate(mocks.EventType, &mocks.EventData{Content: "event2"},
-		timestamp, mocks.AggregateType, id, 2)
+	event2 := eh.NewEvent(mocks.EventType, &mocks.EventData{Content: "event2"}, timestamp,
+		eh.ForAggregate(mocks.AggregateType, id, 2))
 	err = store.Save(ctx, []eh.Event{event2}, 1)
 	if err != nil {
 		t.Error("there should be no error:", err)
@@ -77,8 +77,8 @@ func AcceptanceTest(t *testing.T, ctx context.Context, store eh.EventStore) []eh
 	savedEvents = append(savedEvents, event2)
 
 	// Save event without data, version 3.
-	event3 := eh.NewEventForAggregate(mocks.EventOtherType, nil, timestamp,
-		mocks.AggregateType, id, 3)
+	event3 := eh.NewEvent(mocks.EventOtherType, nil, timestamp,
+		eh.ForAggregate(mocks.AggregateType, id, 3))
 	err = store.Save(ctx, []eh.Event{event3}, 2)
 	if err != nil {
 		t.Error("there should be no error:", err)
@@ -86,12 +86,12 @@ func AcceptanceTest(t *testing.T, ctx context.Context, store eh.EventStore) []eh
 	savedEvents = append(savedEvents, event3)
 
 	// Save multiple events, version 4,5 and 6.
-	event4 := eh.NewEventForAggregate(mocks.EventOtherType, nil, timestamp,
-		mocks.AggregateType, id, 4)
-	event5 := eh.NewEventForAggregate(mocks.EventOtherType, nil, timestamp,
-		mocks.AggregateType, id, 5)
-	event6 := eh.NewEventForAggregate(mocks.EventOtherType, nil, timestamp,
-		mocks.AggregateType, id, 6)
+	event4 := eh.NewEvent(mocks.EventOtherType, nil, timestamp,
+		eh.ForAggregate(mocks.AggregateType, id, 4))
+	event5 := eh.NewEvent(mocks.EventOtherType, nil, timestamp,
+		eh.ForAggregate(mocks.AggregateType, id, 5))
+	event6 := eh.NewEvent(mocks.EventOtherType, nil, timestamp,
+		eh.ForAggregate(mocks.AggregateType, id, 6))
 	err = store.Save(ctx, []eh.Event{event4, event5, event6}, 3)
 	if err != nil {
 		t.Error("there should be no error:", err)
@@ -100,8 +100,8 @@ func AcceptanceTest(t *testing.T, ctx context.Context, store eh.EventStore) []eh
 
 	// Save event for another aggregate.
 	id2 := uuid.New()
-	event7 := eh.NewEventForAggregate(mocks.EventType, &mocks.EventData{Content: "event7"},
-		timestamp, mocks.AggregateType, id2, 1)
+	event7 := eh.NewEvent(mocks.EventType, &mocks.EventData{Content: "event7"}, timestamp,
+		eh.ForAggregate(mocks.AggregateType, id2, 1))
 	err = store.Save(ctx, []eh.Event{event7}, 0)
 	if err != nil {
 		t.Error("there should be no error:", err)
@@ -171,33 +171,33 @@ func MaintainerAcceptanceTest(t *testing.T, ctx context.Context, store eh.EventS
 	// Save some events.
 	id := uuid.New()
 	timestamp := time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)
-	event1 := eh.NewEventForAggregate(mocks.EventType, &mocks.EventData{Content: "event1"},
-		timestamp, mocks.AggregateType, id, 1)
-	event2 := eh.NewEventForAggregate(mocks.EventType, &mocks.EventData{Content: "event1"},
-		timestamp, mocks.AggregateType, id, 2)
-	event3 := eh.NewEventForAggregate(mocks.EventType, &mocks.EventData{Content: "event1"},
-		timestamp, mocks.AggregateType, id, 3)
+	event1 := eh.NewEvent(mocks.EventType, &mocks.EventData{Content: "event1"}, timestamp,
+		eh.ForAggregate(mocks.AggregateType, id, 1))
+	event2 := eh.NewEvent(mocks.EventType, &mocks.EventData{Content: "event1"}, timestamp,
+		eh.ForAggregate(mocks.AggregateType, id, 2))
+	event3 := eh.NewEvent(mocks.EventType, &mocks.EventData{Content: "event1"}, timestamp,
+		eh.ForAggregate(mocks.AggregateType, id, 3))
 	if err := store.Save(ctx, []eh.Event{event1, event2, event3}, 0); err != nil {
 		t.Error("there should be no error:", err)
 	}
 
 	// Replace event, no aggregate.
-	eventWithoutAggregate := eh.NewEventForAggregate(mocks.EventType, &mocks.EventData{Content: "event"},
-		timestamp, mocks.AggregateType, uuid.New(), 1)
+	eventWithoutAggregate := eh.NewEvent(mocks.EventType, &mocks.EventData{Content: "event"}, timestamp,
+		eh.ForAggregate(mocks.AggregateType, uuid.New(), 1))
 	if err := store.Replace(ctx, eventWithoutAggregate); err != eh.ErrAggregateNotFound {
 		t.Error("there should be an aggregate not found error:", err)
 	}
 
 	// Replace event, no event version.
-	eventWithoutVersion := eh.NewEventForAggregate(mocks.EventType, &mocks.EventData{Content: "event20"},
-		timestamp, mocks.AggregateType, id, 20)
+	eventWithoutVersion := eh.NewEvent(mocks.EventType, &mocks.EventData{Content: "event20"}, timestamp,
+		eh.ForAggregate(mocks.AggregateType, id, 20))
 	if err := store.Replace(ctx, eventWithoutVersion); err != eh.ErrInvalidEvent {
 		t.Error("there should be an invalid event error:", err)
 	}
 
 	// Replace event.
-	event2Mod := eh.NewEventForAggregate(mocks.EventType, &mocks.EventData{Content: "event2_mod"},
-		timestamp, mocks.AggregateType, id, 2)
+	event2Mod := eh.NewEvent(mocks.EventType, &mocks.EventData{Content: "event2_mod"}, timestamp,
+		eh.ForAggregate(mocks.AggregateType, id, 2))
 	if err := store.Replace(ctx, event2Mod); err != nil {
 		t.Error("there should be no error:", err)
 	}
@@ -222,14 +222,14 @@ func MaintainerAcceptanceTest(t *testing.T, ctx context.Context, store eh.EventS
 	// Save events of the old type.
 	oldEventType := eh.EventType("old_event_type")
 	id1 := uuid.New()
-	oldEvent1 := eh.NewEventForAggregate(oldEventType, nil, timestamp,
-		mocks.AggregateType, id1, 1)
+	oldEvent1 := eh.NewEvent(oldEventType, nil, timestamp,
+		eh.ForAggregate(mocks.AggregateType, id1, 1))
 	if err := store.Save(ctx, []eh.Event{oldEvent1}, 0); err != nil {
 		t.Error("there should be no error:", err)
 	}
 	id2 := uuid.New()
-	oldEvent2 := eh.NewEventForAggregate(oldEventType, nil, timestamp,
-		mocks.AggregateType, id2, 1)
+	oldEvent2 := eh.NewEvent(oldEventType, nil, timestamp,
+		eh.ForAggregate(mocks.AggregateType, id2, 1))
 	if err := store.Save(ctx, []eh.Event{oldEvent2}, 0); err != nil {
 		t.Error("there should be no error:", err)
 	}
@@ -243,8 +243,8 @@ func MaintainerAcceptanceTest(t *testing.T, ctx context.Context, store eh.EventS
 	if err != nil {
 		t.Error("there should be no error:", err)
 	}
-	newEvent1 := eh.NewEventForAggregate(newEventType, nil, timestamp,
-		mocks.AggregateType, id1, 1)
+	newEvent1 := eh.NewEvent(newEventType, nil, timestamp,
+		eh.ForAggregate(mocks.AggregateType, id1, 1))
 	if len(events) != 1 {
 		t.Fatal("there should be one event")
 	}
@@ -255,8 +255,8 @@ func MaintainerAcceptanceTest(t *testing.T, ctx context.Context, store eh.EventS
 	if err != nil {
 		t.Error("there should be no error:", err)
 	}
-	newEvent2 := eh.NewEventForAggregate(newEventType, nil, timestamp,
-		mocks.AggregateType, id2, 1)
+	newEvent2 := eh.NewEvent(newEventType, nil, timestamp,
+		eh.ForAggregate(mocks.AggregateType, id2, 1))
 	if len(events) != 1 {
 		t.Fatal("there should be one event")
 	}

--- a/eventstore/acceptanece_testing.go
+++ b/eventstore/acceptanece_testing.go
@@ -67,9 +67,11 @@ func AcceptanceTest(t *testing.T, ctx context.Context, store eh.EventStore) []eh
 		t.Error("there should be a ErrIncerrectEventVersion error:", err)
 	}
 
-	// Save event, version 2.
+	// Save event, version 2, with metadata.
 	event2 := eh.NewEvent(mocks.EventType, &mocks.EventData{Content: "event2"}, timestamp,
-		eh.ForAggregate(mocks.AggregateType, id, 2))
+		eh.ForAggregate(mocks.AggregateType, id, 2),
+		eh.WithMetadata(map[string]interface{}{"meta": "data", "num": int32(42)}),
+	)
 	err = store.Save(ctx, []eh.Event{event2}, 1)
 	if err != nil {
 		t.Error("there should be no error:", err)

--- a/eventstore/memory/eventstore.go
+++ b/eventstore/memory/eventstore.go
@@ -208,6 +208,7 @@ func (s *EventStore) RenameEvent(ctx context.Context, from, to eh.EventType) err
 						e.AggregateID(),
 						e.Version(),
 					),
+					eh.WithMetadata(e.Metadata()),
 				)
 			}
 		}
@@ -265,5 +266,6 @@ func copyEvent(ctx context.Context, event eh.Event) (eh.Event, error) {
 			event.AggregateID(),
 			event.Version(),
 		),
+		eh.WithMetadata(event.Metadata()),
 	), nil
 }

--- a/eventstore/memory/eventstore.go
+++ b/eventstore/memory/eventstore.go
@@ -199,13 +199,15 @@ func (s *EventStore) RenameEvent(ctx context.Context, from, to eh.EventType) err
 		for i, e := range aggregate.Events {
 			if e.EventType() == from {
 				// Rename any matching event by duplicating.
-				events[i] = eh.NewEventForAggregate(
+				events[i] = eh.NewEvent(
 					to,
 					e.Data(),
 					e.Timestamp(),
-					e.AggregateType(),
-					e.AggregateID(),
-					e.Version(),
+					eh.ForAggregate(
+						e.AggregateType(),
+						e.AggregateID(),
+						e.Version(),
+					),
 				)
 			}
 		}
@@ -254,12 +256,14 @@ func copyEvent(ctx context.Context, event eh.Event) (eh.Event, error) {
 		copier.Copy(data, event.Data())
 	}
 
-	return eh.NewEventForAggregate(
+	return eh.NewEvent(
 		event.EventType(),
 		data,
 		event.Timestamp(),
-		event.AggregateType(),
-		event.AggregateID(),
-		event.Version(),
+		eh.ForAggregate(
+			event.AggregateType(),
+			event.AggregateID(),
+			event.Version(),
+		),
 	), nil
 }

--- a/eventstore/mongodb/eventstore.go
+++ b/eventstore/mongodb/eventstore.go
@@ -256,6 +256,7 @@ func (s *EventStore) Load(ctx context.Context, id uuid.UUID) ([]eh.Event, error)
 				e.AggregateID,
 				e.Version,
 			),
+			eh.WithMetadata(e.Metadata),
 		)
 		events[i] = event
 	}
@@ -361,13 +362,14 @@ type aggregateRecord struct {
 // evt is the internal event record for the MongoDB event store used
 // to save and load events from the DB.
 type evt struct {
-	EventType     eh.EventType     `bson:"event_type"`
-	RawData       bson.Raw         `bson:"data,omitempty"`
-	data          eh.EventData     `bson:"-"`
-	Timestamp     time.Time        `bson:"timestamp"`
-	AggregateType eh.AggregateType `bson:"aggregate_type"`
-	AggregateID   uuid.UUID        `bson:"_id"`
-	Version       int              `bson:"version"`
+	EventType     eh.EventType           `bson:"event_type"`
+	RawData       bson.Raw               `bson:"data,omitempty"`
+	data          eh.EventData           `bson:"-"`
+	Timestamp     time.Time              `bson:"timestamp"`
+	AggregateType eh.AggregateType       `bson:"aggregate_type"`
+	AggregateID   uuid.UUID              `bson:"_id"`
+	Version       int                    `bson:"version"`
+	Metadata      map[string]interface{} `bson:"metadata"`
 }
 
 // newEvt returns a new evt for an event.
@@ -378,6 +380,7 @@ func newEvt(ctx context.Context, event eh.Event) (*evt, error) {
 		AggregateType: event.AggregateType(),
 		AggregateID:   event.AggregateID(),
 		Version:       event.Version(),
+		Metadata:      event.Metadata(),
 	}
 
 	// Marshal event data if there is any.

--- a/eventstore/mongodb/eventstore.go
+++ b/eventstore/mongodb/eventstore.go
@@ -135,7 +135,7 @@ func (s *EventStore) Save(ctx context.Context, events []eh.Event, originalVersio
 
 	// Build all event records, with incrementing versions starting from the
 	// original aggregate version.
-	dbEvents := make([]dbEvent, len(events))
+	dbEvents := make([]evt, len(events))
 	aggregateID := events[0].AggregateID()
 	for i, event := range events {
 		// Only accept events belonging to the same aggregate.
@@ -155,7 +155,7 @@ func (s *EventStore) Save(ctx context.Context, events []eh.Event, originalVersio
 		}
 
 		// Create the event record for the DB.
-		e, err := newDBEvent(ctx, event)
+		e, err := newEvt(ctx, event)
 		if err != nil {
 			return err
 		}
@@ -226,28 +226,36 @@ func (s *EventStore) Load(ctx context.Context, id uuid.UUID) ([]eh.Event, error)
 	}
 
 	events := make([]eh.Event, len(aggregate.Events))
-	for i, dbEvent := range aggregate.Events {
+	for i, e := range aggregate.Events {
 		// Create an event of the correct type and decode from raw BSON.
-		if len(dbEvent.RawData) > 0 {
+		if len(e.RawData) > 0 {
 			var err error
-			if dbEvent.data, err = eh.CreateEventData(dbEvent.EventType); err != nil {
+			if e.data, err = eh.CreateEventData(e.EventType); err != nil {
 				return nil, eh.EventStoreError{
 					Err:       ErrCouldNotUnmarshalEvent,
 					BaseErr:   err,
 					Namespace: eh.NamespaceFromContext(ctx),
 				}
 			}
-			if err := bson.Unmarshal(dbEvent.RawData, dbEvent.data); err != nil {
+			if err := bson.Unmarshal(e.RawData, e.data); err != nil {
 				return nil, eh.EventStoreError{
 					Err:       ErrCouldNotUnmarshalEvent,
 					BaseErr:   err,
 					Namespace: eh.NamespaceFromContext(ctx),
 				}
 			}
-			dbEvent.RawData = nil
+			e.RawData = nil
 		}
 
-		events[i] = event{dbEvent: dbEvent}
+		event := eh.NewEventForAggregate(
+			e.EventType,
+			e.data,
+			e.Timestamp,
+			e.AggregateType,
+			e.AggregateID,
+			e.Version,
+		)
+		events[i] = event
 	}
 
 	return events, nil
@@ -269,7 +277,7 @@ func (s *EventStore) Replace(ctx context.Context, event eh.Event) error {
 	}
 
 	// Create the event record for the Database.
-	e, err := newDBEvent(ctx, event)
+	e, err := newEvt(ctx, event)
 	if err != nil {
 		return err
 	}
@@ -343,14 +351,14 @@ func (s *EventStore) Close(ctx context.Context) {
 type aggregateRecord struct {
 	AggregateID uuid.UUID `bson:"_id"`
 	Version     int       `bson:"version"`
-	Events      []dbEvent `bson:"events"`
+	Events      []evt     `bson:"events"`
 	// Type        string        `bson:"type"`
 	// Snapshot    bson.Raw      `bson:"snapshot"`
 }
 
-// dbEvent is the internal event record for the MongoDB event store used
+// evt is the internal event record for the MongoDB event store used
 // to save and load events from the DB.
-type dbEvent struct {
+type evt struct {
 	EventType     eh.EventType     `bson:"event_type"`
 	RawData       bson.Raw         `bson:"data,omitempty"`
 	data          eh.EventData     `bson:"-"`
@@ -360,9 +368,9 @@ type dbEvent struct {
 	Version       int              `bson:"version"`
 }
 
-// newDBEvent returns a new dbEvent for an event.
-func newDBEvent(ctx context.Context, event eh.Event) (*dbEvent, error) {
-	e := &dbEvent{
+// newEvt returns a new evt for an event.
+func newEvt(ctx context.Context, event eh.Event) (*evt, error) {
+	e := &evt{
 		EventType:     event.EventType(),
 		Timestamp:     event.Timestamp(),
 		AggregateType: event.AggregateType(),
@@ -384,45 +392,4 @@ func newDBEvent(ctx context.Context, event eh.Event) (*dbEvent, error) {
 	}
 
 	return e, nil
-}
-
-// event is the private implementation of the eventhorizon.Event interface
-// for a MongoDB event store.
-type event struct {
-	dbEvent
-}
-
-// AggrgateID implements the AggrgateID method of the eventhorizon.Event interface.
-func (e event) AggregateID() uuid.UUID {
-	return e.dbEvent.AggregateID
-}
-
-// AggregateType implements the AggregateType method of the eventhorizon.Event interface.
-func (e event) AggregateType() eh.AggregateType {
-	return e.dbEvent.AggregateType
-}
-
-// EventType implements the EventType method of the eventhorizon.Event interface.
-func (e event) EventType() eh.EventType {
-	return e.dbEvent.EventType
-}
-
-// Data implements the Data method of the eventhorizon.Event interface.
-func (e event) Data() eh.EventData {
-	return e.dbEvent.data
-}
-
-// Version implements the Version method of the eventhorizon.Event interface.
-func (e event) Version() int {
-	return e.dbEvent.Version
-}
-
-// Timestamp implements the Timestamp method of the eventhorizon.Event interface.
-func (e event) Timestamp() time.Time {
-	return e.dbEvent.Timestamp
-}
-
-// String implements the String method of the eventhorizon.Event interface.
-func (e event) String() string {
-	return fmt.Sprintf("%s@%d", e.dbEvent.EventType, e.dbEvent.Version)
 }

--- a/eventstore/mongodb/eventstore.go
+++ b/eventstore/mongodb/eventstore.go
@@ -247,13 +247,15 @@ func (s *EventStore) Load(ctx context.Context, id uuid.UUID) ([]eh.Event, error)
 			e.RawData = nil
 		}
 
-		event := eh.NewEventForAggregate(
+		event := eh.NewEvent(
 			e.EventType,
 			e.data,
 			e.Timestamp,
-			e.AggregateType,
-			e.AggregateID,
-			e.Version,
+			eh.ForAggregate(
+				e.AggregateType,
+				e.AggregateID,
+				e.Version,
+			),
 		)
 		events[i] = event
 	}

--- a/eventstore/recorder/eventstore_test.go
+++ b/eventstore/recorder/eventstore_test.go
@@ -63,8 +63,8 @@ func TestEventStore(t *testing.T) {
 
 	// Save event, version 7.
 	timestamp := time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)
-	event7 := eh.NewEventForAggregate(mocks.EventType, &mocks.EventData{Content: "event1"},
-		timestamp, mocks.AggregateType, event1.AggregateID(), 7)
+	event7 := eh.NewEvent(mocks.EventType, &mocks.EventData{Content: "event1"}, timestamp,
+		eh.ForAggregate(mocks.AggregateType, event1.AggregateID(), 7))
 	err := store.Save(ctx, []eh.Event{event7}, 6)
 	if err != nil {
 		t.Error("there should be no error:", err)

--- a/examples/todomvc/backend/domains/todo/aggregate_test.go
+++ b/examples/todomvc/backend/domains/todo/aggregate_test.go
@@ -60,8 +60,9 @@ func TestAggregateHandleCommand(t *testing.T) {
 				ID: id,
 			},
 			[]eh.Event{
-				eh.NewEventForAggregate(Created, nil,
-					TimeNow(), AggregateType, id, 1),
+				eh.NewEvent(Created, nil, TimeNow(),
+					eh.ForAggregate(AggregateType, id, 1),
+				),
 			},
 			nil,
 		},
@@ -81,8 +82,9 @@ func TestAggregateHandleCommand(t *testing.T) {
 			},
 			&Delete{},
 			[]eh.Event{
-				eh.NewEventForAggregate(Deleted, nil,
-					TimeNow(), AggregateType, id, 1),
+				eh.NewEvent(Deleted, nil, TimeNow(),
+					eh.ForAggregate(AggregateType, id, 1),
+				),
 			},
 			nil,
 		},
@@ -104,10 +106,12 @@ func TestAggregateHandleCommand(t *testing.T) {
 				Description: "desc",
 			},
 			[]eh.Event{
-				eh.NewEventForAggregate(ItemAdded, &ItemAddedData{
+				eh.NewEvent(ItemAdded, &ItemAddedData{
 					ItemID:      1,
 					Description: "desc",
-				}, TimeNow(), AggregateType, id, 1),
+				}, TimeNow(),
+					eh.ForAggregate(AggregateType, id, 1),
+				),
 			},
 			nil,
 		},
@@ -127,9 +131,11 @@ func TestAggregateHandleCommand(t *testing.T) {
 				ItemID: 1,
 			},
 			[]eh.Event{
-				eh.NewEventForAggregate(ItemRemoved, &ItemRemovedData{
+				eh.NewEvent(ItemRemoved, &ItemRemovedData{
 					ItemID: 1,
-				}, TimeNow(), AggregateType, id, 1),
+				}, TimeNow(),
+					eh.ForAggregate(AggregateType, id, 1),
+				),
 			},
 			nil,
 		},
@@ -175,12 +181,16 @@ func TestAggregateHandleCommand(t *testing.T) {
 			},
 			&RemoveCompletedItems{},
 			[]eh.Event{
-				eh.NewEventForAggregate(ItemRemoved, &ItemRemovedData{
+				eh.NewEvent(ItemRemoved, &ItemRemovedData{
 					ItemID: 1,
-				}, TimeNow(), AggregateType, id, 1),
-				eh.NewEventForAggregate(ItemRemoved, &ItemRemovedData{
+				}, TimeNow(),
+					eh.ForAggregate(AggregateType, id, 1),
+				),
+				eh.NewEvent(ItemRemoved, &ItemRemovedData{
 					ItemID: 3,
-				}, TimeNow(), AggregateType, id, 2),
+				}, TimeNow(),
+					eh.ForAggregate(AggregateType, id, 2),
+				),
 			},
 			nil,
 		},
@@ -201,10 +211,12 @@ func TestAggregateHandleCommand(t *testing.T) {
 				Description: "new desc",
 			},
 			[]eh.Event{
-				eh.NewEventForAggregate(ItemDescriptionSet, &ItemDescriptionSetData{
+				eh.NewEvent(ItemDescriptionSet, &ItemDescriptionSetData{
 					ItemID:      1,
 					Description: "new desc",
-				}, TimeNow(), AggregateType, id, 1),
+				}, TimeNow(),
+					eh.ForAggregate(AggregateType, id, 1),
+				),
 			},
 			nil,
 		},
@@ -263,10 +275,12 @@ func TestAggregateHandleCommand(t *testing.T) {
 				Checked: true,
 			},
 			[]eh.Event{
-				eh.NewEventForAggregate(ItemChecked, &ItemCheckedData{
+				eh.NewEvent(ItemChecked, &ItemCheckedData{
 					ItemID:  1,
 					Checked: true,
-				}, TimeNow(), AggregateType, id, 1),
+				}, TimeNow(),
+					eh.ForAggregate(AggregateType, id, 1),
+				),
 			},
 			nil,
 		},
@@ -287,10 +301,12 @@ func TestAggregateHandleCommand(t *testing.T) {
 				Checked: false,
 			},
 			[]eh.Event{
-				eh.NewEventForAggregate(ItemChecked, &ItemCheckedData{
+				eh.NewEvent(ItemChecked, &ItemCheckedData{
 					ItemID:  1,
 					Checked: false,
-				}, TimeNow(), AggregateType, id, 1),
+				}, TimeNow(),
+					eh.ForAggregate(AggregateType, id, 1),
+				),
 			},
 			nil,
 		},
@@ -358,14 +374,18 @@ func TestAggregateHandleCommand(t *testing.T) {
 				Checked: true,
 			},
 			[]eh.Event{
-				eh.NewEventForAggregate(ItemChecked, &ItemCheckedData{
+				eh.NewEvent(ItemChecked, &ItemCheckedData{
 					ItemID:  1,
 					Checked: true,
-				}, TimeNow(), AggregateType, id, 1),
-				eh.NewEventForAggregate(ItemChecked, &ItemCheckedData{
+				}, TimeNow(),
+					eh.ForAggregate(AggregateType, id, 1),
+				),
+				eh.NewEvent(ItemChecked, &ItemCheckedData{
 					ItemID:  3,
 					Checked: true,
-				}, TimeNow(), AggregateType, id, 2),
+				}, TimeNow(),
+					eh.ForAggregate(AggregateType, id, 2),
+				),
 			},
 			nil,
 		},
@@ -395,10 +415,12 @@ func TestAggregateHandleCommand(t *testing.T) {
 				Checked: false,
 			},
 			[]eh.Event{
-				eh.NewEventForAggregate(ItemChecked, &ItemCheckedData{
+				eh.NewEvent(ItemChecked, &ItemCheckedData{
 					ItemID:  2,
 					Checked: false,
-				}, TimeNow(), AggregateType, id, 1),
+				}, TimeNow(),
+					eh.ForAggregate(AggregateType, id, 1),
+				),
 			},
 			nil,
 		},
@@ -442,8 +464,9 @@ func TestAggregateApplyEvent(t *testing.T) {
 			&Aggregate{
 				AggregateBase: events.NewAggregateBase(AggregateType, id),
 			},
-			eh.NewEventForAggregate(eh.EventType("unknown"), nil,
-				TimeNow(), AggregateType, id, 1),
+			eh.NewEvent(eh.EventType("unknown"), nil, TimeNow(),
+				eh.ForAggregate(AggregateType, id, 1),
+			),
 			&Aggregate{
 				AggregateBase: events.NewAggregateBase(AggregateType, id),
 			},
@@ -453,8 +476,9 @@ func TestAggregateApplyEvent(t *testing.T) {
 			&Aggregate{
 				AggregateBase: events.NewAggregateBase(AggregateType, id),
 			},
-			eh.NewEventForAggregate(Created, nil,
-				TimeNow(), AggregateType, id, 1),
+			eh.NewEvent(Created, nil, TimeNow(),
+				eh.ForAggregate(AggregateType, id, 1),
+			),
 			&Aggregate{
 				AggregateBase: events.NewAggregateBase(AggregateType, id),
 				created:       true,
@@ -466,8 +490,9 @@ func TestAggregateApplyEvent(t *testing.T) {
 				AggregateBase: events.NewAggregateBase(AggregateType, id),
 				created:       true,
 			},
-			eh.NewEventForAggregate(Deleted, nil,
-				TimeNow(), AggregateType, id, 1),
+			eh.NewEvent(Deleted, nil, TimeNow(),
+				eh.ForAggregate(AggregateType, id, 1),
+			),
 			&Aggregate{
 				AggregateBase: events.NewAggregateBase(AggregateType, id),
 			},
@@ -478,10 +503,12 @@ func TestAggregateApplyEvent(t *testing.T) {
 				AggregateBase: events.NewAggregateBase(AggregateType, id),
 				nextItemID:    1,
 			},
-			eh.NewEventForAggregate(ItemAdded, &ItemAddedData{
+			eh.NewEvent(ItemAdded, &ItemAddedData{
 				ItemID:      1,
 				Description: "desc 1",
-			}, TimeNow(), AggregateType, id, 1),
+			}, TimeNow(),
+				eh.ForAggregate(AggregateType, id, 1),
+			),
 			&Aggregate{
 				AggregateBase: events.NewAggregateBase(AggregateType, id),
 				nextItemID:    2,
@@ -511,9 +538,11 @@ func TestAggregateApplyEvent(t *testing.T) {
 					},
 				},
 			},
-			eh.NewEventForAggregate(ItemRemoved, &ItemRemovedData{
+			eh.NewEvent(ItemRemoved, &ItemRemovedData{
 				ItemID: 2,
-			}, TimeNow(), AggregateType, id, 1),
+			}, TimeNow(),
+				eh.ForAggregate(AggregateType, id, 1),
+			),
 			&Aggregate{
 				AggregateBase: events.NewAggregateBase(AggregateType, id),
 				items: []*TodoItem{
@@ -537,9 +566,11 @@ func TestAggregateApplyEvent(t *testing.T) {
 					},
 				},
 			},
-			eh.NewEventForAggregate(ItemRemoved, &ItemRemovedData{
+			eh.NewEvent(ItemRemoved, &ItemRemovedData{
 				ItemID: 1,
-			}, TimeNow(), AggregateType, id, 1),
+			}, TimeNow(),
+				eh.ForAggregate(AggregateType, id, 1),
+			),
 			&Aggregate{
 				AggregateBase: events.NewAggregateBase(AggregateType, id),
 				items:         []*TodoItem{},
@@ -562,10 +593,12 @@ func TestAggregateApplyEvent(t *testing.T) {
 					},
 				},
 			},
-			eh.NewEventForAggregate(ItemDescriptionSet, &ItemDescriptionSetData{
+			eh.NewEvent(ItemDescriptionSet, &ItemDescriptionSetData{
 				ItemID:      2,
 				Description: "new desc",
-			}, TimeNow(), AggregateType, id, 1),
+			}, TimeNow(),
+				eh.ForAggregate(AggregateType, id, 1),
+			),
 			&Aggregate{
 				AggregateBase: events.NewAggregateBase(AggregateType, id),
 				items: []*TodoItem{
@@ -599,10 +632,12 @@ func TestAggregateApplyEvent(t *testing.T) {
 					},
 				},
 			},
-			eh.NewEventForAggregate(ItemChecked, &ItemCheckedData{
+			eh.NewEvent(ItemChecked, &ItemCheckedData{
 				ItemID:  2,
 				Checked: true,
-			}, TimeNow(), AggregateType, id, 1),
+			}, TimeNow(),
+				eh.ForAggregate(AggregateType, id, 1),
+			),
 			&Aggregate{
 				AggregateBase: events.NewAggregateBase(AggregateType, id),
 				items: []*TodoItem{

--- a/examples/todomvc/backend/domains/todo/projector_test.go
+++ b/examples/todomvc/backend/domains/todo/projector_test.go
@@ -40,14 +40,17 @@ func TestProjector(t *testing.T) {
 	}{
 		"unhandeled event": {
 			&TodoList{},
-			eh.NewEventForAggregate(eh.EventType("unknown"), nil,
-				TimeNow(), AggregateType, id, 1),
+			eh.NewEvent(eh.EventType("unknown"), nil, TimeNow(),
+				eh.ForAggregate(AggregateType, id, 1),
+			),
 			&TodoList{},
 			errors.New("could not project event: unknown"),
 		},
 		"created": {
 			&TodoList{},
-			eh.NewEventForAggregate(Created, nil, TimeNow(), AggregateType, id, 1),
+			eh.NewEvent(Created, nil, TimeNow(),
+				eh.ForAggregate(AggregateType, id, 1),
+			),
 			&TodoList{
 				ID:        id,
 				Version:   1,
@@ -59,8 +62,9 @@ func TestProjector(t *testing.T) {
 		},
 		"deleted": {
 			&TodoList{},
-			eh.NewEventForAggregate(Deleted, nil,
-				TimeNow(), AggregateType, id, 1),
+			eh.NewEvent(Deleted, nil, TimeNow(),
+				eh.ForAggregate(AggregateType, id, 1),
+			),
 			nil,
 			nil,
 		},
@@ -71,10 +75,12 @@ func TestProjector(t *testing.T) {
 				Items:     []*TodoItem{},
 				CreatedAt: TimeNow(),
 			},
-			eh.NewEventForAggregate(ItemAdded, &ItemAddedData{
+			eh.NewEvent(ItemAdded, &ItemAddedData{
 				ItemID:      1,
 				Description: "desc 1",
-			}, TimeNow(), AggregateType, id, 1),
+			}, TimeNow(),
+				eh.ForAggregate(AggregateType, id, 1),
+			),
 			&TodoList{
 				ID:      id,
 				Version: 2,
@@ -108,9 +114,11 @@ func TestProjector(t *testing.T) {
 				},
 				CreatedAt: TimeNow(),
 			},
-			eh.NewEventForAggregate(ItemRemoved, &ItemRemovedData{
+			eh.NewEvent(ItemRemoved, &ItemRemovedData{
 				ItemID: 2,
-			}, TimeNow(), AggregateType, id, 1),
+			}, TimeNow(),
+				eh.ForAggregate(AggregateType, id, 1),
+			),
 			&TodoList{
 				ID:      id,
 				Version: 2,
@@ -139,9 +147,11 @@ func TestProjector(t *testing.T) {
 				},
 				CreatedAt: TimeNow(),
 			},
-			eh.NewEventForAggregate(ItemRemoved, &ItemRemovedData{
+			eh.NewEvent(ItemRemoved, &ItemRemovedData{
 				ItemID: 1,
-			}, TimeNow(), AggregateType, id, 1),
+			}, TimeNow(),
+				eh.ForAggregate(AggregateType, id, 1),
+			),
 			&TodoList{
 				ID:        id,
 				Version:   2,
@@ -169,10 +179,12 @@ func TestProjector(t *testing.T) {
 				},
 				CreatedAt: TimeNow(),
 			},
-			eh.NewEventForAggregate(ItemDescriptionSet, &ItemDescriptionSetData{
+			eh.NewEvent(ItemDescriptionSet, &ItemDescriptionSetData{
 				ItemID:      2,
 				Description: "new desc",
-			}, TimeNow(), AggregateType, id, 1),
+			}, TimeNow(),
+				eh.ForAggregate(AggregateType, id, 1),
+			),
 			&TodoList{
 				ID:      id,
 				Version: 2,
@@ -211,10 +223,12 @@ func TestProjector(t *testing.T) {
 				},
 				CreatedAt: TimeNow(),
 			},
-			eh.NewEventForAggregate(ItemChecked, &ItemCheckedData{
+			eh.NewEvent(ItemChecked, &ItemCheckedData{
 				ItemID:  2,
 				Checked: true,
-			}, TimeNow(), AggregateType, id, 1),
+			}, TimeNow(),
+				eh.ForAggregate(AggregateType, id, 1),
+			),
 			&TodoList{
 				ID:      id,
 				Version: 2,

--- a/matcher_test.go
+++ b/matcher_test.go
@@ -62,12 +62,12 @@ func TestMatchAggregates(t *testing.T) {
 		t.Error("match aggregate should not match nil event")
 	}
 
-	e := NewEventForAggregate("test", nil, time.Now(), at, uuid.Nil, 0)
+	e := NewEvent("test", nil, time.Now(), ForAggregate(at, uuid.Nil, 0))
 	if !m.Match(e) {
 		t.Error("match aggregate should match the event")
 	}
 
-	e = NewEventForAggregate("test", nil, time.Now(), "other", uuid.Nil, 0)
+	e = NewEvent("test", nil, time.Now(), ForAggregate("other", uuid.Nil, 0))
 	if m.Match(e) {
 		t.Error("match aggregate should not match the event")
 	}
@@ -78,11 +78,11 @@ func TestMatchAggregates(t *testing.T) {
 	if m.Match(nil) {
 		t.Error("match any event of should not match nil event")
 	}
-	e1 := NewEventForAggregate("test", nil, time.Now(), at1, uuid.Nil, 0)
+	e1 := NewEvent("test", nil, time.Now(), ForAggregate(at1, uuid.Nil, 0))
 	if !m.Match(e1) {
 		t.Error("match any event of should match the first event")
 	}
-	e2 := NewEventForAggregate("test", nil, time.Now(), at2, uuid.Nil, 0)
+	e2 := NewEvent("test", nil, time.Now(), ForAggregate(at2, uuid.Nil, 0))
 	if !m.Match(e2) {
 		t.Error("match any event of should match the second event")
 	}
@@ -96,15 +96,15 @@ func TestMatchAny(t *testing.T) {
 		MatchAggregates{at},
 	}
 
-	e := NewEventForAggregate(et, nil, time.Now(), at, uuid.Nil, 0)
+	e := NewEvent(et, nil, time.Now(), ForAggregate(at, uuid.Nil, 0))
 	if !m.Match(e) {
 		t.Error("match any of should match the event")
 	}
-	e = NewEventForAggregate("not-matched", nil, time.Now(), at, uuid.Nil, 0)
+	e = NewEvent("not-matched", nil, time.Now(), ForAggregate(at, uuid.Nil, 0))
 	if !m.Match(e) {
 		t.Error("match any of should match the event")
 	}
-	e = NewEventForAggregate(et, nil, time.Now(), "not-matched", uuid.Nil, 0)
+	e = NewEvent(et, nil, time.Now(), ForAggregate("not-matched", uuid.Nil, 0))
 	if !m.Match(e) {
 		t.Error("match any of should match the event")
 	}
@@ -118,15 +118,15 @@ func TestMatchAll(t *testing.T) {
 		MatchAggregates{at},
 	}
 
-	e := NewEventForAggregate(et, nil, time.Now(), at, uuid.Nil, 0)
+	e := NewEvent(et, nil, time.Now(), ForAggregate(at, uuid.Nil, 0))
 	if !m.Match(e) {
 		t.Error("match any of should match the event")
 	}
-	e = NewEventForAggregate("not-matched", nil, time.Now(), at, uuid.Nil, 0)
+	e = NewEvent("not-matched", nil, time.Now(), ForAggregate(at, uuid.Nil, 0))
 	if m.Match(e) {
 		t.Error("match any of should not match the event")
 	}
-	e = NewEventForAggregate(et, nil, time.Now(), "not-matched", uuid.Nil, 0)
+	e = NewEvent(et, nil, time.Now(), ForAggregate("not-matched", uuid.Nil, 0))
 	if m.Match(e) {
 		t.Error("match any of should not match the event")
 	}

--- a/middleware/eventhandler/async/middleware_test.go
+++ b/middleware/eventhandler/async/middleware_test.go
@@ -30,8 +30,8 @@ func TestEventHandler(t *testing.T) {
 	id := uuid.New()
 	eventData := &mocks.EventData{Content: "event1"}
 	timestamp := time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)
-	event := eh.NewEventForAggregate(mocks.EventType, eventData, timestamp,
-		mocks.AggregateType, id, 1)
+	event := eh.NewEvent(mocks.EventType, eventData, timestamp,
+		eh.ForAggregate(mocks.AggregateType, id, 1))
 
 	inner := mocks.NewEventHandler("test")
 	m, errCh := NewMiddleware()

--- a/middleware/eventhandler/observer/middleware_test.go
+++ b/middleware/eventhandler/observer/middleware_test.go
@@ -29,8 +29,8 @@ func TestEventHandler(t *testing.T) {
 	id := uuid.New()
 	eventData := &mocks.EventData{Content: "event1"}
 	timestamp := time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)
-	event := eh.NewEventForAggregate(mocks.EventType, eventData, timestamp,
-		mocks.AggregateType, id, 1)
+	event := eh.NewEvent(mocks.EventType, eventData, timestamp,
+		eh.ForAggregate(mocks.AggregateType, id, 1))
 
 	inner := mocks.NewEventHandler("test")
 

--- a/middleware/eventhandler/scheduler/middleware_test.go
+++ b/middleware/eventhandler/scheduler/middleware_test.go
@@ -37,8 +37,8 @@ func TestCommandHandler(t *testing.T) {
 	eh.UseEventHandlerMiddleware(inner2, m)
 
 	timestamp := time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)
-	expectedEvent := eh.NewEventForAggregate(mocks.EventType, nil, timestamp,
-		mocks.AggregateType, uuid.New(), 1)
+	expectedEvent := eh.NewEvent(mocks.EventType, nil, timestamp,
+		eh.ForAggregate(mocks.AggregateType, uuid.New(), 1))
 
 	// Non-scheduled handling.
 	if err := h.HandleEvent(context.Background(), expectedEvent); err != nil {

--- a/mocks/testutils.go
+++ b/mocks/testutils.go
@@ -35,6 +35,9 @@ func CompareEvents(e1, e2 eh.Event) error {
 	if !reflect.DeepEqual(e1.Data(), e2.Data()) {
 		return fmt.Errorf("incorrect event data: %s (should be %s)", e1.Data(), e2.Data())
 	}
+	if !reflect.DeepEqual(e1.Metadata(), e2.Metadata()) {
+		return fmt.Errorf("incorrect event metadata: %s (should be %s)", e1.Metadata(), e2.Metadata())
+	}
 	return nil
 }
 
@@ -62,6 +65,9 @@ func EqualEvents(evts1, evts2 []eh.Event) bool {
 			return false
 		}
 		if e1.Version() != e2.Version() {
+			return false
+		}
+		if !reflect.DeepEqual(e1.Metadata(), e2.Metadata()) {
 			return false
 		}
 	}


### PR DESCRIPTION
### Description

Adds metadata to events. Useful for app-specific metadata such as request ID, issuing user etc.

### Affected Components

- Event interface
- Event Store
- Event Bus

### Related Issues

Closes #117

### Solution and Design

Adds metadata with a new option construct for the `NewEvent()` functions, in this case the option is `WithMetadata()`. Also deprecates `NewEventForAggregate()` in favour of the `ForAggregate()` option.

### Steps to test and verify
