### PR TITLE
Change "GCP" to "Kafka" in kafka event bus error message

### DIFF
--- a/eventbus/kafka/eventbus.go
+++ b/eventbus/kafka/eventbus.go
@@ -252,7 +252,7 @@ func (b *EventBus) handler(m eh.EventMatcher, h eh.EventHandler, r *kafka.Reader
 			select {
 			case b.errCh <- eh.EventBusError{Err: err, Ctx: ctx}:
 			default:
-				log.Printf("eventhorizon: missed error in GCP event bus: %s", err)
+				log.Printf("eventhorizon: missed error in Kafka event bus: %s", err)
 			}
 			return
 		}


### PR DESCRIPTION
### Description

A typo was identified in the Kafka eventbus, where an error message prints the text:

> eventhorizon: missed error in GCP event bus

This should refer to "Kafka" instead of "GCP"

### Affected Components

- Event Bus

### Related Issues

N/A 

### Solution and Design

Message has been corrected to read:

> eventhorizon: missed error in Kafka event bus

### Steps to test and verify

Trivial change, testing not required
