### PR TITLE
Feature / Separate namespace support

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ See the example folder for a few examples to get you started.
 - Cache - Adds support for in-memory caching of entities from an underlying repo.
 - Tracing - Adds distributed tracing support to an repo operations with OpenTracing.
 
-## Development
+# Development
 
 To develop Event Horizon you need to have Docker and Docker Compose installed.
 

--- a/context_test.go
+++ b/context_test.go
@@ -16,42 +16,8 @@ package eventhorizon
 
 import (
 	"context"
-	"encoding/json"
 	"testing"
 )
-
-func TestContextNamespace(t *testing.T) {
-	ctx := context.Background()
-
-	if ns := NamespaceFromContext(ctx); ns != DefaultNamespace {
-		t.Error("the namespace should be the default:", ns)
-	}
-
-	ctx = NewContextWithNamespace(ctx, "ns")
-	if ns := NamespaceFromContext(ctx); ns != "ns" {
-		t.Error("the namespace should be correct:", ns)
-	}
-
-	vals := MarshalContext(ctx)
-	if ns, ok := vals[namespaceKeyStr].(string); !ok || ns != "ns" {
-		t.Error("the marshaled namespace should be correct:", ns)
-	}
-	b, err := json.Marshal(vals)
-	if err != nil {
-		t.Error("could not marshal JSON:", err)
-	}
-
-	// Marshal via JSON to get more realistic testing.
-
-	vals = map[string]interface{}{}
-	if err := json.Unmarshal(b, &vals); err != nil {
-		t.Error("could not unmarshal JSON:", err)
-	}
-	ctx = UnmarshalContext(context.Background(), vals)
-	if ns := NamespaceFromContext(ctx); ns != "ns" {
-		t.Error("the namespace should be correct:", ns)
-	}
-}
 
 func TestContextMarshaler(t *testing.T) {
 	if len(contextMarshalFuncs) != 1 {

--- a/eventhandler.go
+++ b/eventhandler.go
@@ -66,8 +66,6 @@ type CouldNotHandleEventError struct {
 	Err error
 	// Event is the event that failed to be handled.
 	Event Event
-	// Namespace is the namespace for the error.
-	Namespace string
 }
 
 // Error implements the Error method of the errors.Error interface.
@@ -76,11 +74,7 @@ func (e CouldNotHandleEventError) Error() string {
 	if e.Event != nil {
 		eventStr += " '" + e.Event.String() + "'"
 	}
-	errStr := fmt.Sprintf("could not handle event%s: %s", eventStr, e.Err)
-	if e.Namespace != "" {
-		errStr += " (" + e.Namespace + ")"
-	}
-	return errStr
+	return fmt.Sprintf("could not handle event%s: %s", eventStr, e.Err)
 }
 
 // Unwrap implements the errors.Unwrap method.

--- a/eventhandler/projector/eventhandler.go
+++ b/eventhandler/projector/eventhandler.go
@@ -51,14 +51,12 @@ func (t Type) String() string {
 	return string(t)
 }
 
-// Error is an error in the projector, with the namespace.
+// Error is an error in the projector.
 type Error struct {
 	// Err is the error that happened when projecting the event.
 	Err error
 	// Projector is the projector where the error happened.
 	Projector string
-	// Namespace is the namespace for the error.
-	Namespace string
 	// EventVersion is the version of the event.
 	EventVersion int
 	// EntityVersion is the version of the entity.
@@ -67,8 +65,8 @@ type Error struct {
 
 // Error implements the Error method of the errors.Error interface.
 func (e Error) Error() string {
-	return fmt.Sprintf("%s: %s, event: v%d, entity: v%d (%s)",
-		e.Projector, e.Err, e.EventVersion, e.EntityVersion, e.Namespace)
+	return fmt.Sprintf("%s: %s, event: v%d, entity: v%d",
+		e.Projector, e.Err, e.EventVersion, e.EntityVersion)
 }
 
 // Unwrap implements the errors.Unwrap method.
@@ -129,7 +127,6 @@ func (h *EventHandler) HandleEvent(ctx context.Context, event eh.Event) error {
 			return Error{
 				Err:          ErrModelNotSet,
 				Projector:    h.projector.ProjectorType().String(),
-				Namespace:    eh.NamespaceFromContext(ctx),
 				EventVersion: event.Version(),
 			}
 		}
@@ -138,7 +135,6 @@ func (h *EventHandler) HandleEvent(ctx context.Context, event eh.Event) error {
 		return Error{
 			Err:          err,
 			Projector:    h.projector.ProjectorType().String(),
-			Namespace:    eh.NamespaceFromContext(ctx),
 			EventVersion: event.Version(),
 		}
 	}
@@ -157,7 +153,6 @@ func (h *EventHandler) HandleEvent(ctx context.Context, event eh.Event) error {
 			return Error{
 				Err:           eh.ErrIncorrectEntityVersion,
 				Projector:     h.projector.ProjectorType().String(),
-				Namespace:     eh.NamespaceFromContext(ctx),
 				EventVersion:  event.Version(),
 				EntityVersion: entityVersion,
 			}
@@ -170,7 +165,6 @@ func (h *EventHandler) HandleEvent(ctx context.Context, event eh.Event) error {
 		return Error{
 			Err:           err,
 			Projector:     h.projector.ProjectorType().String(),
-			Namespace:     eh.NamespaceFromContext(ctx),
 			EventVersion:  event.Version(),
 			EntityVersion: entityVersion,
 		}
@@ -183,7 +177,6 @@ func (h *EventHandler) HandleEvent(ctx context.Context, event eh.Event) error {
 			return Error{
 				Err:           eh.ErrIncorrectEntityVersion,
 				Projector:     h.projector.ProjectorType().String(),
-				Namespace:     eh.NamespaceFromContext(ctx),
 				EventVersion:  event.Version(),
 				EntityVersion: entityVersion,
 			}
@@ -196,7 +189,6 @@ func (h *EventHandler) HandleEvent(ctx context.Context, event eh.Event) error {
 			return Error{
 				Err:           err,
 				Projector:     h.projector.ProjectorType().String(),
-				Namespace:     eh.NamespaceFromContext(ctx),
 				EventVersion:  event.Version(),
 				EntityVersion: entityVersion,
 			}
@@ -206,7 +198,6 @@ func (h *EventHandler) HandleEvent(ctx context.Context, event eh.Event) error {
 			return Error{
 				Err:           err,
 				Projector:     h.projector.ProjectorType().String(),
-				Namespace:     eh.NamespaceFromContext(ctx),
 				EventVersion:  event.Version(),
 				EntityVersion: entityVersion,
 			}

--- a/eventhandler/projector/eventhandler_test.go
+++ b/eventhandler/projector/eventhandler_test.go
@@ -257,7 +257,6 @@ func TestEventHandler_LoadError(t *testing.T) {
 	expectedErr := Error{
 		Err:          loadErr,
 		Projector:    TestProjectorType.String(),
-		Namespace:    eh.NamespaceFromContext(ctx),
 		EventVersion: 1,
 	}
 	err := handler.HandleEvent(ctx, event)
@@ -287,7 +286,6 @@ func TestEventHandler_SaveError(t *testing.T) {
 	expectedErr := Error{
 		Err:          saveErr,
 		Projector:    TestProjectorType.String(),
-		Namespace:    eh.NamespaceFromContext(ctx),
 		EventVersion: 1,
 	}
 	err := handler.HandleEvent(ctx, event)
@@ -317,7 +315,6 @@ func TestEventHandler_ProjectError(t *testing.T) {
 	expectedErr := Error{
 		Err:          projectErr,
 		Projector:    TestProjectorType.String(),
-		Namespace:    eh.NamespaceFromContext(ctx),
 		EventVersion: 1,
 	}
 	err := handler.HandleEvent(ctx, event)

--- a/eventhandler/saga/eventhandler.go
+++ b/eventhandler/saga/eventhandler.go
@@ -49,20 +49,17 @@ func (t Type) String() string {
 	return string(t)
 }
 
-// Error is an error in the projector, with the namespace.
+// Error is an error in the projector.
 type Error struct {
 	// Err is the error that happened when projecting the event.
 	Err error
 	// Saga is the saga where the error happened.
 	Saga string
-	// Namespace is the namespace for the error.
-	Namespace string
 }
 
 // Error implements the Error method of the errors.Error interface.
 func (e Error) Error() string {
-	return fmt.Sprintf("%s: %s (%s)",
-		e.Saga, e.Err, e.Namespace)
+	return fmt.Sprintf("%s: %s", e.Saga, e.Err)
 }
 
 // Unwrap implements the errors.Unwrap method.
@@ -93,9 +90,8 @@ func (h *EventHandler) HandleEvent(ctx context.Context, event eh.Event) error {
 	// Run the saga which can issue commands on the provided command handler.
 	if err := h.saga.RunSaga(ctx, event, h.commandHandler); err != nil {
 		return Error{
-			Err:       err,
-			Saga:      h.saga.SagaType().String(),
-			Namespace: eh.NamespaceFromContext(ctx),
+			Err:  err,
+			Saga: h.saga.SagaType().String(),
 		}
 	}
 

--- a/eventstore.go
+++ b/eventstore.go
@@ -30,14 +30,12 @@ type EventStore interface {
 	Load(context.Context, uuid.UUID) ([]Event, error)
 }
 
-// EventStoreError is an error in the event store, with the namespace.
+// EventStoreError is an error in the event store.
 type EventStoreError struct {
 	// Err is the error.
 	Err error
 	// BaseErr is an optional underlying error, for example from the DB driver.
 	BaseErr error
-	// Namespace is the namespace for the error.
-	Namespace string
 }
 
 // Error implements the Error method of the errors.Error interface.
@@ -46,7 +44,7 @@ func (e EventStoreError) Error() string {
 	if e.BaseErr != nil {
 		errStr += ": " + e.BaseErr.Error()
 	}
-	return errStr + " (" + e.Namespace + ")"
+	return errStr
 }
 
 // Unwrap implements the errors.Unwrap method.

--- a/eventstore/acceptanece_testing.go
+++ b/eventstore/acceptanece_testing.go
@@ -31,12 +31,11 @@ import (
 // implementation:
 //
 //   func TestEventStore(t *testing.T) {
-//       ctx := context.Background() // Or other when testing namespaces.
 //       store := NewEventStore()
-//       eventstore.AcceptanceTest(t, ctx, store)
+//       eventstore.AcceptanceTest(t, store, context.Background())
 //   }
 //
-func AcceptanceTest(t *testing.T, ctx context.Context, store eh.EventStore) []eh.Event {
+func AcceptanceTest(t *testing.T, store eh.EventStore, ctx context.Context) []eh.Event {
 	savedEvents := []eh.Event{}
 
 	type contextKey string

--- a/eventstore/maintenance_testing.go
+++ b/eventstore/maintenance_testing.go
@@ -29,12 +29,11 @@ import (
 // case in each implementation:
 //
 //   func TestEventStore(t *testing.T) {
-//       ctx := context.Background() // Or other when testing namespaces.
 //       store := NewEventStore()
-//       eventstore.AcceptanceTest(t, ctx, store)
+//       eventstore.AcceptanceTest(t, store, context.Background())
 //   }
 //
-func MaintenanceAcceptanceTest(t *testing.T, ctx context.Context, store eh.EventStore, storeMaintenance eh.EventStoreMaintenance) {
+func MaintenanceAcceptanceTest(t *testing.T, store eh.EventStore, storeMaintenance eh.EventStoreMaintenance, ctx context.Context) {
 	type contextKey string
 	ctx = context.WithValue(ctx, contextKey("testkey"), "testval")
 

--- a/eventstore/memory/eventmaintenance_test.go
+++ b/eventstore/memory/eventmaintenance_test.go
@@ -30,5 +30,5 @@ func TestEventStoreMaintenance(t *testing.T) {
 		t.Fatal("there should be a store")
 	}
 
-	eventstore.MaintenanceAcceptanceTest(t, context.Background(), store, store)
+	eventstore.MaintenanceAcceptanceTest(t, store, store, context.Background())
 }

--- a/eventstore/memory/eventstore_test.go
+++ b/eventstore/memory/eventstore_test.go
@@ -34,10 +34,7 @@ func TestEventStore(t *testing.T) {
 		t.Fatal("there should be a store")
 	}
 
-	// Run the actual test suite, both for default and custom namespace.
-	eventstore.AcceptanceTest(t, context.Background(), store)
-	ctx := eh.NewContextWithNamespace(context.Background(), "ns")
-	eventstore.AcceptanceTest(t, ctx, store)
+	eventstore.AcceptanceTest(t, store, context.Background())
 }
 
 func TestWithEventHandler(t *testing.T) {

--- a/eventstore/mongodb/eventmaintenance_test.go
+++ b/eventstore/mongodb/eventmaintenance_test.go
@@ -53,6 +53,5 @@ func TestEventStoreMaintenanceIntegration(t *testing.T) {
 	}
 	defer store.Close(context.Background())
 
-	// Additional tests for the maintenance, implemented by the store.
-	eventstore.MaintenanceAcceptanceTest(t, context.Background(), store, store)
+	eventstore.MaintenanceAcceptanceTest(t, store, store, context.Background())
 }

--- a/eventstore/mongodb/eventstore_test.go
+++ b/eventstore/mongodb/eventstore_test.go
@@ -57,11 +57,7 @@ func TestEventStoreIntegration(t *testing.T) {
 	}
 	defer store.Close(context.Background())
 
-	customNamespaceCtx := eh.NewContextWithNamespace(context.Background(), "ns")
-
-	// Run the actual test suite, both for default and custom namespace.
-	eventstore.AcceptanceTest(t, context.Background(), store)
-	eventstore.AcceptanceTest(t, customNamespaceCtx, store)
+	eventstore.AcceptanceTest(t, store, context.Background())
 }
 
 func TestWithEventHandlerIntegration(t *testing.T) {

--- a/eventstore/mongodb_v2/eventmaintenance_test.go
+++ b/eventstore/mongodb_v2/eventmaintenance_test.go
@@ -53,6 +53,5 @@ func TestEventStoreMaintenanceIntegration(t *testing.T) {
 	}
 	defer store.Close(context.Background())
 
-	// Additional tests for the maintenance, implemented by the store.
-	eventstore.MaintenanceAcceptanceTest(t, context.Background(), store, store)
+	eventstore.MaintenanceAcceptanceTest(t, store, store, context.Background())
 }

--- a/eventstore/mongodb_v2/eventstore.go
+++ b/eventstore/mongodb_v2/eventstore.go
@@ -36,7 +36,6 @@ import (
 // EventStore is an eventhorizon.EventStore for MongoDB, using one collection
 // for all events and another to keep track of all aggregates/streams. It also
 // keep tracks of the global position of events, stored as metadata.
-// NOTE: This event store has NO namespace support.
 type EventStore struct {
 	client       *mongo.Client
 	events       *mongo.Collection

--- a/eventstore/mongodb_v2/eventstore_test.go
+++ b/eventstore/mongodb_v2/eventstore_test.go
@@ -58,8 +58,7 @@ func TestEventStoreIntegration(t *testing.T) {
 
 	defer store.Close(context.Background())
 
-	// Run the actual test suite.
-	eventstore.AcceptanceTest(t, context.Background(), store)
+	eventstore.AcceptanceTest(t, store, context.Background())
 }
 
 func TestWithEventHandlerIntegration(t *testing.T) {

--- a/eventstore/recorder/eventstore_test.go
+++ b/eventstore/recorder/eventstore_test.go
@@ -39,7 +39,7 @@ func TestEventStore(t *testing.T) {
 
 	// Run the actual test suite, with recording enabled.
 	store.StartRecording()
-	savedEvents := eventstore.AcceptanceTest(t, context.Background(), store)
+	savedEvents := eventstore.AcceptanceTest(t, store, context.Background())
 	store.StopRecording()
 
 	record := store.GetRecord()

--- a/examples/guestlist/memory/memory_test.go
+++ b/examples/guestlist/memory/memory_test.go
@@ -59,10 +59,8 @@ func Example() {
 	guestListRepo := memory.NewRepo()
 	guestListRepo.SetEntityFactory(func() eh.Entity { return &guestlist.GuestList{} })
 
-	// Set the namespace to use.
-	ctx, cancel := context.WithCancel(
-		eh.NewContextWithNamespace(context.Background(), "simple"),
-	)
+	// Create a context with cancellation.
+	ctx, cancel := context.WithCancel(context.Background())
 
 	// Setup a test utility waiter that waits for all 11 events to occur before
 	// evaluating results.

--- a/examples/guestlist/mongodb/mongodb_test.go
+++ b/examples/guestlist/mongodb/mongodb_test.go
@@ -88,10 +88,8 @@ guest list: 4 invited - 3 accepted, 1 declined - 2 confirmed, 1 denied`)
 	}
 	guestListRepo.SetEntityFactory(func() eh.Entity { return &guestlist.GuestList{} })
 
-	// Set the namespace to use.
-	ctx, cancel := context.WithCancel(
-		eh.NewContextWithNamespace(context.Background(), "mongodb"),
-	)
+	// Create a context with cancellation.
+	ctx, cancel := context.WithCancel(context.Background())
 
 	// Setup a test utility waiter that waits for all 11 events to occur before
 	// evaluating results.

--- a/examples/todomvc/backend/domains/todo/setup.go
+++ b/examples/todomvc/backend/domains/todo/setup.go
@@ -23,11 +23,11 @@ func SetupDomain(
 ) error {
 
 	// Set the entity factory for the base repo.
-	if repo := memory.Repository(repo); repo != nil {
-		repo.SetEntityFactory(func() eh.Entity { return &TodoList{} })
+	if memoryRepo := memory.IntoRepo(ctx, repo); memoryRepo != nil {
+		memoryRepo.SetEntityFactory(func() eh.Entity { return &TodoList{} })
 	}
-	if repo := mongodb.Repository(repo); repo != nil {
-		repo.SetEntityFactory(func() eh.Entity { return &TodoList{} })
+	if mongodbRepo := mongodb.IntoRepo(ctx, repo); mongodbRepo != nil {
+		mongodbRepo.SetEntityFactory(func() eh.Entity { return &TodoList{} })
 	}
 
 	// Create the read model projector.

--- a/examples/todomvc/backend/handler/handler_test.go
+++ b/examples/todomvc/backend/handler/handler_test.go
@@ -84,8 +84,8 @@ func TestGetAll(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Error("the status should be correct:", w.Code)
 	}
-	if string(w.Body.Bytes()) != `[]` {
-		t.Error("the body should be correct:", string(w.Body.Bytes()))
+	if w.Body.String() != `[]` {
+		t.Error("the body should be correct:", w.Body.String())
 	}
 
 	id := uuid.New()
@@ -115,8 +115,8 @@ func TestGetAll(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Error("the status should be correct:", w.Code)
 	}
-	if string(w.Body.Bytes()) != `[{"id":"`+id.String()+`","version":2,"items":[{"id":0,"desc":"desc","completed":false}],"created_at":"`+todo.TimeNow().Format(time.RFC3339Nano)+`","updated_at":"`+todo.TimeNow().Format(time.RFC3339Nano)+`"}]` {
-		t.Error("the body should be correct:", string(w.Body.Bytes()))
+	if w.Body.String() != `[{"id":"`+id.String()+`","version":2,"items":[{"id":0,"desc":"desc","completed":false}],"created_at":"`+todo.TimeNow().Format(time.RFC3339Nano)+`","updated_at":"`+todo.TimeNow().Format(time.RFC3339Nano)+`"}]` {
+		t.Error("the body should be correct:", w.Body.String())
 	}
 
 	// Cancel all handlers and wait.
@@ -146,8 +146,8 @@ func TestCreate(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Error("the status should be correct:", w.Code)
 	}
-	if string(w.Body.Bytes()) != `` {
-		t.Error("the body should be correct:", string(w.Body.Bytes()))
+	if w.Body.Len() != 0 {
+		t.Error("the body should be correct:", w.Body.String())
 	}
 
 	waiter := waiter.NewEventHandler()
@@ -212,8 +212,8 @@ func TestDelete(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Error("the status should be correct:", w.Code)
 	}
-	if string(w.Body.Bytes()) != `` {
-		t.Error("the body should be correct:", string(w.Body.Bytes()))
+	if w.Body.Len() != 0 {
+		t.Error("the body should be correct:", w.Body.String())
 	}
 
 	waiter := waiter.NewEventHandler()
@@ -264,8 +264,8 @@ func TestAddItem(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Error("the status should be correct:", w.Code)
 	}
-	if string(w.Body.Bytes()) != `` {
-		t.Error("the body should be correct:", string(w.Body.Bytes()))
+	if w.Body.Len() != 0 {
+		t.Error("the body should be correct:", w.Body.String())
 	}
 
 	waiter := waiter.NewEventHandler()
@@ -341,8 +341,8 @@ func TestRemoveItem(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Error("the status should be correct:", w.Code)
 	}
-	if string(w.Body.Bytes()) != `` {
-		t.Error("the body should be correct:", string(w.Body.Bytes()))
+	if w.Body.Len() != 0 {
+		t.Error("the body should be correct:", w.Body.String())
 	}
 
 	waiter := waiter.NewEventHandler()
@@ -426,8 +426,8 @@ func TestRemoveCompleted(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Error("the status should be correct:", w.Code)
 	}
-	if string(w.Body.Bytes()) != `` {
-		t.Error("the body should be correct:", string(w.Body.Bytes()))
+	if w.Body.Len() != 0 {
+		t.Error("the body should be correct:", w.Body.String())
 	}
 
 	waiter := waiter.NewEventHandler()
@@ -505,8 +505,8 @@ func TestSetItemDesc(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Error("the status should be correct:", w.Code)
 	}
-	if string(w.Body.Bytes()) != `` {
-		t.Error("the body should be correct:", string(w.Body.Bytes()))
+	if w.Body.Len() != 0 {
+		t.Error("the body should be correct:", w.Body.String())
 	}
 
 	waiter := waiter.NewEventHandler()
@@ -588,8 +588,8 @@ func TestCheckItem(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Error("the status should be correct:", w.Code)
 	}
-	if string(w.Body.Bytes()) != `` {
-		t.Error("the body should be correct:", string(w.Body.Bytes()))
+	if w.Body.Len() != 0 {
+		t.Error("the body should be correct:", w.Body.String())
 	}
 
 	waiter := waiter.NewEventHandler()
@@ -676,8 +676,8 @@ func TestCheckAllItems(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Error("the status should be correct:", w.Code)
 	}
-	if string(w.Body.Bytes()) != `` {
-		t.Error("the body should be correct:", string(w.Body.Bytes()))
+	if w.Body.Len() != 0 {
+		t.Error("the body should be correct:", w.Body.String())
 	}
 
 	waiter := waiter.NewEventHandler()

--- a/examples/todomvc/backend/handler/handler_test.go
+++ b/examples/todomvc/backend/handler/handler_test.go
@@ -791,11 +791,11 @@ func NewIntegrationTestSession(ctx context.Context) (
 	todoRepo := version.NewRepo(repo)
 
 	// NOTE: Temp clear of DB on startup.
-	mongoRepo, ok := todoRepo.Parent().(*mongodb.Repo)
-	if !ok {
+	mongodbRepo := mongodb.IntoRepo(ctx, todoRepo)
+	if mongodbRepo == nil {
 		log.Fatal("incorrect repo type")
 	}
-	if err := mongoRepo.Clear(ctx); err != nil {
+	if err := mongodbRepo.Clear(ctx); err != nil {
 		log.Println("could not clear DB:", err)
 	}
 

--- a/mocks/mocks.go
+++ b/mocks/mocks.go
@@ -381,8 +381,8 @@ type Repo struct {
 
 var _ = eh.ReadWriteRepo(&Repo{})
 
-// Parent implements the Parent method of the eventhorizon.ReadRepo interface.
-func (r *Repo) Parent() eh.ReadRepo {
+// InnerRepo implements the InnerRepo method of the eventhorizon.ReadRepo interface.
+func (r *Repo) InnerRepo(ctx context.Context) eh.ReadRepo {
 	return r.ParentRepo
 }
 

--- a/namespace/context.go
+++ b/namespace/context.go
@@ -1,0 +1,63 @@
+// Copyright (c) 2021 - The Event Horizon authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package namespace
+
+import (
+	"context"
+
+	eh "github.com/looplab/eventhorizon"
+)
+
+// DefaultNamespace is the namespace to use if not set in the context.
+const DefaultNamespace = "default"
+
+// Strings used to marshal context values.
+const (
+	namespaceKeyStr = "eh_namespace"
+)
+
+func init() {
+	eh.RegisterContextMarshaler(func(ctx context.Context, vals map[string]interface{}) {
+		if ns, ok := ctx.Value(namespaceKey).(string); ok {
+			vals[namespaceKeyStr] = ns
+		}
+	})
+	eh.RegisterContextUnmarshaler(func(ctx context.Context, vals map[string]interface{}) context.Context {
+		if ns, ok := vals[namespaceKeyStr].(string); ok {
+			ctx = NewContext(ctx, ns)
+		}
+		return ctx
+	})
+}
+
+type contextKey int
+
+const (
+	namespaceKey contextKey = iota
+)
+
+// FromContext returns the namespace from the context, or the default namespace.
+func FromContext(ctx context.Context) string {
+	if ns, ok := ctx.Value(namespaceKey).(string); ok {
+		return ns
+	}
+	return DefaultNamespace
+}
+
+// NewContext sets the namespace to use in the context. The namespace is used to
+// determine which database to use, among other things.
+func NewContext(ctx context.Context, namespace string) context.Context {
+	return context.WithValue(ctx, namespaceKey, namespace)
+}

--- a/namespace/context_test.go
+++ b/namespace/context_test.go
@@ -1,0 +1,56 @@
+// Copyright (c) 2021 - The Event Horizon authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package namespace
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	eh "github.com/looplab/eventhorizon"
+)
+
+func TestContext(t *testing.T) {
+	ctx := context.Background()
+
+	if ns := FromContext(ctx); ns != DefaultNamespace {
+		t.Error("the namespace should be the default:", ns)
+	}
+
+	ctx = NewContext(ctx, "ns")
+	if ns := FromContext(ctx); ns != "ns" {
+		t.Error("the namespace should be correct:", ns)
+	}
+
+	vals := eh.MarshalContext(ctx)
+	if ns, ok := vals[namespaceKeyStr].(string); !ok || ns != "ns" {
+		t.Error("the marshaled namespace should be correct:", ns)
+	}
+	b, err := json.Marshal(vals)
+	if err != nil {
+		t.Error("could not marshal JSON:", err)
+	}
+
+	// Marshal via JSON to get more realistic testing.
+
+	vals = map[string]interface{}{}
+	if err := json.Unmarshal(b, &vals); err != nil {
+		t.Error("could not unmarshal JSON:", err)
+	}
+	ctx = eh.UnmarshalContext(context.Background(), vals)
+	if ns := FromContext(ctx); ns != "ns" {
+		t.Error("the namespace should be correct:", ns)
+	}
+}

--- a/namespace/error.go
+++ b/namespace/error.go
@@ -1,0 +1,41 @@
+// Copyright (c) 2021 - The Event Horizon authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package namespace
+
+import "fmt"
+
+// Error is an error that contains info about in which name space the underlying
+// error occurred.
+type Error struct {
+	// Err is the error.
+	Err error
+	// Namespace is the namespace for the error.
+	Namespace string
+}
+
+// Error implements the Error method of the errors.Error interface.
+func (e Error) Error() string {
+	return fmt.Sprintf("%s (%s)", e.Err, e.Namespace)
+}
+
+// Unwrap implements the errors.Unwrap method.
+func (e Error) Unwrap() error {
+	return e.Err
+}
+
+// Cause implements the github.com/pkg/errors Unwrap method.
+func (e Error) Cause() error {
+	return e.Unwrap()
+}

--- a/namespace/eventstore.go
+++ b/namespace/eventstore.go
@@ -1,0 +1,102 @@
+// Copyright (c) 2021 - The Event Horizon authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package namespace
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	eh "github.com/looplab/eventhorizon"
+	"github.com/looplab/eventhorizon/uuid"
+)
+
+// EventStore is an event store with support for namespaces passed in the context.
+type EventStore struct {
+	eventStores   map[string]eh.EventStore
+	eventStoresMu sync.RWMutex
+	newEventStore func(ns string) (eh.EventStore, error)
+}
+
+// NewEventStore creates a new event store which will use the provided factory
+// function to create new event stores for the provided namespace.
+//
+// Usage:
+//    eventStore := NewEventStore(func(ns string) (eh.EventStore, error) {
+//        s, err := mongodb.NewEventStore("mongodb://", ns)
+//        if err != nil {
+//            return nil, err
+//        }
+//        return s, nil
+//    })
+//
+// Usage shared DB client:
+//    client, err := mongo.Connect(ctx)
+//    ...
+//
+//    eventStore := NewEventStore(func(ns string) (eh.EventStore, error) {
+//        s, err := mongodb.NewEventStoreWithClient(client, ns)
+//        if err != nil {
+//            return nil, err
+//        }
+//        return s, nil
+//    })
+func NewEventStore(factory func(ns string) (eh.EventStore, error)) *EventStore {
+	return &EventStore{
+		eventStores:   map[string]eh.EventStore{},
+		newEventStore: factory,
+	}
+}
+
+// Save implements the Save method of the eventhorizon.EventStore interface.
+func (s *EventStore) Save(ctx context.Context, events []eh.Event, originalVersion int) error {
+	store, err := s.eventStore(ctx)
+	if err != nil {
+		return err
+	}
+	return store.Save(ctx, events, originalVersion)
+}
+
+// Load implements the Load method of the eventhorizon.EventStore interface.
+func (s *EventStore) Load(ctx context.Context, id uuid.UUID) ([]eh.Event, error) {
+	store, err := s.eventStore(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return store.Load(ctx, id)
+}
+
+// eventStore is a helper that returns or creates event stores for each namespace.
+func (s *EventStore) eventStore(ctx context.Context) (eh.EventStore, error) {
+	ns := FromContext(ctx)
+	s.eventStoresMu.RLock()
+	eventStore, ok := s.eventStores[ns]
+	s.eventStoresMu.RUnlock()
+	if !ok {
+		s.eventStoresMu.Lock()
+		// Perform an additional existence check within the write lock in the
+		// unlikely event that someone else added the event store right before us.
+		if _, ok := s.eventStores[ns]; !ok {
+			var err error
+			eventStore, err = s.newEventStore(ns)
+			if err != nil {
+				return nil, fmt.Errorf("could not create event store for namespace '%s': %w", ns, err)
+			}
+			s.eventStores[ns] = eventStore
+		}
+		s.eventStoresMu.Unlock()
+	}
+	return eventStore, nil
+}

--- a/namespace/repo.go
+++ b/namespace/repo.go
@@ -1,0 +1,148 @@
+// Copyright (c) 2021 - The Event Horizon authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package namespace
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	eh "github.com/looplab/eventhorizon"
+	"github.com/looplab/eventhorizon/uuid"
+)
+
+// Repo is a repo with support for namespaces passed in the context.
+type Repo struct {
+	repos   map[string]eh.ReadWriteRepo
+	reposMu sync.RWMutex
+	newRepo func(ns string) (eh.ReadWriteRepo, error)
+}
+
+// NewRepo creates a new repo which will use the provided factory function to
+// create new repos for the provided namespace.
+//
+// Usage:
+//    repo := NewRepo(func(ns string) (eh.ReadWriteRepo, error) {
+//        r, err := mongodb.NewRepo("mongodb://", "db", "model")
+//        if err != nil {
+//            return nil, err
+//        }
+//        r.SetEntityFactory(func() eh.Entity{
+//            return &Model{}
+//        })
+//        return r, nil
+//    })
+//
+// Usage shared DB client:
+//    client, err := mongo.Connect(ctx)
+//    ...
+//
+//    repo := NewRepo(func(ns string) (eh.ReadWriteRepo, error) {
+//        r, err := mongodb.NewRepoWithClient(client, "db", "model")
+//        if err != nil {
+//            return nil, err
+//        }
+//        r.SetEntityFactory(func() eh.Entity{
+//            return &Model{}
+//        })
+//        return r, nil
+//    })
+func NewRepo(factory func(ns string) (eh.ReadWriteRepo, error)) *Repo {
+	return &Repo{
+		repos:   map[string]eh.ReadWriteRepo{},
+		newRepo: factory,
+	}
+}
+
+// InnerRepo implements the InnerRepo method of the eventhorizon.ReadRepo interface.
+func (r *Repo) InnerRepo(ctx context.Context) eh.ReadRepo {
+	repo, err := r.repo(ctx)
+	if err != nil {
+		// TODO: Log/handle error.
+		return nil
+	}
+	return repo
+}
+
+// IntoRepo tries to convert a eh.ReadRepo into a Repo by recursively looking at
+// inner repos. Returns nil if none was found.
+func IntoRepo(ctx context.Context, repo eh.ReadRepo) *Repo {
+	if repo == nil {
+		return nil
+	}
+	if r, ok := repo.(*Repo); ok {
+		return r
+	}
+	return IntoRepo(ctx, repo.InnerRepo(ctx))
+}
+
+// Find implements the Find method of the eventhorizon.ReadRepo interface.
+func (r *Repo) Find(ctx context.Context, id uuid.UUID) (eh.Entity, error) {
+	repo, err := r.repo(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return repo.Find(ctx, id)
+}
+
+// FindAll implements the FindAll method of the eventhorizon.ReadRepo interface.
+func (r *Repo) FindAll(ctx context.Context) ([]eh.Entity, error) {
+	repo, err := r.repo(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return repo.FindAll(ctx)
+}
+
+// Save implements the Save method of the eventhorizon.WriteRepo interface.
+func (r *Repo) Save(ctx context.Context, entity eh.Entity) error {
+	repo, err := r.repo(ctx)
+	if err != nil {
+		return err
+	}
+	return repo.Save(ctx, entity)
+}
+
+// Remove implements the Remove method of the eventhorizon.WriteRepo interface.
+func (r *Repo) Remove(ctx context.Context, id uuid.UUID) error {
+	repo, err := r.repo(ctx)
+	if err != nil {
+		return err
+	}
+	return repo.Remove(ctx, id)
+}
+
+// repo is a helper that returns or creates repos for each namespace.
+func (r *Repo) repo(ctx context.Context) (eh.ReadWriteRepo, error) {
+	ns := FromContext(ctx)
+	r.reposMu.RLock()
+	repo, ok := r.repos[ns]
+	r.reposMu.RUnlock()
+	if !ok {
+		r.reposMu.Lock()
+		// Perform an additional existence check within the write lock in the
+		// unlikely event that someone else added the repo right before us.
+		if _, ok := r.repos[ns]; !ok {
+			var err error
+			repo, err = r.newRepo(ns)
+			if err != nil {
+				return nil, fmt.Errorf("could not create repo for namespace '%s': %w", ns, err)
+			}
+			r.repos[ns] = repo
+		}
+		r.reposMu.Unlock()
+	}
+	return repo, nil
+}

--- a/namespace/repo_test.go
+++ b/namespace/repo_test.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2021 - The Event Horizon authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package namespace
+
+import (
+	"context"
+	"testing"
+
+	eh "github.com/looplab/eventhorizon"
+	"github.com/looplab/eventhorizon/mocks"
+	"github.com/looplab/eventhorizon/repo"
+	"github.com/looplab/eventhorizon/repo/memory"
+)
+
+// NOTE: Not named "Integration" to enable running with the unit tests.
+func TestReadRepo(t *testing.T) {
+	repos := map[string]eh.ReadWriteRepo{}
+
+	r := NewRepo(func(ns string) (eh.ReadWriteRepo, error) {
+		r := memory.NewRepo()
+		r.SetEntityFactory(func() eh.Entity {
+			return &mocks.Model{}
+		})
+		repos[ns] = r
+		return r, nil
+	})
+	if r == nil {
+		t.Error("there should be a repository")
+	}
+
+	// Namespaces for testing; one default and one custom.
+	defaultCtx := context.Background()
+	otherCtx := NewContext(context.Background(), "other")
+
+	// Check that repos are created on access.
+	innerDefault := r.InnerRepo(defaultCtx)
+	defaultRepo, ok := repos["default"]
+	if !ok {
+		t.Error("the default namespace should have been used")
+	}
+	if innerDefault != defaultRepo {
+		t.Error("the default repo should be correct")
+	}
+
+	innerOther := r.InnerRepo(otherCtx)
+	otherRepo, ok := repos["other"]
+	if !ok {
+		t.Error("the other namespace should have been used")
+	}
+	if innerOther != otherRepo {
+		t.Error("the other repo should be correct")
+	}
+
+	// Test both namespaces.
+	repo.AcceptanceTest(t, r, defaultCtx)
+	repo.AcceptanceTest(t, r, otherCtx)
+}

--- a/repo.go
+++ b/repo.go
@@ -23,9 +23,9 @@ import (
 
 // ReadRepo is a read repository for entities.
 type ReadRepo interface {
-	// Parent returns the parent read repository, if there is one.
+	// InnerRepo returns the inner read repository, if there is one.
 	// Useful for iterating a wrapped set of repositories to get a specific one.
-	Parent() ReadRepo
+	InnerRepo(context.Context) ReadRepo
 
 	// Find returns an entity for an ID.
 	Find(context.Context, uuid.UUID) (Entity, error)
@@ -84,14 +84,12 @@ var (
 	ErrIncorrectEntityVersion = errors.New("incorrect entity version")
 )
 
-// RepoError is an error in the read repository, with the namespace.
+// RepoError is an error in the read repository.
 type RepoError struct {
 	// Err is the error.
 	Err error
 	// BaseErr is an optional underlying error, for example from the DB driver.
 	BaseErr error
-	// Namespace is the namespace for the error.
-	Namespace string
 }
 
 // Error implements the Error method of the errors.Error interface.
@@ -100,7 +98,7 @@ func (e RepoError) Error() string {
 	if e.BaseErr != nil {
 		errStr += ": " + e.BaseErr.Error()
 	}
-	return errStr + " (" + e.Namespace + ")"
+	return errStr
 }
 
 // Unwrap implements the errors.Unwrap method.

--- a/repo/acceptance_testing.go
+++ b/repo/acceptance_testing.go
@@ -30,12 +30,11 @@ import (
 // implementation:
 //
 //   func TestRepo(t *testing.T) {
-//       ctx := context.Background() // Or other when testing namespaces.
 //       store := NewRepo()
-//       repo.AcceptanceTest(t, ctx, store)
+//       repo.AcceptanceTest(t, store, context.Background())
 //   }
 //
-func AcceptanceTest(t *testing.T, ctx context.Context, repo eh.ReadWriteRepo) {
+func AcceptanceTest(t *testing.T, repo eh.ReadWriteRepo, ctx context.Context) {
 	// Find non-existing item.
 	entity, err := repo.Find(ctx, uuid.New())
 	if rrErr, ok := err.(eh.RepoError); !ok || rrErr.Err != eh.ErrEntityNotFound {

--- a/repo/cache/repo_test.go
+++ b/repo/cache/repo_test.go
@@ -35,32 +35,26 @@ func TestReadRepo(t *testing.T) {
 	if r == nil {
 		t.Error("there should be a repository")
 	}
-	if parent := r.Parent(); parent != baseRepo {
-		t.Error("the parent repo should be correct:", parent)
+	if inner := r.InnerRepo(context.Background()); inner != baseRepo {
+		t.Error("the inner repo should be correct:", inner)
 	}
 
-	// Read repository with default namespace.
-	repo.AcceptanceTest(t, context.Background(), r)
-
-	// Read repository with other namespace.
-	ctx := eh.NewContextWithNamespace(context.Background(), "ns")
-	repo.AcceptanceTest(t, ctx, r)
-
+	repo.AcceptanceTest(t, r, context.Background())
 }
 
-func TestRepository(t *testing.T) {
-	if r := Repository(nil); r != nil {
-		t.Error("the parent repository should be nil:", r)
+func TestIntoRepo(t *testing.T) {
+	if r := IntoRepo(context.Background(), nil); r != nil {
+		t.Error("the repository should be nil:", r)
 	}
 
 	inner := &mocks.Repo{}
-	if r := Repository(inner); r != nil {
-		t.Error("the parent repository should be nil:", r)
+	if r := IntoRepo(context.Background(), inner); r != nil {
+		t.Error("the repository should be correct:", r)
 	}
 
-	r := NewRepo(inner)
-	outer := &mocks.Repo{ParentRepo: r}
-	if r := Repository(outer); r != r {
-		t.Error("the parent repository should be correct:", r)
+	middle := NewRepo(inner)
+	outer := &mocks.Repo{ParentRepo: middle}
+	if r := IntoRepo(context.Background(), outer); r != middle {
+		t.Error("the repository should be correct:", r)
 	}
 }

--- a/repo/memory/repo_test.go
+++ b/repo/memory/repo_test.go
@@ -33,32 +33,26 @@ func TestReadRepo(t *testing.T) {
 	r.SetEntityFactory(func() eh.Entity {
 		return &mocks.Model{}
 	})
-	if r.Parent() != nil {
-		t.Error("the parent repo should be nil")
+	if r.InnerRepo(context.Background()) != nil {
+		t.Error("the inner repo should be nil")
 	}
 
-	// Repo with default namespace.
-	repo.AcceptanceTest(t, context.Background(), r)
-
-	// Repo with other namespace
-	ctx := eh.NewContextWithNamespace(context.Background(), "ns")
-	repo.AcceptanceTest(t, ctx, r)
-
+	repo.AcceptanceTest(t, r, context.Background())
 }
 
-func TestRepository(t *testing.T) {
-	if r := Repository(nil); r != nil {
-		t.Error("the parent repository should be nil:", r)
+func TestIntoRepo(t *testing.T) {
+	if r := IntoRepo(context.Background(), nil); r != nil {
+		t.Error("the repository should be nil:", r)
 	}
 
-	inner := &mocks.Repo{}
-	if r := Repository(inner); r != nil {
-		t.Error("the parent repository should be nil:", r)
+	other := &mocks.Repo{}
+	if r := IntoRepo(context.Background(), other); r != nil {
+		t.Error("the repository should be correct:", r)
 	}
 
-	repo := NewRepo()
-	outer := &mocks.Repo{ParentRepo: repo}
-	if r := Repository(outer); r != repo {
-		t.Error("the parent repository should be correct:", r)
+	inner := NewRepo()
+	outer := &mocks.Repo{ParentRepo: inner}
+	if r := IntoRepo(context.Background(), outer); r != inner {
+		t.Error("the repository should be correct:", r)
 	}
 }

--- a/repo/tracing/repo_test.go
+++ b/repo/tracing/repo_test.go
@@ -35,32 +35,26 @@ func TestReadRepo(t *testing.T) {
 	if r == nil {
 		t.Error("there should be a repository")
 	}
-	if parent := r.Parent(); parent != baseRepo {
-		t.Error("the parent repo should be correct:", parent)
+	if inner := r.InnerRepo(context.Background()); inner != baseRepo {
+		t.Error("the inner repo should be correct:", inner)
 	}
 
-	// Read repository with default namespace.
-	repo.AcceptanceTest(t, context.Background(), r)
-
-	// Read repository with other namespace.
-	ctx := eh.NewContextWithNamespace(context.Background(), "ns")
-	repo.AcceptanceTest(t, ctx, r)
-
+	repo.AcceptanceTest(t, r, context.Background())
 }
 
-func TestRepository(t *testing.T) {
-	if r := Repository(nil); r != nil {
-		t.Error("the parent repository should be nil:", r)
+func TestIntoRepo(t *testing.T) {
+	if r := IntoRepo(context.Background(), nil); r != nil {
+		t.Error("the repository should be nil:", r)
 	}
 
 	inner := &mocks.Repo{}
-	if r := Repository(inner); r != nil {
-		t.Error("the parent repository should be nil:", r)
+	if r := IntoRepo(context.Background(), inner); r != nil {
+		t.Error("the repository should be correct:", r)
 	}
 
-	r := NewRepo(inner)
-	outer := &mocks.Repo{ParentRepo: r}
-	if r := Repository(outer); r != r {
-		t.Error("the parent repository should be correct:", r)
+	middle := NewRepo(inner)
+	outer := &mocks.Repo{ParentRepo: middle}
+	if r := IntoRepo(context.Background(), outer); r != middle {
+		t.Error("the repository should be correct:", r)
 	}
 }

--- a/repo/version/context.go
+++ b/repo/version/context.go
@@ -46,7 +46,6 @@ func init() {
 
 type contextKey int
 
-// Context keys for namespace and min version.
 const (
 	minVersionKey contextKey = iota
 )

--- a/repo/version/repo_test.go
+++ b/repo/version/repo_test.go
@@ -39,22 +39,17 @@ func TestReadRepo(t *testing.T) {
 	if r == nil {
 		t.Error("there should be a repository")
 	}
-	if parent := r.Parent(); parent != baseRepo {
-		t.Error("the parent repo should be correct:", parent)
+	if inner := r.InnerRepo(context.Background()); inner != baseRepo {
+		t.Error("the inner repo should be correct:", inner)
 	}
 
-	// Read repository with default namespace.
-	repo.AcceptanceTest(t, context.Background(), r)
-	extraRepoTests(t, context.Background(), r, baseRepo)
-
-	// Read repository with other namespace.
-	ctx := eh.NewContextWithNamespace(context.Background(), "ns")
-	repo.AcceptanceTest(t, ctx, r)
-	extraRepoTests(t, ctx, r, baseRepo)
-
+	repo.AcceptanceTest(t, r, context.Background())
+	extraRepoTests(t, r, baseRepo)
 }
 
-func extraRepoTests(t *testing.T, ctx context.Context, r *Repo, baseRepo *memory.Repo) {
+func extraRepoTests(t *testing.T, r *Repo, baseRepo *memory.Repo) {
+	ctx := context.Background()
+
 	// Set a model without version for the first test case.
 	// A repo should not change models mid-life like this.
 	baseRepo.SetEntityFactory(func() eh.Entity {
@@ -255,19 +250,19 @@ func extraRepoTests(t *testing.T, ctx context.Context, r *Repo, baseRepo *memory
 	}
 }
 
-func TestRepository(t *testing.T) {
-	if r := Repository(nil); r != nil {
-		t.Error("the parent repository should be nil:", r)
+func TestIntoRepo(t *testing.T) {
+	if r := IntoRepo(context.Background(), nil); r != nil {
+		t.Error("the repository should be nil:", r)
 	}
 
 	inner := &mocks.Repo{}
-	if r := Repository(inner); r != nil {
-		t.Error("the parent repository should be nil:", r)
+	if r := IntoRepo(context.Background(), inner); r != nil {
+		t.Error("the repository should be correct:", r)
 	}
 
-	repo := NewRepo(inner)
-	outer := &mocks.Repo{ParentRepo: repo}
-	if r := Repository(outer); r != repo {
-		t.Error("the parent repository should be correct:", r)
+	middle := NewRepo(inner)
+	outer := &mocks.Repo{ParentRepo: middle}
+	if r := IntoRepo(context.Background(), outer); r != middle {
+		t.Error("the repository should be correct:", r)
 	}
 }


### PR DESCRIPTION
### Description

**BEWARE: After this PR repos/event stores are created with their FULL DB NAME not prefix only, as it was before. To keep the old default DB name set it to `prefix + "_default"` when creating repos/event stores.**

Moves all namespace support to a separate package `namespace`. The package contains an event store and repo with namespace support that uses any underlying event store and repo as storage. The factory function provided in the `New...()` methods is used to create event stores/repos the first time a namespace is used.

```go
eventStore := NewEventStore(func(ns string) (eh.EventStore, error) {
	s, err := mongodb.NewEventStore("mongodb://", ns)
	if err != nil {
		return nil, err
	}
	return s, nil
})
```

### Affected Components

- Event Store
- Repo
- Context
- Errors with previous namespace support

### Related Issues

### Solution and Design

### Steps to test and verify
