### PR TITLE
Fix / Use JSON encoding for the Memory repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,15 +12,26 @@ cache:
 
 jobs:
   include:
-    - stage: test
+    - name: "Test (unit)"
       if: type == pull_request
-      script: make run test
+      script: make test
       env:
         - GO111MODULE=on
 
-    - stage: test_and_cover
-      name: "Test (with coverage)"
+    - name: "Test (integration)"
+      if: type == pull_request
+      script: make run test_integration
+      env:
+        - GO111MODULE=on
+
+    - name: "Test (unit with coverage)"
       if: type != pull_request
-      script: make run cover publish_cover
+      script: make cover publish_cover
+      env:
+        - GO111MODULE=on
+
+    - name: "Test (integration)"
+      if: type != pull_request
+      script: make run test_integration
       env:
         - GO111MODULE=on

--- a/aggregatestore/model/aggregatestore.go
+++ b/aggregatestore/model/aggregatestore.go
@@ -53,7 +53,7 @@ func NewAggregateStore(repo eh.ReadWriteRepo, eventHandler eh.EventHandler) (*Ag
 // Load implements the Load method of the eventhorizon.AggregateStore interface.
 func (r *AggregateStore) Load(ctx context.Context, aggregateType eh.AggregateType, id uuid.UUID) (eh.Aggregate, error) {
 	item, err := r.repo.Find(ctx, id)
-	if rrErr, ok := err.(eh.RepoError); ok && rrErr.Err == eh.ErrEntityNotFound {
+	if errors.Is(err, eh.ErrEntityNotFound) {
 		// Create the aggregate.
 		if item, err = eh.CreateAggregate(aggregateType, id); err != nil {
 			return nil, err

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,9 +3,6 @@ version: "3.4"
 services:
   golang:
     image: golang:1.15
-    depends_on:
-      - mongo
-      - gpubsub
     environment:
       MONGO_HOST: "mongo:27017"
       PUBSUB_EMULATOR_HOST: "gpubsub:8793"
@@ -37,6 +34,8 @@ services:
 
   kafka:
     image: wurstmeister/kafka
+    depends_on:
+      - zookeeper
     ports:
       - "9092:9092"
     environment:

--- a/eventbus/gcp/eventbus_test.go
+++ b/eventbus/gcp/eventbus_test.go
@@ -24,7 +24,11 @@ import (
 	"github.com/looplab/eventhorizon/eventbus"
 )
 
-func TestEventBus(t *testing.T) {
+func TestEventBusIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
 	// Connect to localhost if not running inside docker
 	if os.Getenv("PUBSUB_EMULATOR_HOST") == "" {
 		os.Setenv("PUBSUB_EMULATOR_HOST", "localhost:8793")
@@ -50,7 +54,11 @@ func TestEventBus(t *testing.T) {
 	eventbus.AcceptanceTest(t, bus1, bus2, time.Second)
 }
 
-func TestEventBusLoad(t *testing.T) {
+func TestEventBusLoadtest(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
 	// Connect to localhost if not running inside docker
 	if os.Getenv("PUBSUB_EMULATOR_HOST") == "" {
 		os.Setenv("PUBSUB_EMULATOR_HOST", "localhost:8793")

--- a/eventbus/kafka/eventbus_test.go
+++ b/eventbus/kafka/eventbus_test.go
@@ -24,7 +24,11 @@ import (
 	"github.com/looplab/eventhorizon/eventbus"
 )
 
-func TestEventBus(t *testing.T) {
+func TestEventBusIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
 	// Connect to localhost if not running inside docker
 	broker := os.Getenv("KAFKA_BROKER_HOST")
 	if broker == "" {
@@ -55,7 +59,11 @@ func TestEventBus(t *testing.T) {
 	eventbus.AcceptanceTest(t, bus1, bus2, 10*time.Second)
 }
 
-func TestEventBusLoad(t *testing.T) {
+func TestEventBusLoadtest(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
 	// Connect to localhost if not running inside docker
 	broker := os.Getenv("KAFKA_BROKER_HOST")
 	if broker == "" {

--- a/eventbus/local/eventbus_test.go
+++ b/eventbus/local/eventbus_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/looplab/eventhorizon/eventbus"
 )
 
+// NOTE: Not named "Integration" to enable running with the unit tests.
 func TestEventBus(t *testing.T) {
 	group := NewGroup()
 	if group == nil {
@@ -40,7 +41,7 @@ func TestEventBus(t *testing.T) {
 	eventbus.AcceptanceTest(t, bus1, bus2, time.Second)
 }
 
-func TestEventBusLoad(t *testing.T) {
+func TestEventBusLoadtest(t *testing.T) {
 	bus := NewEventBus(nil)
 	if bus == nil {
 		t.Fatal("there should be a bus")

--- a/eventbus/tracing/eventbus_test.go
+++ b/eventbus/tracing/eventbus_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/looplab/eventhorizon/eventbus/local"
 )
 
+// NOTE: Not named "Integration" to enable running with the unit tests.
 func TestEventBus(t *testing.T) {
 	group := local.NewGroup()
 	if group == nil {
@@ -49,7 +50,7 @@ func TestEventBus(t *testing.T) {
 	eventbus.AcceptanceTest(t, bus1, bus2, time.Second)
 }
 
-func TestEventBusLoad(t *testing.T) {
+func TestEventBusLoadtest(t *testing.T) {
 	innerBus := local.NewEventBus(nil)
 	if innerBus == nil {
 		t.Fatal("there should be a bus")

--- a/eventstore/mongodb/eventstore_test.go
+++ b/eventstore/mongodb/eventstore_test.go
@@ -23,7 +23,11 @@ import (
 	"github.com/looplab/eventhorizon/eventstore"
 )
 
-func TestEventStore(t *testing.T) {
+func TestEventStoreIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
 	// Use MongoDB in Docker with fallback to localhost.
 	url := os.Getenv("MONGO_HOST")
 	if url == "" {

--- a/eventstore/recorder/eventstore_test.go
+++ b/eventstore/recorder/eventstore_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/looplab/eventhorizon/mocks"
 )
 
+// NOTE: Not named "Integration" to enable running with the unit tests.
 func TestEventStore(t *testing.T) {
 	baseStore := memory.NewEventStore()
 	store := NewEventStore(baseStore)

--- a/eventstore/tracing/eventstore_test.go
+++ b/eventstore/tracing/eventstore_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/looplab/eventhorizon/eventstore/memory"
 )
 
+// NOTE: Not named "Integration" to enable running with the unit tests.
 func TestEventStore(t *testing.T) {
 	innerStore := memory.NewEventStore()
 	if innerStore == nil {

--- a/examples/guestlist/domains/guestlist/projectors.go
+++ b/examples/guestlist/domains/guestlist/projectors.go
@@ -147,7 +147,7 @@ func (p *GuestListProjector) HandleEvent(ctx context.Context, event eh.Event) er
 	// Load or create the guest list.
 	var g *GuestList
 	m, err := p.repo.Find(ctx, p.eventID)
-	if rrErr, ok := err.(eh.RepoError); ok && rrErr.Err == eh.ErrEntityNotFound {
+	if errors.Is(err, eh.ErrEntityNotFound) {
 		g = &GuestList{
 			ID: p.eventID,
 		}

--- a/examples/guestlist/memory/memory_test.go
+++ b/examples/guestlist/memory/memory_test.go
@@ -30,6 +30,7 @@ import (
 	repo "github.com/looplab/eventhorizon/repo/memory"
 )
 
+// NOTE: Not named "Integration" to enable running with the unit tests.
 func Example() {
 	// Create the event store.
 	eventStore := eventstore.NewEventStore()

--- a/examples/guestlist/mongodb/mongodb_test.go
+++ b/examples/guestlist/mongodb/mongodb_test.go
@@ -20,6 +20,7 @@ import (
 	"log"
 	"os"
 	"sort"
+	"testing"
 	"time"
 
 	"github.com/google/uuid"
@@ -32,7 +33,11 @@ import (
 	"github.com/looplab/eventhorizon/repo/version"
 )
 
-func Example() {
+func ExampleIntegration() {
+	if testing.Short() {
+		os.Exit(0)
+	}
+
 	// Use MongoDB in Docker with fallback to localhost.
 	url := os.Getenv("MONGO_HOST")
 	if url == "" {

--- a/httputils/query.go
+++ b/httputils/query.go
@@ -16,6 +16,7 @@ package httputils
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"path"
 
@@ -53,7 +54,7 @@ func QueryHandler(repo eh.ReadRepo) http.Handler {
 			}
 
 			if data, err = repo.Find(r.Context(), id); err != nil {
-				if rrErr, ok := err.(eh.RepoError); ok && rrErr.Err == eh.ErrEntityNotFound {
+				if errors.Is(err, eh.ErrEntityNotFound) {
 					http.Error(w, "could not find item", http.StatusNotFound)
 					return
 				}

--- a/repo/cache/repo_test.go
+++ b/repo/cache/repo_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/looplab/eventhorizon/repo/memory"
 )
 
+// NOTE: Not named "Integration" to enable running with the unit tests.
 func TestReadRepo(t *testing.T) {
 	baseRepo := memory.NewRepo()
 	baseRepo.SetEntityFactory(func() eh.Entity {

--- a/repo/memory/repo_test.go
+++ b/repo/memory/repo_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/looplab/eventhorizon/repo"
 )
 
+// NOTE: Not named "Integration" to enable running with the unit tests.
 func TestReadRepo(t *testing.T) {
 	r := NewRepo()
 	if r == nil {

--- a/repo/mongodb/repo_test.go
+++ b/repo/mongodb/repo_test.go
@@ -31,7 +31,11 @@ import (
 	"github.com/looplab/eventhorizon/repo"
 )
 
-func TestReadRepo(t *testing.T) {
+func TestReadRepoIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
 	// Local Mongo testing with Docker
 	url := os.Getenv("MONGO_HOST")
 

--- a/repo/tracing/repo_test.go
+++ b/repo/tracing/repo_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/looplab/eventhorizon/repo/memory"
 )
 
+// NOTE: Not named "Integration" to enable running with the unit tests.
 func TestReadRepo(t *testing.T) {
 	baseRepo := memory.NewRepo()
 	baseRepo.SetEntityFactory(func() eh.Entity {

--- a/repo/version/repo_test.go
+++ b/repo/version/repo_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/looplab/eventhorizon/repo/memory"
 )
 
+// NOTE: Not named "Integration" to enable running with the unit tests.
 func TestReadRepo(t *testing.T) {
 	baseRepo := memory.NewRepo()
 	baseRepo.SetEntityFactory(func() eh.Entity {

--- a/repo/version/repo_test.go
+++ b/repo/version/repo_test.go
@@ -86,7 +86,7 @@ func extraRepoTests(t *testing.T, ctx context.Context, r *Repo, baseRepo *memory
 		ID:        uuid.New(),
 		Version:   1,
 		Content:   "m1",
-		CreatedAt: time.Now().Round(time.Millisecond),
+		CreatedAt: time.Now().Round(time.Microsecond).UTC(),
 	}
 	if err := r.Save(ctx, m1); err != nil {
 		t.Error("there should be no error:", err)
@@ -168,7 +168,7 @@ func extraRepoTests(t *testing.T, ctx context.Context, r *Repo, baseRepo *memory
 		ID:        uuid.New(),
 		Version:   1,
 		Content:   "m2",
-		CreatedAt: time.Now().Round(time.Millisecond),
+		CreatedAt: time.Now().Round(time.Microsecond).UTC(),
 	}
 	if err := r.Save(ctx, m2); err != nil {
 		t.Error("there should be no error:", err)
@@ -195,7 +195,7 @@ func extraRepoTests(t *testing.T, ctx context.Context, r *Repo, baseRepo *memory
 		ID:        uuid.New(),
 		Version:   1,
 		Content:   "m3",
-		CreatedAt: time.Now().Round(time.Millisecond),
+		CreatedAt: time.Now().Round(time.Microsecond).UTC(),
 	}
 	go func() {
 		<-time.After(100 * time.Millisecond)
@@ -235,7 +235,7 @@ func extraRepoTests(t *testing.T, ctx context.Context, r *Repo, baseRepo *memory
 		ID:        uuid.New(),
 		Version:   4,
 		Content:   "modelMinVersion",
-		CreatedAt: time.Now().Round(time.Millisecond),
+		CreatedAt: time.Now().Round(time.Microsecond).UTC(),
 	}
 	go func() {
 		<-time.After(100 * time.Millisecond)


### PR DESCRIPTION
### Description

Use JSON encoding for the Memory repo.

Also adds some more of the `errors.Is/As` usage.

### Affected Components

- Memory repo

### Related Issues

### Solution and Design

By using a real byte encoding for the memory repo it more closely emulates a real DB to expose issues and avoid shared memory bugs.

### Steps to test and verify

