### PR TITLE
281 / Saga command handling

### DIFF
--- a/eventhandler/projector/eventhandler_test.go
+++ b/eventhandler/projector/eventhandler_test.go
@@ -131,7 +131,7 @@ func TestEventHandler_UpdateModelWithVersion(t *testing.T) {
 		Content: "version 1",
 	}
 	if err := handler.HandleEvent(ctx, event); err != nil {
-		t.Error("there shoud be no error:", err)
+		t.Error("there should be no error:", err)
 	}
 	if projector.event != event {
 		t.Error("the handled event should be correct:", projector.event)
@@ -256,10 +256,12 @@ func TestEventHandler_LoadError(t *testing.T) {
 	repo.LoadErr = loadErr
 	expectedErr := Error{
 		Err:          loadErr,
-		EventVersion: 1,
+		Projector:    TestProjectorType.String(),
 		Namespace:    eh.NamespaceFromContext(ctx),
+		EventVersion: 1,
 	}
-	if err := handler.HandleEvent(ctx, event); !reflect.DeepEqual(err, expectedErr) {
+	err := handler.HandleEvent(ctx, event)
+	if !errors.Is(err, expectedErr) {
 		t.Error("there shoud be an error:", err)
 	}
 }
@@ -284,10 +286,12 @@ func TestEventHandler_SaveError(t *testing.T) {
 	repo.SaveErr = saveErr
 	expectedErr := Error{
 		Err:          saveErr,
-		EventVersion: 1,
+		Projector:    TestProjectorType.String(),
 		Namespace:    eh.NamespaceFromContext(ctx),
+		EventVersion: 1,
 	}
-	if err := handler.HandleEvent(ctx, event); !reflect.DeepEqual(err, expectedErr) {
+	err := handler.HandleEvent(ctx, event)
+	if !errors.Is(err, expectedErr) {
 		t.Error("there shoud be an error:", err)
 	}
 }
@@ -312,10 +316,12 @@ func TestEventHandler_ProjectError(t *testing.T) {
 	projector.err = projectErr
 	expectedErr := Error{
 		Err:          projectErr,
-		EventVersion: 1,
+		Projector:    TestProjectorType.String(),
 		Namespace:    eh.NamespaceFromContext(ctx),
+		EventVersion: 1,
 	}
-	if err := handler.HandleEvent(ctx, event); !reflect.DeepEqual(err, expectedErr) {
+	err := handler.HandleEvent(ctx, event)
+	if !errors.Is(err, expectedErr) {
 		t.Error("there shoud be an error:", err)
 	}
 }

--- a/eventhandler/saga/eventhandler_test.go
+++ b/eventhandler/saga/eventhandler_test.go
@@ -63,8 +63,11 @@ func (m *TestSaga) SagaType() Type {
 	return TestSagaType
 }
 
-func (m *TestSaga) RunSaga(ctx context.Context, event eh.Event) []eh.Command {
+func (m *TestSaga) RunSaga(ctx context.Context, event eh.Event, h eh.CommandHandler) error {
 	m.event = event
 	m.context = ctx
-	return m.commands
+	for _, cmd := range m.commands {
+		return h.HandleCommand(ctx, cmd)
+	}
+	return nil
 }


### PR DESCRIPTION
### Description

Previously all commands from a saga were returned and run in one batch. This could be undesirable both for performance, error handling and correctness reasons.

### Affected Components

- Saga event handler

### Related Issues

Closes #281

### Solution and Design

Let sagas execute commands directly on a provided command bus to be able to react to errors when handling commands.

### Steps to test and verify
