### PR TITLE
Fix / Use Bitnami images for Kafka/Zookeeper

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,18 +28,21 @@ services:
       - "--host-port=0.0.0.0:8793"
 
   zookeeper:
-    image: wurstmeister/zookeeper
+    image: bitnami/zookeeper:3.6.2
     ports:
       - "2181:2181"
+    environment:
+      - ALLOW_ANONYMOUS_LOGIN=yes
 
   kafka:
-    image: wurstmeister/kafka
+    image: bitnami/kafka:2.7.0
     depends_on:
       - zookeeper
     ports:
       - "9092:9092"
     environment:
-      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-      KAFKA_ADVERTISED_HOST_NAME: localhost
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
+      - KAFKA_BROKER_ID=1
+      - KAFKA_LISTENERS=PLAINTEXT://:9092
+      - KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://127.0.0.1:9092
+      - KAFKA_ZOOKEEPER_CONNECT=zookeeper:2181
+      - ALLOW_PLAINTEXT_LISTENER=yes


### PR DESCRIPTION
### Description

Use Bitnami images for Kafka/Zookeeper. I had some issues running the Wurstmeister Kafka on Apple M1, did not have time to investigate but the Bitnami images works. This uses the recommended setup for development.

### Affected Components

- Event Bus, Kafka

### Related Issues

### Solution and Design

### Steps to test and verify

1. ...
