### PR TITLE
Feature / Publish on bus from the Event Store

### DIFF
--- a/aggregatestore/events/aggregatestore.go
+++ b/aggregatestore/events/aggregatestore.go
@@ -26,15 +26,12 @@ import (
 // uses an event store for loading and saving events used to build the aggregate
 // and an event handler to handle resulting events.
 type AggregateStore struct {
-	store        eh.EventStore
-	eventHandler eh.EventHandler
+	store eh.EventStore
 }
 
 var (
 	// ErrInvalidEventStore is when a dispatcher is created with a nil event store.
 	ErrInvalidEventStore = errors.New("invalid event store")
-	// ErrInvalidEventBus is when a dispatcher is created with a nil event bus.
-	ErrInvalidEventBus = errors.New("invalid event bus")
 	// ErrInvalidAggregateType is when  the aggregate does not implement event.Aggregte.
 	ErrInvalidAggregateType = errors.New("invalid aggregate type")
 	// ErrMismatchedEventType occurs when loaded events from ID does not match aggregate type.
@@ -68,18 +65,12 @@ func (e ApplyEventError) Cause() error {
 // NewAggregateStore creates a aggregate store with an event store and an event
 // handler that will handle resulting events (for example by publishing them
 // on an event bus).
-func NewAggregateStore(store eh.EventStore, eventHandler eh.EventHandler) (*AggregateStore, error) {
+func NewAggregateStore(store eh.EventStore) (*AggregateStore, error) {
 	if store == nil {
 		return nil, ErrInvalidEventStore
 	}
-
-	if eventHandler == nil {
-		return nil, ErrInvalidEventBus
-	}
-
 	d := &AggregateStore{
-		store:        store,
-		eventHandler: eventHandler,
+		store: store,
 	}
 	return d, nil
 }
@@ -131,12 +122,6 @@ func (r *AggregateStore) Save(ctx context.Context, agg eh.Aggregate) error {
 	// after this save. Currently it is not reused.
 	if err := r.applyEvents(ctx, a, events); err != nil {
 		return err
-	}
-
-	for _, e := range events {
-		if err := r.eventHandler.HandleEvent(ctx, e); err != nil {
-			return err
-		}
 	}
 
 	return nil

--- a/eventbus/local/eventbus.go
+++ b/eventbus/local/eventbus.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"log"
 	"sync"
+	"time"
 
 	eh "github.com/looplab/eventhorizon"
 	"github.com/looplab/eventhorizon/codec/json"
@@ -143,6 +144,9 @@ func (b *EventBus) handle(ctx context.Context, m eh.EventMatcher, h eh.EventHand
 	for {
 		select {
 		case data := <-ch:
+			// Artificial delay to simulate network.
+			time.Sleep(10 * time.Millisecond)
+
 			event, ctx, err := b.codec.UnmarshalEvent(ctx, data)
 			if err != nil {
 				err = fmt.Errorf("could not unmarshal event: %w", err)

--- a/eventstore.go
+++ b/eventstore.go
@@ -72,11 +72,15 @@ func (e EventStoreError) Cause() error {
 	return e.Unwrap()
 }
 
-// ErrNoEventsToAppend is when no events are available to append.
-var ErrNoEventsToAppend = errors.New("no events to append")
-
-// ErrInvalidEvent is when an event does not implement the Event interface.
-var ErrInvalidEvent = errors.New("invalid event")
-
-// ErrIncorrectEventVersion is when an event is for an other version of the aggregate.
-var ErrIncorrectEventVersion = errors.New("mismatching event version")
+var (
+	// ErrNoEventsToAppend is when no events are available to append.
+	ErrNoEventsToAppend = errors.New("no events to append")
+	// ErrInvalidEvent is when an event does not implement the Event interface.
+	ErrInvalidEvent = errors.New("invalid event")
+	// ErrIncorrectEventVersion is when an event is for an other version of the aggregate.
+	ErrIncorrectEventVersion = errors.New("mismatching event version")
+	// ErrCouldNotSaveEvents is when events could not be saved.
+	ErrCouldNotSaveEvents = errors.New("could not save events")
+	// ErrCouldNotHandleEvents is when the events could not be handeled after saving.
+	ErrCouldNotHandleEvents = errors.New("could not handle events")
+)

--- a/eventstore/memory/eventstore.go
+++ b/eventstore/memory/eventstore.go
@@ -17,6 +17,7 @@ package memory
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 
 	"github.com/google/uuid"
@@ -107,6 +108,7 @@ func (s *EventStore) Save(ctx context.Context, events []eh.Event, originalVersio
 			if aggregate.Version != originalVersion {
 				return eh.EventStoreError{
 					Err:       ErrCouldNotSaveAggregate,
+					BaseErr:   fmt.Errorf("invalid original version %d", originalVersion),
 					Namespace: eh.NamespaceFromContext(ctx),
 				}
 			}

--- a/eventstore/memory/eventstore.go
+++ b/eventstore/memory/eventstore.go
@@ -27,12 +27,8 @@ import (
 )
 
 var (
-	// ErrCouldNotSaveAggregate is when an aggregate could not be saved.
-	ErrCouldNotSaveAggregate = errors.New("could not save aggregate")
 	// ErrCouldNotCreateEvent is when event data could not be created.
 	ErrCouldNotCreateEvent = errors.New("could not create event")
-	// ErrCouldNotHandleEvents is when the events could not be handeled after saving.
-	ErrCouldNotHandleEvents = errors.New("could not handle events")
 )
 
 // EventStore implements EventStore as an in memory structure.
@@ -127,7 +123,7 @@ func (s *EventStore) Save(ctx context.Context, events []eh.Event, originalVersio
 		if aggregate, ok := s.db[ns][aggregateID]; ok {
 			if aggregate.Version != originalVersion {
 				return eh.EventStoreError{
-					Err:       ErrCouldNotSaveAggregate,
+					Err:       eh.ErrCouldNotSaveEvents,
 					BaseErr:   fmt.Errorf("invalid original version %d", originalVersion),
 					Namespace: eh.NamespaceFromContext(ctx),
 				}
@@ -146,7 +142,7 @@ func (s *EventStore) Save(ctx context.Context, events []eh.Event, originalVersio
 		for _, e := range events {
 			if err := s.eventHandler.HandleEvent(ctx, e); err != nil {
 				return eh.EventStoreError{
-					Err:       ErrCouldNotHandleEvents,
+					Err:       eh.ErrCouldNotHandleEvents,
 					BaseErr:   err,
 					Namespace: eh.NamespaceFromContext(ctx),
 				}

--- a/eventstore/memory/eventstore_test.go
+++ b/eventstore/memory/eventstore_test.go
@@ -17,13 +17,19 @@ package memory
 import (
 	"context"
 	"testing"
+	"time"
 
+	"github.com/google/uuid"
 	eh "github.com/looplab/eventhorizon"
 	"github.com/looplab/eventhorizon/eventstore"
+	"github.com/looplab/eventhorizon/mocks"
 )
 
 func TestEventStore(t *testing.T) {
-	store := NewEventStore()
+	store, err := NewEventStore()
+	if err != nil {
+		t.Fatal("there should be no error:", err)
+	}
 	if store == nil {
 		t.Fatal("there should be a store")
 	}
@@ -33,4 +39,52 @@ func TestEventStore(t *testing.T) {
 	ctx := eh.NewContextWithNamespace(context.Background(), "ns")
 	eventstore.AcceptanceTest(t, ctx, store)
 	eventstore.MaintainerAcceptanceTest(t, context.Background(), store)
+}
+
+func TestWithEventHandler(t *testing.T) {
+	h := &mocks.EventBus{}
+
+	store, err := NewEventStore(WithEventHandler(h))
+	if err != nil {
+		t.Fatal("there should be no error:", err)
+	}
+	if store == nil {
+		t.Fatal("there should be a store")
+	}
+
+	ctx := context.Background()
+
+	// The event handler should be called.
+	id1 := uuid.New()
+	timestamp := time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)
+	event1 := eh.NewEventForAggregate(mocks.EventType, &mocks.EventData{Content: "event1"},
+		timestamp, mocks.AggregateType, id1, 1)
+	err = store.Save(ctx, []eh.Event{event1}, 0)
+	if err != nil {
+		t.Error("there should be no error:", err)
+	}
+	expected := []eh.Event{event1}
+	// The saved events should be ok.
+	events, err := store.Load(ctx, id1)
+	if err != nil {
+		t.Error("there should be no error:", err)
+	}
+	// The stored events should be ok.
+	for i, event := range events {
+		if err := eh.CompareEvents(event, expected[i], eh.IgnoreVersion()); err != nil {
+			t.Error("the stored event was incorrect:", err)
+		}
+		if event.Version() != i+1 {
+			t.Error("the event version should be correct:", event, event.Version())
+		}
+	}
+	// The handeled events should be ok.
+	for i, event := range h.Events {
+		if err := eh.CompareEvents(event, expected[i], eh.IgnoreVersion()); err != nil {
+			t.Error("the handeled event was incorrect:", err)
+		}
+		if event.Version() != i+1 {
+			t.Error("the event version should be correct:", event, event.Version())
+		}
+	}
 }

--- a/eventstore/mongodb/eventstore.go
+++ b/eventstore/mongodb/eventstore.go
@@ -45,12 +45,6 @@ var (
 	ErrCouldNotMarshalEvent = errors.New("could not marshal event")
 	// ErrCouldNotUnmarshalEvent is when an event could not be unmarshaled into a concrete type.
 	ErrCouldNotUnmarshalEvent = errors.New("could not unmarshal event")
-	// ErrCouldNotLoadAggregate is when an aggregate could not be loaded.
-	ErrCouldNotLoadAggregate = errors.New("could not load aggregate")
-	// ErrCouldNotSaveAggregate is when an aggregate could not be saved.
-	ErrCouldNotSaveAggregate = errors.New("could not save aggregate")
-	// ErrCouldNotHandleEvents is when the events could not be handeled after saving.
-	ErrCouldNotHandleEvents = errors.New("could not handle events")
 )
 
 // EventStore implements an EventStore for MongoDB.
@@ -181,7 +175,7 @@ func (s *EventStore) Save(ctx context.Context, events []eh.Event, originalVersio
 
 		if _, err := c.InsertOne(ctx, aggregate); err != nil {
 			return eh.EventStoreError{
-				Err:       ErrCouldNotSaveAggregate,
+				Err:       eh.ErrCouldNotSaveEvents,
 				BaseErr:   err,
 				Namespace: eh.NamespaceFromContext(ctx),
 			}
@@ -201,13 +195,13 @@ func (s *EventStore) Save(ctx context.Context, events []eh.Event, originalVersio
 			},
 		); err != nil {
 			return eh.EventStoreError{
-				Err:       ErrCouldNotSaveAggregate,
+				Err:       eh.ErrCouldNotSaveEvents,
 				BaseErr:   err,
 				Namespace: eh.NamespaceFromContext(ctx),
 			}
 		} else if r.MatchedCount == 0 {
 			return eh.EventStoreError{
-				Err:       ErrCouldNotSaveAggregate,
+				Err:       eh.ErrCouldNotSaveEvents,
 				BaseErr:   fmt.Errorf("invalid original version %d", originalVersion),
 				Namespace: eh.NamespaceFromContext(ctx),
 			}
@@ -219,7 +213,7 @@ func (s *EventStore) Save(ctx context.Context, events []eh.Event, originalVersio
 		for _, e := range events {
 			if err := s.eventHandler.HandleEvent(ctx, e); err != nil {
 				return eh.EventStoreError{
-					Err:       ErrCouldNotHandleEvents,
+					Err:       eh.ErrCouldNotHandleEvents,
 					BaseErr:   err,
 					Namespace: eh.NamespaceFromContext(ctx),
 				}
@@ -316,7 +310,7 @@ func (s *EventStore) Replace(ctx context.Context, event eh.Event) error {
 		},
 	); err != nil {
 		return eh.EventStoreError{
-			Err:       ErrCouldNotSaveAggregate,
+			Err:       eh.ErrCouldNotSaveEvents,
 			BaseErr:   err,
 			Namespace: eh.NamespaceFromContext(ctx),
 		}
@@ -342,7 +336,7 @@ func (s *EventStore) RenameEvent(ctx context.Context, from, to eh.EventType) err
 		},
 	); err != nil {
 		return eh.EventStoreError{
-			Err:       ErrCouldNotSaveAggregate,
+			Err:       eh.ErrCouldNotSaveEvents,
 			BaseErr:   err,
 			Namespace: eh.NamespaceFromContext(ctx),
 		}

--- a/eventstore/recorder/eventstore_test.go
+++ b/eventstore/recorder/eventstore_test.go
@@ -28,7 +28,10 @@ import (
 
 // NOTE: Not named "Integration" to enable running with the unit tests.
 func TestEventStore(t *testing.T) {
-	baseStore := memory.NewEventStore()
+	baseStore, err := memory.NewEventStore()
+	if err != nil {
+		t.Fatal("there should be no error:", err)
+	}
 	store := NewEventStore(baseStore)
 	if store == nil {
 		t.Fatal("there should be a store")
@@ -66,7 +69,7 @@ func TestEventStore(t *testing.T) {
 	timestamp := time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)
 	event7 := eh.NewEvent(mocks.EventType, &mocks.EventData{Content: "event1"}, timestamp,
 		eh.ForAggregate(mocks.AggregateType, event1.AggregateID(), 7))
-	err := store.Save(ctx, []eh.Event{event7}, 6)
+	err = store.Save(ctx, []eh.Event{event7}, 6)
 	if err != nil {
 		t.Error("there should be no error:", err)
 	}

--- a/eventstore/tracing/eventstore_test.go
+++ b/eventstore/tracing/eventstore_test.go
@@ -25,7 +25,10 @@ import (
 
 // NOTE: Not named "Integration" to enable running with the unit tests.
 func TestEventStore(t *testing.T) {
-	innerStore := memory.NewEventStore()
+	innerStore, err := memory.NewEventStore()
+	if err != nil {
+		t.Fatal("there should be no error:", err)
+	}
 	if innerStore == nil {
 		t.Fatal("there should be a store")
 	}

--- a/examples/guestlist/domains/guestlist/setup.go
+++ b/examples/guestlist/domains/guestlist/setup.go
@@ -42,7 +42,7 @@ func Setup(
 		eh.UseEventHandlerMiddleware(&Logger{}, observer.Middleware))
 
 	// Create the aggregate repository.
-	aggregateStore, err := events.NewAggregateStore(eventStore, eventBus)
+	aggregateStore, err := events.NewAggregateStore(eventStore)
 	if err != nil {
 		log.Fatalf("could not create aggregate store: %s", err)
 	}

--- a/examples/guestlist/memory/memory_test.go
+++ b/examples/guestlist/memory/memory_test.go
@@ -33,9 +33,6 @@ import (
 
 // NOTE: Not named "Integration" to enable running with the unit tests.
 func Example() {
-	// Create the event store.
-	eventStore := eventstore.NewEventStore()
-
 	// Create the event bus that distributes events.
 	eventBus := eventbus.NewEventBus()
 	go func() {
@@ -43,6 +40,11 @@ func Example() {
 			log.Printf("eventbus: %s", e.Error())
 		}
 	}()
+
+	// Create the event store.
+	eventStore, _ := eventstore.NewEventStore(
+		eventstore.WithEventHandler(eventBus), // Add the event bus as a handler after save.
+	)
 
 	// Create the command bus.
 	commandBus := bus.NewCommandHandler()

--- a/examples/guestlist/mongodb/mongodb_test.go
+++ b/examples/guestlist/mongodb/mongodb_test.go
@@ -52,12 +52,6 @@ guest list: 4 invited - 3 accepted, 1 declined - 2 confirmed, 1 denied`)
 	}
 	url := "mongodb://" + addr
 
-	// Create the event store.
-	eventStore, err := eventstore.NewEventStore(url, "demo")
-	if err != nil {
-		log.Fatalf("could not create event store: %s", err)
-	}
-
 	// Create the event bus that distributes events.
 	eventBus := eventbus.NewEventBus()
 	go func() {
@@ -65,6 +59,14 @@ guest list: 4 invited - 3 accepted, 1 declined - 2 confirmed, 1 denied`)
 			log.Printf("eventbus: %s", e.Error())
 		}
 	}()
+
+	// Create the event store.
+	eventStore, err := eventstore.NewEventStore(url, "demo",
+		eventstore.WithEventHandler(eventBus), // Add the event bus as a handler after save.
+	)
+	if err != nil {
+		log.Fatalf("could not create event store: %s", err)
+	}
 
 	// Create the command bus.
 	commandBus := bus.NewCommandHandler()

--- a/examples/guestlist/mongodb/mongodb_test.go
+++ b/examples/guestlist/mongodb/mongodb_test.go
@@ -25,13 +25,15 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+
 	eh "github.com/looplab/eventhorizon"
 	"github.com/looplab/eventhorizon/commandhandler/bus"
-	eventbus "github.com/looplab/eventhorizon/eventbus/local"
-	eventstore "github.com/looplab/eventhorizon/eventstore/mongodb"
-	"github.com/looplab/eventhorizon/examples/guestlist/domains/guestlist"
-	repo "github.com/looplab/eventhorizon/repo/mongodb"
+	localEventBus "github.com/looplab/eventhorizon/eventbus/local"
+	mongoEventStore "github.com/looplab/eventhorizon/eventstore/mongodb"
+	"github.com/looplab/eventhorizon/repo/mongodb"
 	"github.com/looplab/eventhorizon/repo/version"
+
+	"github.com/looplab/eventhorizon/examples/guestlist/domains/guestlist"
 )
 
 func ExampleIntegration() {
@@ -51,9 +53,10 @@ guest list: 4 invited - 3 accepted, 1 declined - 2 confirmed, 1 denied`)
 		addr = "localhost:27017"
 	}
 	url := "mongodb://" + addr
+	dbPrefix := "guestlist-example"
 
 	// Create the event bus that distributes events.
-	eventBus := eventbus.NewEventBus()
+	eventBus := localEventBus.NewEventBus(nil)
 	go func() {
 		for e := range eventBus.Errors() {
 			log.Printf("eventbus: %s", e.Error())
@@ -61,8 +64,8 @@ guest list: 4 invited - 3 accepted, 1 declined - 2 confirmed, 1 denied`)
 	}()
 
 	// Create the event store.
-	eventStore, err := eventstore.NewEventStore(url, "demo",
-		eventstore.WithEventHandler(eventBus), // Add the event bus as a handler after save.
+	eventStore, err := mongoEventStore.NewEventStore(url, dbPrefix,
+		mongoEventStore.WithEventHandler(eventBus), // Add the event bus as a handler after save.
 	)
 	if err != nil {
 		log.Fatalf("could not create event store: %s", err)
@@ -72,14 +75,15 @@ guest list: 4 invited - 3 accepted, 1 declined - 2 confirmed, 1 denied`)
 	commandBus := bus.NewCommandHandler()
 
 	// Create the read repositories.
-	invitationRepo, err := repo.NewRepo(url, "demo", "invitations")
+	invitationRepo, err := mongodb.NewRepo(url, dbPrefix, "invitations")
 	if err != nil {
 		log.Fatalf("could not create invitation repository: %s", err)
 	}
 	invitationRepo.SetEntityFactory(func() eh.Entity { return &guestlist.Invitation{} })
 	// A version repo is needed for the projector to handle eventual consistency.
 	invitationVersionRepo := version.NewRepo(invitationRepo)
-	guestListRepo, err := repo.NewRepo(url, "demo", "guest_lists")
+
+	guestListRepo, err := mongodb.NewRepo(url, dbPrefix, "guest_lists")
 	if err != nil {
 		log.Fatalf("could not create guest list repository: %s", err)
 	}

--- a/examples/todomvc/backend/domains/todo/setup.go
+++ b/examples/todomvc/backend/domains/todo/setup.go
@@ -43,7 +43,7 @@ func SetupDomain(
 	}, projector)
 
 	// Create the event sourced aggregate repository.
-	aggregateStore, err := events.NewAggregateStore(eventStore, eventBus)
+	aggregateStore, err := events.NewAggregateStore(eventStore)
 	if err != nil {
 		return fmt.Errorf("could not create aggregate store: %w", err)
 	}

--- a/examples/todomvc/backend/main.go
+++ b/examples/todomvc/backend/main.go
@@ -34,7 +34,6 @@ import (
 	mongoRepo "github.com/looplab/eventhorizon/repo/mongodb"
 	tracingRepo "github.com/looplab/eventhorizon/repo/tracing"
 	"github.com/looplab/eventhorizon/repo/version"
-	versionRepo "github.com/looplab/eventhorizon/repo/version"
 
 	"github.com/looplab/eventhorizon/examples/todomvc/backend/domains/todo"
 	"github.com/looplab/eventhorizon/examples/todomvc/backend/handler"
@@ -44,11 +43,11 @@ func main() {
 	log.Println("starting TodoMVC backend")
 
 	// Use MongoDB in Docker with fallback to localhost.
-	dbAddr := os.Getenv("MONGODB_ADDR")
-	if dbAddr == "" {
-		dbAddr = "localhost:27017"
+	addr := os.Getenv("MONGODB_ADDR")
+	if addr == "" {
+		addr = "localhost:27017"
 	}
-	dbURL := "mongodb://" + dbAddr
+	url := "mongodb://" + addr
 	dbPrefix := "todomvc-example"
 
 	// Connect to localhost if not running inside docker
@@ -86,7 +85,7 @@ func main() {
 
 	// Create the event store.
 	var eventStore eh.EventStore
-	if eventStore, err = mongoEventStore.NewEventStore(dbURL, dbPrefix,
+	if eventStore, err = mongoEventStore.NewEventStore(url, dbPrefix,
 		mongoEventStore.WithEventHandler(eventBus), // Add the event bus as a handler after save.
 	); err != nil {
 		log.Fatal("could not create event store: ", err)
@@ -107,10 +106,10 @@ func main() {
 
 	// Create the repository and wrap in a version repository.
 	var todoRepo eh.ReadWriteRepo
-	if todoRepo, err = mongoRepo.NewRepo(dbURL, dbPrefix, "todos"); err != nil {
+	if todoRepo, err = mongoRepo.NewRepo(url, dbPrefix, "todos"); err != nil {
 		log.Fatal("could not create invitation repository: ", err)
 	}
-	todoRepo = versionRepo.NewRepo(todoRepo)
+	todoRepo = version.NewRepo(todoRepo)
 	todoRepo = tracingRepo.NewRepo(todoRepo)
 
 	// Setup the Todo domain.


### PR DESCRIPTION
### Description

Publish on bus from the Event Store. Should make for a more flexible setup when implementing an atomic save/publish later.

### Affected Components

- Event Aggregate Store
- Event Store
- Examples/setup

### Related Issues

### Solution and Design

The Event Store now has an option called `WithEventHandle` which adds an event handler to call after saving events. Typically this event handler is the event bus.

### Steps to test and verify
