### PR TITLE
don't recreate stream if it already exist

### DIFF
--- a/eventbus/jetstream/eventbus.go
+++ b/eventbus/jetstream/eventbus.go
@@ -74,6 +74,10 @@ func NewEventBus(url, appID string, options ...Option) (*EventBus, error) {
 		return nil, fmt.Errorf("could not create Jetstream context: %w", err)
 	}
 
+	if b.stream, err = b.js.StreamInfo(b.streamName); err == nil {
+		return b, nil
+	}
+
 	// Create the stream, which stores messages received on the subject.
 	subjects := b.streamName + ".*.*"
 	cfg := &nats.StreamConfig{
@@ -81,6 +85,7 @@ func NewEventBus(url, appID string, options ...Option) (*EventBus, error) {
 		Subjects: []string{subjects},
 		Storage:  nats.FileStorage,
 	}
+
 	if b.stream, err = b.js.AddStream(cfg); err != nil {
 		return nil, fmt.Errorf("could not create Jetstream stream: %w", err)
 	}


### PR DESCRIPTION
### Description

In situation where multiple writers are publishing to a shared Stream we
do not need to recreate stream that already exist. This will return a
Stream if it's found otherwise attempt to create it.

### Affected Components

- Event Bus, Jetstream

### Related Issues

None

### Solution and Design

Check that the Stream exist first. Then if it does, use it. Otherwise create a new Stream.

### Steps to test and verify
