### PR TITLE
Feature / UUID alias type

### DIFF
--- a/aggregate.go
+++ b/aggregate.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/google/uuid"
+	"github.com/looplab/eventhorizon/uuid"
 )
 
 // Aggregate is an interface representing a versioned data entity created from

--- a/aggregate_test.go
+++ b/aggregate_test.go
@@ -19,7 +19,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/google/uuid"
+	"github.com/looplab/eventhorizon/uuid"
 )
 
 func TestCreateAggregate(t *testing.T) {

--- a/aggregatestore/events/aggregatebase.go
+++ b/aggregatestore/events/aggregatebase.go
@@ -17,8 +17,8 @@ package events
 import (
 	"time"
 
-	"github.com/google/uuid"
 	eh "github.com/looplab/eventhorizon"
+	"github.com/looplab/eventhorizon/uuid"
 )
 
 // AggregateBase is a event sourced aggregate base to embed in a domain aggregate.

--- a/aggregatestore/events/aggregatebase_test.go
+++ b/aggregatestore/events/aggregatebase_test.go
@@ -20,8 +20,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
 	eh "github.com/looplab/eventhorizon"
+	"github.com/looplab/eventhorizon/uuid"
 )
 
 func TestNewAggregateBase(t *testing.T) {

--- a/aggregatestore/events/aggregatestore.go
+++ b/aggregatestore/events/aggregatestore.go
@@ -18,8 +18,8 @@ import (
 	"context"
 	"errors"
 
-	"github.com/google/uuid"
 	eh "github.com/looplab/eventhorizon"
+	"github.com/looplab/eventhorizon/uuid"
 )
 
 // AggregateStore is an aggregate store using event sourcing. It

--- a/aggregatestore/events/aggregatestore_test.go
+++ b/aggregatestore/events/aggregatestore_test.go
@@ -21,9 +21,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
 	eh "github.com/looplab/eventhorizon"
 	"github.com/looplab/eventhorizon/mocks"
+	"github.com/looplab/eventhorizon/uuid"
 )
 
 func TestNewAggregateStore(t *testing.T) {

--- a/aggregatestore/model/aggregatestore.go
+++ b/aggregatestore/model/aggregatestore.go
@@ -18,8 +18,8 @@ import (
 	"context"
 	"errors"
 
-	"github.com/google/uuid"
 	eh "github.com/looplab/eventhorizon"
+	"github.com/looplab/eventhorizon/uuid"
 )
 
 // AggregateStore is an aggregate store that uses a read write repo for

--- a/aggregatestore/model/aggregatestore_test.go
+++ b/aggregatestore/model/aggregatestore_test.go
@@ -21,9 +21,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
 	eh "github.com/looplab/eventhorizon"
 	"github.com/looplab/eventhorizon/mocks"
+	"github.com/looplab/eventhorizon/uuid"
 )
 
 func TestNewAggregateStore(t *testing.T) {

--- a/codec/acceptance_testing.go
+++ b/codec/acceptance_testing.go
@@ -19,10 +19,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
-
 	eh "github.com/looplab/eventhorizon"
 	"github.com/looplab/eventhorizon/mocks"
+	"github.com/looplab/eventhorizon/uuid"
 )
 
 func init() {

--- a/codec/bson/codec.go
+++ b/codec/bson/codec.go
@@ -19,10 +19,10 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/google/uuid"
 	"go.mongodb.org/mongo-driver/bson"
 
 	eh "github.com/looplab/eventhorizon"
+	"github.com/looplab/eventhorizon/uuid"
 )
 
 // EventCodec is a codec for marshaling and unmarshaling events

--- a/codec/json/codec.go
+++ b/codec/json/codec.go
@@ -20,9 +20,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/google/uuid"
-
 	eh "github.com/looplab/eventhorizon"
+	"github.com/looplab/eventhorizon/uuid"
 )
 
 // EventCodec is a codec for marshaling and unmarshaling events

--- a/command.go
+++ b/command.go
@@ -21,7 +21,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/google/uuid"
+	"github.com/looplab/eventhorizon/uuid"
 )
 
 // Command is a domain command that is sent to a Dispatcher.

--- a/command_test.go
+++ b/command_test.go
@@ -19,7 +19,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
+	"github.com/looplab/eventhorizon/uuid"
 )
 
 func TestCreateCommand(t *testing.T) {

--- a/commandhandler/aggregate/commandhandler_test.go
+++ b/commandhandler/aggregate/commandhandler_test.go
@@ -20,9 +20,9 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/google/uuid"
 	eh "github.com/looplab/eventhorizon"
 	"github.com/looplab/eventhorizon/mocks"
+	"github.com/looplab/eventhorizon/uuid"
 )
 
 func TestNewCommandHandler(t *testing.T) {

--- a/commandhandler/bus/commandhandler_test.go
+++ b/commandhandler/bus/commandhandler_test.go
@@ -20,9 +20,9 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/google/uuid"
 	eh "github.com/looplab/eventhorizon"
 	"github.com/looplab/eventhorizon/mocks"
+	"github.com/looplab/eventhorizon/uuid"
 )
 
 func TestCommandHandler(t *testing.T) {

--- a/context.go
+++ b/context.go
@@ -19,7 +19,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/google/uuid"
+	"github.com/looplab/eventhorizon/uuid"
 )
 
 // DefaultNamespace is the namespace to use if not set in the context.

--- a/entity.go
+++ b/entity.go
@@ -14,7 +14,7 @@
 
 package eventhorizon
 
-import "github.com/google/uuid"
+import "github.com/looplab/eventhorizon/uuid"
 
 // Entity is an item which is identified by an ID.
 //

--- a/event.go
+++ b/event.go
@@ -20,7 +20,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/google/uuid"
+	"github.com/looplab/eventhorizon/uuid"
 )
 
 // Event is a domain event describing a change that has happened to an aggregate.

--- a/event_test.go
+++ b/event_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
+	"github.com/looplab/eventhorizon/uuid"
 )
 
 func TestNewEvent(t *testing.T) {

--- a/eventbus/acceptance_testing.go
+++ b/eventbus/acceptance_testing.go
@@ -22,12 +22,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/kr/pretty"
 
 	eh "github.com/looplab/eventhorizon"
 	"github.com/looplab/eventhorizon/middleware/eventhandler/observer"
 	"github.com/looplab/eventhorizon/mocks"
+	"github.com/looplab/eventhorizon/uuid"
 )
 
 // AcceptanceTest is the acceptance test that all implementations of EventBus

--- a/eventhandler/projector/eventhandler_test.go
+++ b/eventhandler/projector/eventhandler_test.go
@@ -21,10 +21,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
 	eh "github.com/looplab/eventhorizon"
 	"github.com/looplab/eventhorizon/mocks"
 	"github.com/looplab/eventhorizon/repo/version"
+	"github.com/looplab/eventhorizon/uuid"
 )
 
 func TestEventHandler_CreateModel(t *testing.T) {

--- a/eventhandler/saga/eventhandler_test.go
+++ b/eventhandler/saga/eventhandler_test.go
@@ -20,9 +20,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
 	eh "github.com/looplab/eventhorizon"
 	"github.com/looplab/eventhorizon/mocks"
+	"github.com/looplab/eventhorizon/uuid"
 )
 
 func TestEventHandler(t *testing.T) {

--- a/eventhandler/waiter/eventhandler.go
+++ b/eventhandler/waiter/eventhandler.go
@@ -17,8 +17,8 @@ package waiter
 import (
 	"context"
 
-	"github.com/google/uuid"
 	eh "github.com/looplab/eventhorizon"
+	"github.com/looplab/eventhorizon/uuid"
 )
 
 // EventHandler waits for certain events to match a criteria.

--- a/eventhandler/waiter/eventhandler_test.go
+++ b/eventhandler/waiter/eventhandler_test.go
@@ -22,9 +22,9 @@ import (
 
 	"time"
 
-	"github.com/google/uuid"
 	eh "github.com/looplab/eventhorizon"
 	"github.com/looplab/eventhorizon/mocks"
+	"github.com/looplab/eventhorizon/uuid"
 )
 
 func TestEventHandler(t *testing.T) {

--- a/eventstore.go
+++ b/eventstore.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"errors"
 
-	"github.com/google/uuid"
+	"github.com/looplab/eventhorizon/uuid"
 )
 
 // EventStore is an interface for an event sourcing event store.

--- a/eventstore/acceptanece_testing.go
+++ b/eventstore/acceptanece_testing.go
@@ -21,10 +21,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
-
 	eh "github.com/looplab/eventhorizon"
 	"github.com/looplab/eventhorizon/mocks"
+	"github.com/looplab/eventhorizon/uuid"
 )
 
 // AcceptanceTest is the acceptance test that all implementations of EventStore

--- a/eventstore/maintenance_testing.go
+++ b/eventstore/maintenance_testing.go
@@ -19,10 +19,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
-
 	eh "github.com/looplab/eventhorizon"
 	"github.com/looplab/eventhorizon/mocks"
+	"github.com/looplab/eventhorizon/uuid"
 )
 
 // MaintenanceAcceptanceTest is the acceptance test that all implementations of

--- a/eventstore/memory/eventmaintenance.go
+++ b/eventstore/memory/eventmaintenance.go
@@ -17,9 +17,8 @@ package memory
 import (
 	"context"
 
-	"github.com/google/uuid"
-
 	eh "github.com/looplab/eventhorizon"
+	"github.com/looplab/eventhorizon/uuid"
 )
 
 // Replace implements the Replace method of the eventhorizon.EventStore interface.

--- a/eventstore/memory/eventstore.go
+++ b/eventstore/memory/eventstore.go
@@ -20,10 +20,10 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/google/uuid"
 	"github.com/jinzhu/copier"
 
 	eh "github.com/looplab/eventhorizon"
+	"github.com/looplab/eventhorizon/uuid"
 )
 
 var (

--- a/eventstore/memory/eventstore_test.go
+++ b/eventstore/memory/eventstore_test.go
@@ -19,10 +19,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
 	eh "github.com/looplab/eventhorizon"
 	"github.com/looplab/eventhorizon/eventstore"
 	"github.com/looplab/eventhorizon/mocks"
+	"github.com/looplab/eventhorizon/uuid"
 )
 
 func TestEventStore(t *testing.T) {

--- a/eventstore/mongodb/eventstore.go
+++ b/eventstore/mongodb/eventstore.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/google/uuid"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
 	mongoOptions "go.mongodb.org/mongo-driver/mongo/options"
@@ -32,6 +31,7 @@ import (
 	_ "github.com/looplab/eventhorizon/codec/bson"
 
 	eh "github.com/looplab/eventhorizon"
+	"github.com/looplab/eventhorizon/uuid"
 )
 
 var (

--- a/eventstore/mongodb/eventstore_test.go
+++ b/eventstore/mongodb/eventstore_test.go
@@ -22,11 +22,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
-
 	eh "github.com/looplab/eventhorizon"
 	"github.com/looplab/eventhorizon/eventstore"
 	"github.com/looplab/eventhorizon/mocks"
+	"github.com/looplab/eventhorizon/uuid"
 )
 
 func TestEventStoreIntegration(t *testing.T) {

--- a/eventstore/tracing/eventstore.go
+++ b/eventstore/tracing/eventstore.go
@@ -17,10 +17,11 @@ package tracing
 import (
 	"context"
 
-	"github.com/google/uuid"
-	eh "github.com/looplab/eventhorizon"
 	"github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/ext"
+
+	eh "github.com/looplab/eventhorizon"
+	"github.com/looplab/eventhorizon/uuid"
 )
 
 // EventStore is a EventStore that adds tracing.

--- a/examples/guestlist/domains/guestlist/aggregate.go
+++ b/examples/guestlist/domains/guestlist/aggregate.go
@@ -20,9 +20,9 @@ import (
 	"log"
 	"time"
 
-	"github.com/google/uuid"
 	eh "github.com/looplab/eventhorizon"
 	"github.com/looplab/eventhorizon/aggregatestore/events"
+	"github.com/looplab/eventhorizon/uuid"
 )
 
 func init() {

--- a/examples/guestlist/domains/guestlist/commands.go
+++ b/examples/guestlist/domains/guestlist/commands.go
@@ -15,8 +15,8 @@
 package guestlist
 
 import (
-	"github.com/google/uuid"
 	eh "github.com/looplab/eventhorizon"
+	"github.com/looplab/eventhorizon/uuid"
 )
 
 func init() {

--- a/examples/guestlist/domains/guestlist/projectors.go
+++ b/examples/guestlist/domains/guestlist/projectors.go
@@ -20,9 +20,9 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/google/uuid"
 	eh "github.com/looplab/eventhorizon"
 	"github.com/looplab/eventhorizon/eventhandler/projector"
+	"github.com/looplab/eventhorizon/uuid"
 )
 
 // Invitation is a read model object for an invitation.

--- a/examples/guestlist/domains/guestlist/saga.go
+++ b/examples/guestlist/domains/guestlist/saga.go
@@ -18,9 +18,9 @@ import (
 	"context"
 	"sync"
 
-	"github.com/google/uuid"
 	eh "github.com/looplab/eventhorizon"
 	"github.com/looplab/eventhorizon/eventhandler/saga"
+	"github.com/looplab/eventhorizon/uuid"
 )
 
 // ResponseSagaType is the type of the saga.

--- a/examples/guestlist/domains/guestlist/setup.go
+++ b/examples/guestlist/domains/guestlist/setup.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"log"
 
-	"github.com/google/uuid"
 	eh "github.com/looplab/eventhorizon"
 	"github.com/looplab/eventhorizon/aggregatestore/events"
 	"github.com/looplab/eventhorizon/commandhandler/aggregate"
@@ -26,6 +25,7 @@ import (
 	"github.com/looplab/eventhorizon/eventhandler/projector"
 	"github.com/looplab/eventhorizon/eventhandler/saga"
 	"github.com/looplab/eventhorizon/middleware/eventhandler/observer"
+	"github.com/looplab/eventhorizon/uuid"
 )
 
 // Setup configures the guestlist.

--- a/examples/guestlist/memory/memory_test.go
+++ b/examples/guestlist/memory/memory_test.go
@@ -22,13 +22,14 @@ import (
 	"sync"
 	"time"
 
-	"github.com/google/uuid"
 	eh "github.com/looplab/eventhorizon"
 	"github.com/looplab/eventhorizon/commandhandler/bus"
 	localEventBus "github.com/looplab/eventhorizon/eventbus/local"
 	memoryEventStore "github.com/looplab/eventhorizon/eventstore/memory"
-	"github.com/looplab/eventhorizon/examples/guestlist/domains/guestlist"
 	"github.com/looplab/eventhorizon/repo/memory"
+	"github.com/looplab/eventhorizon/uuid"
+
+	"github.com/looplab/eventhorizon/examples/guestlist/domains/guestlist"
 )
 
 // NOTE: Not named "Integration" to enable running with the unit tests.

--- a/examples/guestlist/mongodb/mongodb_test.go
+++ b/examples/guestlist/mongodb/mongodb_test.go
@@ -24,14 +24,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
-
 	eh "github.com/looplab/eventhorizon"
 	"github.com/looplab/eventhorizon/commandhandler/bus"
 	localEventBus "github.com/looplab/eventhorizon/eventbus/local"
 	mongoEventStore "github.com/looplab/eventhorizon/eventstore/mongodb"
 	"github.com/looplab/eventhorizon/repo/mongodb"
 	"github.com/looplab/eventhorizon/repo/version"
+	"github.com/looplab/eventhorizon/uuid"
 
 	"github.com/looplab/eventhorizon/examples/guestlist/domains/guestlist"
 )

--- a/examples/todomvc/backend/domains/todo/aggregate.go
+++ b/examples/todomvc/backend/domains/todo/aggregate.go
@@ -20,9 +20,9 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/google/uuid"
 	eh "github.com/looplab/eventhorizon"
 	"github.com/looplab/eventhorizon/aggregatestore/events"
+	"github.com/looplab/eventhorizon/uuid"
 )
 
 func init() {

--- a/examples/todomvc/backend/domains/todo/aggregate_test.go
+++ b/examples/todomvc/backend/domains/todo/aggregate_test.go
@@ -21,11 +21,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/kr/pretty"
+
 	eh "github.com/looplab/eventhorizon"
 	"github.com/looplab/eventhorizon/aggregatestore/events"
 	"github.com/looplab/eventhorizon/mocks"
+	"github.com/looplab/eventhorizon/uuid"
 )
 
 func TestAggregateHandleCommand(t *testing.T) {

--- a/examples/todomvc/backend/domains/todo/commands.go
+++ b/examples/todomvc/backend/domains/todo/commands.go
@@ -15,8 +15,8 @@
 package todo
 
 import (
-	"github.com/google/uuid"
 	eh "github.com/looplab/eventhorizon"
+	"github.com/looplab/eventhorizon/uuid"
 )
 
 func init() {

--- a/examples/todomvc/backend/domains/todo/model.go
+++ b/examples/todomvc/backend/domains/todo/model.go
@@ -17,8 +17,8 @@ package todo
 import (
 	"time"
 
-	"github.com/google/uuid"
 	eh "github.com/looplab/eventhorizon"
+	"github.com/looplab/eventhorizon/uuid"
 )
 
 // TodoItem represents each item that can be completed in the todo list.

--- a/examples/todomvc/backend/domains/todo/model_test.go
+++ b/examples/todomvc/backend/domains/todo/model_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
+	"github.com/looplab/eventhorizon/uuid"
 )
 
 func TestModelJSON(t *testing.T) {

--- a/examples/todomvc/backend/domains/todo/projector_test.go
+++ b/examples/todomvc/backend/domains/todo/projector_test.go
@@ -21,9 +21,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/kr/pretty"
+
 	eh "github.com/looplab/eventhorizon"
+	"github.com/looplab/eventhorizon/uuid"
 )
 
 func TestProjector(t *testing.T) {

--- a/examples/todomvc/backend/handler/handler_test.go
+++ b/examples/todomvc/backend/handler/handler_test.go
@@ -26,8 +26,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
-
 	eh "github.com/looplab/eventhorizon"
 	"github.com/looplab/eventhorizon/commandhandler/bus"
 	gcpEventBus "github.com/looplab/eventhorizon/eventbus/gcp"
@@ -39,6 +37,7 @@ import (
 	"github.com/looplab/eventhorizon/repo/memory"
 	"github.com/looplab/eventhorizon/repo/mongodb"
 	"github.com/looplab/eventhorizon/repo/version"
+	"github.com/looplab/eventhorizon/uuid"
 
 	"github.com/looplab/eventhorizon/examples/todomvc/backend/domains/todo"
 )

--- a/examples/todomvc/backend/main.go
+++ b/examples/todomvc/backend/main.go
@@ -21,8 +21,6 @@ import (
 	"os"
 	"os/signal"
 
-	"github.com/google/uuid"
-
 	eh "github.com/looplab/eventhorizon"
 	"github.com/looplab/eventhorizon/commandhandler/bus"
 	gcpEventBus "github.com/looplab/eventhorizon/eventbus/gcp"
@@ -34,6 +32,7 @@ import (
 	mongoRepo "github.com/looplab/eventhorizon/repo/mongodb"
 	tracingRepo "github.com/looplab/eventhorizon/repo/tracing"
 	"github.com/looplab/eventhorizon/repo/version"
+	"github.com/looplab/eventhorizon/uuid"
 
 	"github.com/looplab/eventhorizon/examples/todomvc/backend/domains/todo"
 	"github.com/looplab/eventhorizon/examples/todomvc/backend/handler"

--- a/httputils/query.go
+++ b/httputils/query.go
@@ -20,8 +20,8 @@ import (
 	"net/http"
 	"path"
 
-	"github.com/google/uuid"
 	eh "github.com/looplab/eventhorizon"
+	"github.com/looplab/eventhorizon/uuid"
 )
 
 // QueryHandler returns one or all items from a eventhorizon.ReadRepo. If the

--- a/matcher_test.go
+++ b/matcher_test.go
@@ -18,7 +18,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
+	"github.com/looplab/eventhorizon/uuid"
 )
 
 func TestMatchEvents(t *testing.T) {

--- a/middleware/commandhandler/async/middleware_test.go
+++ b/middleware/commandhandler/async/middleware_test.go
@@ -21,9 +21,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
 	eh "github.com/looplab/eventhorizon"
 	"github.com/looplab/eventhorizon/mocks"
+	"github.com/looplab/eventhorizon/uuid"
 )
 
 func TestCommandHandler(t *testing.T) {

--- a/middleware/commandhandler/scheduler/middleware_test.go
+++ b/middleware/commandhandler/scheduler/middleware_test.go
@@ -21,9 +21,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
 	eh "github.com/looplab/eventhorizon"
 	"github.com/looplab/eventhorizon/mocks"
+	"github.com/looplab/eventhorizon/uuid"
 )
 
 func TestCommandHandler_Immediate(t *testing.T) {

--- a/middleware/commandhandler/validator/middleware_test.go
+++ b/middleware/commandhandler/validator/middleware_test.go
@@ -20,9 +20,9 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/google/uuid"
 	eh "github.com/looplab/eventhorizon"
 	"github.com/looplab/eventhorizon/mocks"
+	"github.com/looplab/eventhorizon/uuid"
 )
 
 func TestCommandHandler_Immediate(t *testing.T) {

--- a/middleware/eventhandler/async/middleware_test.go
+++ b/middleware/eventhandler/async/middleware_test.go
@@ -21,9 +21,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
 	eh "github.com/looplab/eventhorizon"
 	"github.com/looplab/eventhorizon/mocks"
+	"github.com/looplab/eventhorizon/uuid"
 )
 
 func TestEventHandler(t *testing.T) {

--- a/middleware/eventhandler/observer/middleware.go
+++ b/middleware/eventhandler/observer/middleware.go
@@ -18,8 +18,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/google/uuid"
 	eh "github.com/looplab/eventhorizon"
+	"github.com/looplab/eventhorizon/uuid"
 )
 
 // Group provides groupings of observers by different criteria.

--- a/middleware/eventhandler/observer/middleware_test.go
+++ b/middleware/eventhandler/observer/middleware_test.go
@@ -20,9 +20,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
 	eh "github.com/looplab/eventhorizon"
 	"github.com/looplab/eventhorizon/mocks"
+	"github.com/looplab/eventhorizon/uuid"
 )
 
 func TestEventHandler(t *testing.T) {

--- a/middleware/eventhandler/scheduler/middleware_test.go
+++ b/middleware/eventhandler/scheduler/middleware_test.go
@@ -21,9 +21,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
 	eh "github.com/looplab/eventhorizon"
 	"github.com/looplab/eventhorizon/mocks"
+	"github.com/looplab/eventhorizon/uuid"
 )
 
 func TestCommandHandler(t *testing.T) {

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
+	"github.com/looplab/eventhorizon/uuid"
 )
 
 func TestCommandHandlerMiddleware(t *testing.T) {

--- a/mocks/mocks.go
+++ b/mocks/mocks.go
@@ -19,8 +19,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/google/uuid"
 	eh "github.com/looplab/eventhorizon"
+	"github.com/looplab/eventhorizon/uuid"
 )
 
 func init() {

--- a/repo.go
+++ b/repo.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"errors"
 
-	"github.com/google/uuid"
+	"github.com/looplab/eventhorizon/uuid"
 )
 
 // ReadRepo is a read repository for entities.

--- a/repo/acceptance_testing.go
+++ b/repo/acceptance_testing.go
@@ -20,9 +20,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
 	eh "github.com/looplab/eventhorizon"
 	"github.com/looplab/eventhorizon/mocks"
+	"github.com/looplab/eventhorizon/uuid"
 )
 
 // AcceptanceTest is the acceptance test that all implementations of Repo

--- a/repo/cache/repo.go
+++ b/repo/cache/repo.go
@@ -19,8 +19,8 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/google/uuid"
 	eh "github.com/looplab/eventhorizon"
+	"github.com/looplab/eventhorizon/uuid"
 )
 
 type namespace string

--- a/repo/memory/repo.go
+++ b/repo/memory/repo.go
@@ -20,9 +20,8 @@ import (
 	"errors"
 	"sync"
 
-	"github.com/google/uuid"
-
 	eh "github.com/looplab/eventhorizon"
+	"github.com/looplab/eventhorizon/uuid"
 )
 
 type namespace string

--- a/repo/mongodb/repo.go
+++ b/repo/mongodb/repo.go
@@ -19,7 +19,6 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/google/uuid"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
@@ -32,6 +31,7 @@ import (
 	_ "github.com/looplab/eventhorizon/codec/bson"
 
 	eh "github.com/looplab/eventhorizon"
+	"github.com/looplab/eventhorizon/uuid"
 )
 
 var (

--- a/repo/mongodb/repo_test.go
+++ b/repo/mongodb/repo_test.go
@@ -24,13 +24,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
 
 	eh "github.com/looplab/eventhorizon"
 	"github.com/looplab/eventhorizon/mocks"
 	"github.com/looplab/eventhorizon/repo"
+	"github.com/looplab/eventhorizon/uuid"
 )
 
 func TestReadRepoIntegration(t *testing.T) {

--- a/repo/tracing/repo.go
+++ b/repo/tracing/repo.go
@@ -17,10 +17,11 @@ package tracing
 import (
 	"context"
 
-	"github.com/google/uuid"
-	eh "github.com/looplab/eventhorizon"
 	"github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/ext"
+
+	eh "github.com/looplab/eventhorizon"
+	"github.com/looplab/eventhorizon/uuid"
 )
 
 // Repo is a ReadWriteRepo that adds tracing.

--- a/repo/version/repo.go
+++ b/repo/version/repo.go
@@ -18,9 +18,10 @@ import (
 	"context"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/jpillora/backoff"
+
 	eh "github.com/looplab/eventhorizon"
+	"github.com/looplab/eventhorizon/uuid"
 )
 
 // Repo is a middleware that adds version checking to a read repository.

--- a/repo/version/repo_test.go
+++ b/repo/version/repo_test.go
@@ -21,11 +21,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
 	eh "github.com/looplab/eventhorizon"
 	"github.com/looplab/eventhorizon/mocks"
 	"github.com/looplab/eventhorizon/repo"
 	"github.com/looplab/eventhorizon/repo/memory"
+	"github.com/looplab/eventhorizon/uuid"
 )
 
 // NOTE: Not named "Integration" to enable running with the unit tests.

--- a/uuid/uuid.go
+++ b/uuid/uuid.go
@@ -1,0 +1,27 @@
+// Package UUID provides an easy to replace UUID package.
+// Forks of Event Horizon can re-implement this package with a UUID library of choice.
+package uuid
+
+import "github.com/google/uuid"
+
+// UUID is an alias type for github.com/google/uuid.UUID
+type UUID = uuid.UUID
+
+// Nil is an empty UUID.
+var Nil = UUID(uuid.Nil)
+
+// New creates a new UUID.
+func New() UUID {
+	return UUID(uuid.New())
+}
+
+// Parse parses a UUID from a string, or returns an error.
+func Parse(s string) (UUID, error) {
+	id, err := uuid.Parse(s)
+	return UUID(id), err
+}
+
+// MustParse parses a UUID from a string, or panics.
+func MustParse(s string) UUID {
+	return UUID(uuid.MustParse(s))
+}


### PR DESCRIPTION
### Description

Add UUID alias type for easier replacement of the whole UUID package. A fork of Event Horizon only needs to provide the functions inside the uuid package. This seems to be the next-best solution to have configurable ID types until generic lands.

### Affected Components

- UUID type

### Related Issues

### Solution and Design

### Steps to test and verify
