### PR TITLE
Fix / Remove key and use only 1 partition for Kafka

### DIFF
--- a/eventbus/kafka/eventbus.go
+++ b/eventbus/kafka/eventbus.go
@@ -75,7 +75,7 @@ func NewEventBus(addr, appID string, options ...Option) (*EventBus, error) {
 	resp, err := client.CreateTopics(ctx, &kafka.CreateTopicsRequest{
 		Topics: []kafka.TopicConfig{{
 			Topic:             topic,
-			NumPartitions:     2,
+			NumPartitions:     1,
 			ReplicationFactor: 1,
 		}},
 	})
@@ -91,7 +91,6 @@ func NewEventBus(addr, appID string, options ...Option) (*EventBus, error) {
 	b.writer = &kafka.Writer{
 		Addr:         kafka.TCP(addr),
 		Topic:        topic,
-		Balancer:     &kafka.LeastBytes{},
 		BatchSize:    1,                // Write every event to the bus without delay.
 		RequiredAcks: kafka.RequireOne, // Stronger consistency.
 	}
@@ -128,7 +127,6 @@ func (b *EventBus) HandleEvent(ctx context.Context, event eh.Event) error {
 	}
 
 	if err := b.writer.WriteMessages(ctx, kafka.Message{
-		Key:   []byte(event.AggregateID().String()),
 		Value: data,
 		Headers: []kafka.Header{
 			{


### PR DESCRIPTION
### Description

This is to preserve ordering among all events, not just for a single
aggregate as was the case before.

### Affected Components

- Event Bus, Kafka

### Related Issues

### Solution and Design

### Steps to test and verify
