### PR TITLE
280 / AggregateError for errors when handling commands in aggregates

### DIFF
--- a/aggregate.go
+++ b/aggregate.go
@@ -64,6 +64,27 @@ var ErrAggregateNotFound = errors.New("aggregate not found")
 // ErrAggregateNotRegistered is when no aggregate factory was registered.
 var ErrAggregateNotRegistered = errors.New("aggregate not registered")
 
+// AggregateError is an error caused in the aggregate when handling a command.
+type AggregateError struct {
+	// Err is the error.
+	Err error
+}
+
+// Error implements the Error method of the errors.Error interface.
+func (e AggregateError) Error() string {
+	return "aggregate error: " + e.Err.Error()
+}
+
+// Unwrap implements the errors.Unwrap method.
+func (e AggregateError) Unwrap() error {
+	return e.Err
+}
+
+// Cause implements the github.com/pkg/errors Unwrap method.
+func (e AggregateError) Cause() error {
+	return e.Unwrap()
+}
+
 // RegisterAggregate registers an aggregate factory for a type. The factory is
 // used to create concrete aggregate types when loading from the database.
 //

--- a/aggregate_test.go
+++ b/aggregate_test.go
@@ -16,6 +16,7 @@ package eventhorizon
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/google/uuid"
@@ -24,7 +25,7 @@ import (
 func TestCreateAggregate(t *testing.T) {
 	id := uuid.New()
 	aggregate, err := CreateAggregate(TestAggregateRegisterType, id)
-	if err != ErrAggregateNotRegistered {
+	if !errors.Is(err, ErrAggregateNotRegistered) {
 		t.Error("there should be a aggregate not registered error:", err)
 	}
 

--- a/aggregatestore/events/aggregatestore.go
+++ b/aggregatestore/events/aggregatestore.go
@@ -45,20 +45,25 @@ var ErrMismatchedEventType = errors.New("mismatched event type and aggregate typ
 // ApplyEventError is when an event could not be applied. It contains the error
 // and the event that caused it.
 type ApplyEventError struct {
-	// Event is the event that caused the error.
-	Event eh.Event
 	// Err is the error that happened when applying the event.
 	Err error
+	// Event is the event being applied when the error happened.
+	Event eh.Event
 }
 
 // Error implements the Error method of the error interface.
-func (a ApplyEventError) Error() string {
-	return "failed to apply event " + a.Event.String() + ": " + a.Err.Error()
+func (e ApplyEventError) Error() string {
+	return "failed to apply event " + e.Event.String() + ": " + e.Err.Error()
 }
 
-// Cause returns the cause of this error.
-func (a ApplyEventError) Cause() error {
-	return a.Err
+// Unwrap implements the errors.Unwrap method.
+func (e ApplyEventError) Unwrap() error {
+	return e.Err
+}
+
+// Cause implements the github.com/pkg/errors Unwrap method.
+func (e ApplyEventError) Cause() error {
+	return e.Unwrap()
 }
 
 // NewAggregateStore creates a aggregate store with an event store and an event

--- a/aggregatestore/events/aggregatestore_test.go
+++ b/aggregatestore/events/aggregatestore_test.go
@@ -35,7 +35,7 @@ func TestNewAggregateStore(t *testing.T) {
 	}
 
 	store, err := NewAggregateStore(nil, bus)
-	if err != ErrInvalidEventStore {
+	if !errors.Is(err, ErrInvalidEventStore) {
 		t.Error("there should be a ErrInvalidEventStore error:", err)
 	}
 	if store != nil {
@@ -43,7 +43,7 @@ func TestNewAggregateStore(t *testing.T) {
 	}
 
 	store, err = NewAggregateStore(eventStore, nil)
-	if err != ErrInvalidEventBus {
+	if !errors.Is(err, ErrInvalidEventBus) {
 		t.Error("there should be a ErrInvalidEventBus error:", err)
 	}
 	if store != nil {
@@ -114,10 +114,11 @@ func TestAggregateStore_LoadEvents(t *testing.T) {
 	}
 
 	// Store error.
-	eventStore.Err = errors.New("error")
+	storeErr := errors.New("error")
+	eventStore.Err = storeErr
 	_, err = store.Load(ctx, TestAggregateType, id)
-	if err == nil || err.Error() != "error" {
-		t.Error("there should be an error named 'error':", err)
+	if !errors.Is(err, storeErr) {
+		t.Error("the error should be correct:", err)
 	}
 	eventStore.Err = nil
 }
@@ -143,7 +144,7 @@ func TestAggregateStore_LoadEvents_MismatchedEventType(t *testing.T) {
 	}
 
 	loaded, err := store.Load(ctx, TestAggregateType, otherAggregateID)
-	if err != ErrMismatchedEventType {
+	if !errors.Is(err, ErrMismatchedEventType) {
 		t.Fatal("there should be a ErrMismatchedEventType error:", err)
 	}
 	if loaded != nil {
@@ -193,10 +194,11 @@ func TestAggregateStore_SaveEvents(t *testing.T) {
 
 	// Store error.
 	event1 = agg.AppendEvent(mocks.EventType, &mocks.EventData{Content: "event"}, timestamp)
-	eventStore.Err = errors.New("aggregate error")
+	aggregateErr := errors.New("aggregate error")
+	eventStore.Err = aggregateErr
 	err = store.Save(ctx, agg)
-	if err == nil || err.Error() != "aggregate error" {
-		t.Error("there should be an error named 'error':", err)
+	if !errors.Is(err, aggregateErr) {
+		t.Error("the error should be correct:", err)
 	}
 	eventStore.Err = nil
 
@@ -211,10 +213,11 @@ func TestAggregateStore_SaveEvents(t *testing.T) {
 
 	// Bus error.
 	event1 = agg.AppendEvent(mocks.EventType, &mocks.EventData{Content: "event"}, timestamp)
-	bus.Err = errors.New("bus error")
+	busErr := errors.New("bus error")
+	bus.Err = busErr
 	err = store.Save(ctx, agg)
-	if err == nil || err.Error() != "bus error" {
-		t.Error("there should be an error named 'error':", err)
+	if !errors.Is(err, busErr) {
+		t.Error("the error should be correct:", err)
 	}
 }
 
@@ -225,7 +228,7 @@ func TestAggregateStore_AggregateNotRegistered(t *testing.T) {
 
 	id := uuid.New()
 	agg, err := store.Load(ctx, "TestAggregate3", id)
-	if err != eh.ErrAggregateNotRegistered {
+	if !errors.Is(err, eh.ErrAggregateNotRegistered) {
 		t.Error("there should be a eventhorizon.ErrAggregateNotRegistered error:", err)
 	}
 	if agg != nil {

--- a/aggregatestore/model/aggregatestore_test.go
+++ b/aggregatestore/model/aggregatestore_test.go
@@ -33,7 +33,7 @@ func TestNewAggregateStore(t *testing.T) {
 	}
 
 	store, err := NewAggregateStore(nil, nil)
-	if err != ErrInvalidRepo {
+	if !errors.Is(err, ErrInvalidRepo) {
 		t.Error("there should be a ErrInvalidRepo error:", err)
 	}
 	if store != nil {
@@ -82,10 +82,11 @@ func TestAggregateStore_Load(t *testing.T) {
 	}
 
 	// Store error.
-	repo.LoadErr = errors.New("error")
+	storeErr := errors.New("error")
+	repo.LoadErr = storeErr
 	_, err = store.Load(ctx, AggregateType, id)
-	if err == nil || err.Error() != "error" {
-		t.Error("there should be an error named 'error':", err)
+	if !errors.Is(err, storeErr) {
+		t.Error("the error should be correct:", err)
 	}
 	repo.LoadErr = nil
 }
@@ -104,7 +105,7 @@ func TestAggregateStore_Load_InvalidAggregate(t *testing.T) {
 	}
 
 	loadedAgg, err := store.Load(ctx, AggregateType, id)
-	if err != ErrInvalidAggregate {
+	if !errors.Is(err, ErrInvalidAggregate) {
 		t.Fatal("there should be a ErrInvalidAggregate error:", err)
 	}
 	if loadedAgg != nil {
@@ -128,10 +129,11 @@ func TestAggregateStore_Save(t *testing.T) {
 	}
 
 	// Store error.
-	repo.SaveErr = errors.New("aggregate error")
+	aggregateErr := errors.New("aggregate error")
+	repo.SaveErr = aggregateErr
 	err = store.Save(ctx, agg)
-	if err == nil || err.Error() != "aggregate error" {
-		t.Error("there should be an error named 'error':", err)
+	if !errors.Is(err, aggregateErr) {
+		t.Error("the error should be correct:", err)
 	}
 	repo.SaveErr = nil
 }
@@ -164,11 +166,12 @@ func TestAggregateStore_SaveWithPublish(t *testing.T) {
 	}
 
 	// Simulate a bus error.
-	bus.Err = errors.New("bus error")
+	busErr := errors.New("bus error")
+	bus.Err = busErr
 	agg.AppendEvent(event)
 	err = store.Save(ctx, agg)
-	if err == nil || err.Error() != "bus error" {
-		t.Error("there should be an error named 'error':", err)
+	if !errors.Is(err, busErr) {
+		t.Error("the error should be correct:", err)
 	}
 	if len(agg.SliceEventSource) != 0 {
 		t.Error("there should be no events to publish")

--- a/command_test.go
+++ b/command_test.go
@@ -15,6 +15,7 @@
 package eventhorizon
 
 import (
+	"errors"
 	"testing"
 	"time"
 
@@ -23,7 +24,7 @@ import (
 
 func TestCreateCommand(t *testing.T) {
 	cmd, err := CreateCommand(TestCommandRegisterType)
-	if err != ErrCommandNotRegistered {
+	if !errors.Is(err, ErrCommandNotRegistered) {
 		t.Error("there should be a command not registered error:", err)
 	}
 

--- a/commandhandler/aggregate/commandhandler.go
+++ b/commandhandler/aggregate/commandhandler.go
@@ -67,7 +67,7 @@ func (h *CommandHandler) HandleCommand(ctx context.Context, cmd eh.Command) erro
 	}
 
 	if err = a.HandleCommand(ctx, cmd); err != nil {
-		return err
+		return eh.AggregateError{Err: err}
 	}
 
 	return h.store.Save(ctx, a)

--- a/commandhandler/aggregate/commandhandler_test.go
+++ b/commandhandler/aggregate/commandhandler_test.go
@@ -38,7 +38,7 @@ func TestNewCommandHandler(t *testing.T) {
 	}
 
 	h, err = NewCommandHandler(mocks.AggregateType, nil)
-	if err != ErrNilAggregateStore {
+	if !errors.Is(err, ErrNilAggregateStore) {
 		t.Error("there should be a ErrNilAggregateStore error:", err)
 	}
 	if h != nil {
@@ -84,7 +84,7 @@ func TestCommandHandler_AggregateNotFound(t *testing.T) {
 		Content: "command1",
 	}
 	err = h.HandleCommand(context.Background(), cmd)
-	if err != eh.ErrAggregateNotFound {
+	if !errors.Is(err, eh.ErrAggregateNotFound) {
 		t.Error("there should be a command error:", err)
 	}
 }
@@ -111,13 +111,14 @@ func TestCommandHandler_ErrorInHandler(t *testing.T) {
 func TestCommandHandler_ErrorWhenSaving(t *testing.T) {
 	a, h, store := createAggregateAndHandler(t)
 
-	store.Err = errors.New("save error")
+	saveErr := errors.New("save error")
+	store.Err = saveErr
 	cmd := &mocks.Command{
 		ID:      a.EntityID(),
 		Content: "command1",
 	}
 	err := h.HandleCommand(context.Background(), cmd)
-	if err == nil || err.Error() != "save error" {
+	if !errors.Is(err, saveErr) {
 		t.Error("there should be a command error:", err)
 	}
 }
@@ -130,7 +131,7 @@ func TestCommandHandler_NoHandlers(t *testing.T) {
 		Content: "command1",
 	}
 	err := h.HandleCommand(context.Background(), cmd)
-	if err != eh.ErrAggregateNotFound {
+	if !errors.Is(err, eh.ErrAggregateNotFound) {
 		t.Error("there should be a ErrAggregateNotFound error:", nil)
 	}
 }

--- a/commandhandler/aggregate/commandhandler_test.go
+++ b/commandhandler/aggregate/commandhandler_test.go
@@ -92,13 +92,15 @@ func TestCommandHandler_AggregateNotFound(t *testing.T) {
 func TestCommandHandler_ErrorInHandler(t *testing.T) {
 	a, h, _ := createAggregateAndHandler(t)
 
-	a.Err = errors.New("command error")
+	commandErr := errors.New("command error")
+	a.Err = commandErr
 	cmd := &mocks.Command{
 		ID:      a.EntityID(),
 		Content: "command1",
 	}
 	err := h.HandleCommand(context.Background(), cmd)
-	if err == nil || err.Error() != "command error" {
+	var aggregateErr eh.AggregateError
+	if !errors.As(err, &aggregateErr) || !errors.Is(err, commandErr) {
 		t.Error("there should be a command error:", err)
 	}
 	if !reflect.DeepEqual(a.Commands, []eh.Command{}) {

--- a/commandhandler/bus/commandhandler_test.go
+++ b/commandhandler/bus/commandhandler_test.go
@@ -16,6 +16,7 @@ package bus
 
 import (
 	"context"
+	"errors"
 	"reflect"
 	"testing"
 
@@ -35,7 +36,7 @@ func TestCommandHandler(t *testing.T) {
 	t.Log("handle with no handler")
 	cmd := &mocks.Command{ID: uuid.New(), Content: "command1"}
 	err := bus.HandleCommand(ctx, cmd)
-	if err != ErrHandlerNotFound {
+	if !errors.Is(err, ErrHandlerNotFound) {
 		t.Error("there should be a ErrHandlerNotFound error:", err)
 	}
 
@@ -59,7 +60,7 @@ func TestCommandHandler(t *testing.T) {
 	}
 
 	err = bus.SetHandler(handler, mocks.CommandType)
-	if err != ErrHandlerAlreadySet {
+	if !errors.Is(err, ErrHandlerAlreadySet) {
 		t.Error("there should be a ErrHandlerAlreadySet error:", err)
 	}
 }

--- a/event_test.go
+++ b/event_test.go
@@ -15,6 +15,7 @@
 package eventhorizon
 
 import (
+	"errors"
 	"reflect"
 	"testing"
 	"time"
@@ -85,7 +86,7 @@ func TestNewEvent(t *testing.T) {
 
 func TestCreateEventData(t *testing.T) {
 	data, err := CreateEventData(TestEventRegisterType)
-	if err != ErrEventDataNotRegistered {
+	if !errors.Is(err, ErrEventDataNotRegistered) {
 		t.Error("there should be a event not registered error:", err)
 	}
 

--- a/eventbus.go
+++ b/eventbus.go
@@ -41,8 +41,11 @@ type EventBus interface {
 // EventBusError is an async error containing the error returned from a handler
 // and the event that it happened on.
 type EventBusError struct {
-	Err   error
-	Ctx   context.Context
+	// Err is the error.
+	Err error
+	// Ctx is the context used when the error happened.
+	Ctx context.Context
+	// Event is the event handeled when the error happened.
 	Event Event
 }
 
@@ -51,16 +54,21 @@ func (e EventBusError) Error() string {
 	return fmt.Sprintf("%s: (%s)", e.Err, e.Event)
 }
 
-// Cause returns the cause of this error.
-func (e EventBusError) Cause() error {
+// Unwrap implements the errors.Unwrap method.
+func (e EventBusError) Unwrap() error {
 	return e.Err
 }
 
-// ErrMissingMatcher is returned when adding a handler without a matcher.
+// Cause implements the github.com/pkg/errors Unwrap method.
+func (e EventBusError) Cause() error {
+	return e.Unwrap()
+}
+
+// ErrMissingMatcher is returned when calling AddHandler without a matcher.
 var ErrMissingMatcher = errors.New("missing matcher")
 
-// ErrMissingHandler is returned when adding a handler with a nil handler.
+// ErrMissingHandler is returned when calling AddHandler with a nil handler.
 var ErrMissingHandler = errors.New("missing handler")
 
-// ErrHandlerAlreadyAdded is returned when adding the same handler twice.
+// ErrHandlerAlreadyAdded is returned when calling AddHandler weth the same handler twice.
 var ErrHandlerAlreadyAdded = errors.New("handler already added")

--- a/eventhandler/projector/eventhandler.go
+++ b/eventhandler/projector/eventhandler.go
@@ -48,7 +48,7 @@ type Type string
 
 // Error is an error in the projector, with the namespace.
 type Error struct {
-	// Err is the error.
+	// Err is the error that happened when projecting the event.
 	Err error
 	// EventVersion is the version of the event.
 	EventVersion int
@@ -68,6 +68,16 @@ func (e Error) Error() string {
 	}
 	return fmt.Sprintf("projector: %s, event: v%d, entity: v%d (%s)",
 		errStr, e.EventVersion, e.EntityVersion, e.Namespace)
+}
+
+// Unwrap implements the errors.Unwrap method.
+func (e Error) Unwrap() error {
+	return e.Err
+}
+
+// Cause implements the github.com/pkg/errors Unwrap method.
+func (e Error) Cause() error {
+	return e.Unwrap()
 }
 
 // ErrModelNotSet is when a model factory is not set on the EventHandler.

--- a/eventhandler/waiter/eventhandler_test.go
+++ b/eventhandler/waiter/eventhandler_test.go
@@ -16,6 +16,7 @@ package waiter
 
 import (
 	"context"
+	"errors"
 	"reflect"
 	"testing"
 
@@ -67,7 +68,8 @@ func TestEventHandler(t *testing.T) {
 	ctx, cancel = context.WithTimeout(context.Background(), 10*time.Millisecond)
 	defer cancel()
 	event, err = l.Wait(ctx)
-	if err == nil || err.Error() != "context deadline exceeded" {
+	deadlineExceededErr := context.DeadlineExceeded
+	if !errors.Is(err, deadlineExceededErr) {
 		t.Error("there should be a context deadline exceeded error")
 	}
 	if event != nil {

--- a/eventstore.go
+++ b/eventstore.go
@@ -62,9 +62,14 @@ func (e EventStoreError) Error() string {
 	return errStr + " (" + e.Namespace + ")"
 }
 
-// Cause returns the cause of this error.
-func (e EventStoreError) Cause() error {
+// Unwrap implements the errors.Unwrap method.
+func (e EventStoreError) Unwrap() error {
 	return e.Err
+}
+
+// Cause implements the github.com/pkg/errors Unwrap method.
+func (e EventStoreError) Cause() error {
+	return e.Unwrap()
 }
 
 // ErrNoEventsToAppend is when no events are available to append.

--- a/examples/todomvc/backend/handler/handler_test.go
+++ b/examples/todomvc/backend/handler/handler_test.go
@@ -16,6 +16,7 @@ package handler
 
 import (
 	"context"
+	"errors"
 	"log"
 	"net/http"
 	"net/http/httptest"
@@ -226,7 +227,8 @@ func TestDelete(t *testing.T) {
 	cancelTimeout()
 
 	_, err = todoRepo.Find(ctx, id)
-	if rrErr, ok := err.(eh.RepoError); !ok || rrErr.Err != eh.ErrEntityNotFound {
+	var repoErr eh.RepoError
+	if !errors.As(err, &repoErr) || !errors.Is(err, eh.ErrEntityNotFound) {
 		t.Error("there should be a not found error:", err)
 	}
 

--- a/middleware/commandhandler/async/middleware.go
+++ b/middleware/commandhandler/async/middleware.go
@@ -40,12 +40,25 @@ func NewMiddleware() (eh.CommandHandlerMiddleware, chan Error) {
 
 // Error is an error containing the error and the command.
 type Error struct {
-	Err     error
-	Ctx     context.Context
+	// Err is the error that happened when handling the command.
+	Err error
+	// Ctx is the context used when the error happened.
+	Ctx context.Context
+	// Command is the command handeled when the error happened.
 	Command eh.Command
 }
 
 // Error implements the Error method of the error interface.
 func (e Error) Error() string {
 	return fmt.Sprintf("%s (%s): %s", e.Command.CommandType(), e.Command.AggregateID(), e.Err.Error())
+}
+
+// Unwrap implements the errors.Unwrap method.
+func (e Error) Unwrap() error {
+	return e.Err
+}
+
+// Cause implements the github.com/pkg/errors Unwrap method.
+func (e Error) Cause() error {
+	return e.Unwrap()
 }

--- a/middleware/commandhandler/async/middleware_test.go
+++ b/middleware/commandhandler/async/middleware_test.go
@@ -61,7 +61,7 @@ func TestCommandHandler(t *testing.T) {
 	}
 	select {
 	case err := <-errCh:
-		if err.Err != handlingErr {
+		if !errors.Is(err, handlingErr) {
 			t.Error("the error should be correct:", err.Err)
 		}
 		if err.Ctx != ctx {

--- a/middleware/commandhandler/scheduler/middleware.go
+++ b/middleware/commandhandler/scheduler/middleware.go
@@ -82,12 +82,25 @@ func (c *command) ExecuteAt() time.Time {
 
 // Error is an async error containing the error and the command.
 type Error struct {
-	Err     error
-	Ctx     context.Context
+	// Err is the error that happened when handling the command.
+	Err error
+	// Ctx is the context used when the error happened.
+	Ctx context.Context
+	// Command is the command handeled when the error happened.
 	Command eh.Command
 }
 
 // Error implements the Error method of the error interface.
 func (e Error) Error() string {
 	return fmt.Sprintf("%s (%s): %s", e.Command.CommandType(), e.Command.AggregateID(), e.Err.Error())
+}
+
+// Unwrap implements the errors.Unwrap method.
+func (e Error) Unwrap() error {
+	return e.Err
+}
+
+// Cause implements the github.com/pkg/errors Unwrap method.
+func (e Error) Cause() error {
+	return e.Unwrap()
 }

--- a/middleware/commandhandler/scheduler/middleware_test.go
+++ b/middleware/commandhandler/scheduler/middleware_test.go
@@ -138,7 +138,8 @@ func TestCommandHandler_ContextCanceled(t *testing.T) {
 	case err = <-errCh:
 	case <-time.After(10 * time.Millisecond):
 	}
-	if err.Err == nil || err.Err.Error() != "context canceled" {
+	canceledErr := context.Canceled
+	if !errors.Is(err, canceledErr) {
 		t.Error("there should be an error:", err)
 	}
 }
@@ -168,7 +169,8 @@ func TestCommandHandler_ContextDeadline(t *testing.T) {
 	case err = <-errCh:
 	case <-time.After(10 * time.Millisecond):
 	}
-	if err.Err == nil || err.Err.Error() != "context deadline exceeded" {
+	deadlineExceededErr := context.DeadlineExceeded
+	if !errors.Is(err, deadlineExceededErr) {
 		t.Error("there should be an error:", err)
 	}
 }

--- a/middleware/eventhandler/async/middleware.go
+++ b/middleware/eventhandler/async/middleware.go
@@ -48,8 +48,11 @@ func (h *eventHandler) HandleEvent(ctx context.Context, event eh.Event) error {
 
 // Error is an async error containing the error and the event.
 type Error struct {
-	Err   error
-	Ctx   context.Context
+	// Err is the error that happened when handling the event.
+	Err error
+	// Ctx is the context used when the error happened.
+	Ctx context.Context
+	// Event is the event handeled when the error happened.
 	Event eh.Event
 }
 

--- a/middleware/eventhandler/scheduler/middleware_test.go
+++ b/middleware/eventhandler/scheduler/middleware_test.go
@@ -16,6 +16,7 @@ package scheduler
 
 import (
 	"context"
+	"errors"
 	"reflect"
 	"testing"
 	"time"
@@ -92,7 +93,7 @@ func TestCommandHandler(t *testing.T) {
 	cancelScheduler()
 	if err := scheduler.ScheduleEvent(context.Background(), "* * * * * * *", func(t time.Time) eh.Event {
 		return nil
-	}); err != context.Canceled {
+	}); !errors.Is(err, context.Canceled) {
 		t.Error("there should be a context canceled error:", err)
 	}
 }

--- a/repo.go
+++ b/repo.go
@@ -86,9 +86,14 @@ func (e RepoError) Error() string {
 	return errStr + " (" + e.Namespace + ")"
 }
 
-// Cause returns the cause of this error.
-func (e RepoError) Cause() error {
+// Unwrap implements the errors.Unwrap method.
+func (e RepoError) Unwrap() error {
 	return e.Err
+}
+
+// Cause implements the github.com/pkg/errors Unwrap method.
+func (e RepoError) Cause() error {
+	return e.Unwrap()
 }
 
 // ErrEntityNotFound is when a entity could not be found.

--- a/repo/mongodb/repo_test.go
+++ b/repo/mongodb/repo_test.go
@@ -16,6 +16,7 @@ package mongodb
 
 import (
 	"context"
+	"errors"
 	"os"
 	"reflect"
 	"testing"
@@ -100,7 +101,8 @@ func extraRepoTests(t *testing.T, ctx context.Context, r *Repo) {
 	result, err = r.FindCustom(ctx, func(ctx context.Context, c *mongo.Collection) (*mongo.Cursor, error) {
 		return nil, nil
 	})
-	if rrErr, ok := err.(eh.RepoError); !ok || rrErr.Err != ErrInvalidQuery {
+	var repoErr eh.RepoError
+	if !errors.As(err, &repoErr) || !errors.Is(err, ErrInvalidQuery) {
 		t.Error("there should be a invalid query error:", err)
 	}
 
@@ -114,7 +116,7 @@ func extraRepoTests(t *testing.T, ctx context.Context, r *Repo) {
 		// Be sure to return nil to not execute the query again in FindCustom.
 		return nil, nil
 	})
-	if rrErr, ok := err.(eh.RepoError); !ok || rrErr.Err != ErrInvalidQuery {
+	if !errors.As(err, &repoErr) || !errors.Is(err, ErrInvalidQuery) {
 		t.Error("there should be a invalid query error:", err)
 	}
 	if count != 2 {

--- a/repo/version/repo_test.go
+++ b/repo/version/repo_test.go
@@ -16,6 +16,7 @@ package version
 
 import (
 	"context"
+	"errors"
 	"reflect"
 	"testing"
 	"time"
@@ -70,7 +71,8 @@ func extraRepoTests(t *testing.T, ctx context.Context, r *Repo, baseRepo *memory
 	// Find with min version without version.
 	ctxVersion := NewContextWithMinVersion(ctx, 1)
 	model, err := r.Find(ctxVersion, simpleModel.ID)
-	if rrErr, ok := err.(eh.RepoError); !ok || rrErr.Err != eh.ErrEntityHasNoVersion {
+	var repoErr eh.RepoError
+	if !errors.As(err, &repoErr) || !errors.Is(err, eh.ErrEntityHasNoVersion) {
 		t.Error("there should be a model has no version error:", err)
 	}
 
@@ -92,7 +94,7 @@ func extraRepoTests(t *testing.T, ctx context.Context, r *Repo, baseRepo *memory
 	// Find with min version, too low.
 	ctxVersion = NewContextWithMinVersion(ctx, 2)
 	model, err = r.Find(ctxVersion, m1.ID)
-	if rrErr, ok := err.(eh.RepoError); !ok || rrErr.Err != eh.ErrIncorrectEntityVersion {
+	if !errors.As(err, &repoErr) || !errors.Is(err, eh.ErrIncorrectEntityVersion) {
 		t.Error("there should be a incorrect model version error:", err)
 	}
 
@@ -223,7 +225,7 @@ func extraRepoTests(t *testing.T, ctx context.Context, r *Repo, baseRepo *memory
 	ctxVersion, cancel = context.WithTimeout(ctxVersion, 10*time.Millisecond)
 	defer cancel()
 	model, err = r.Find(ctxVersion, m3.ID)
-	if err != context.DeadlineExceeded {
+	if !errors.Is(err, context.DeadlineExceeded) {
 		t.Error("there should be a deadline exceeded error:", err)
 	}
 


### PR DESCRIPTION
### Description

Adds an AggregateError for errors that happens when handling commands in aggregates.

### Affected Components

- Aggregate command handler

### Related Issues

Closes #280

### Solution and Design

Also adds Unwrap() methods to all errors that wraps errors.

### Steps to test and verify
