### PR TITLE
Use wurstmeister/kafka to support Aarch64 dev

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,21 +69,22 @@ services:
       ALLOW_ANONYMOUS_LOGIN: "yes"
 
   kafka:
-    image: bitnami/kafka:2.8.0
+    image: wurstmeister/kafka
     depends_on:
       - zookeeper
     ports:
-      - "9092:9092"
       - "9093:9093"
     environment:
       KAFKA_BROKER_ID: "1"
       KAFKA_ZOOKEEPER_CONNECT: "zookeeper:2181"
       ALLOW_PLAINTEXT_LISTENER: "yes"
-      KAFKA_CFG_LISTENERS: "INTERNAL://:9092,EXTERNAL://:9093"
-      KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP: "INTERNAL:PLAINTEXT,EXTERNAL:PLAINTEXT"
-      KAFKA_CFG_ADVERTISED_LISTENERS: "INTERNAL://kafka:9092,EXTERNAL://localhost:9093"
+      KAFKA_LISTENERS: INTERNAL://:9092,EXTERNAL://:9093
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: INTERNAL:PLAINTEXT,EXTERNAL:PLAINTEXT
+      KAFKA_ADVERTISED_LISTENERS: INTERNAL://kafka:9092,EXTERNAL://localhost:9093
       KAFKA_INTER_BROKER_LISTENER_NAME: "INTERNAL"
-      KAFKA_CFG_OFFSETS_TOPIC_NUM_PARTITIONS: "5"
+      KAFKA_OFFSETS_TOPIC_NUM_PARTITIONS: "5"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
 
   redis:
     image: redis:6.2-alpine3.13


### PR DESCRIPTION
### Description

Use wurstmeister/kafka to support Aarch64 dev by cloning https://github.com/includeno/kafka-docker and building with `docker build -t wurstmeister/kafka .`.

### Affected Components

- Event Bus (Kafka)

### Related Issues

### Solution and Design

### Steps to test and verify
