### PR TITLE
Edit link for PR Template in contributing doc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,7 @@ If you find a bug report it by creating a new Github issue.
 
 ### Pull Requests
 
-* Fill in [the required template](PULL_REQUEST_TEMPLATE.md)
+* Fill in [the required template](.github/PULL_REQUEST_TEMPLATE.md)
 * Follow the [Golang Styleguide](#golang-styleguide)
 * Document new code based on the [Documentation Styleguide](#documentation-styleguide)
 * End all files with a newline


### PR DESCRIPTION
Issue: 287

### Description
Minor update to contributing documentation to fix 

### Affected Components

- Contributing documentation

### Related Issues

Closes #287

### Solution and Design

Adding a `.github/` prefix to the markdown link as PULL_REQUEST_TEMPLATE.md file was moved into that folder

### Steps to test and verify

1. Open README on master
2. Click on 'contribution guidelines'
3. Click on 'required template'
4. Brought to expected template page