### PR TITLE
Fix / Prevent possible dead lock in memory event store

### DIFF
--- a/eventstore/recorder/eventstore_test.go
+++ b/eventstore/recorder/eventstore_test.go
@@ -42,7 +42,7 @@ func TestEventStore(t *testing.T) {
 	savedEvents := eventstore.AcceptanceTest(t, store, context.Background())
 	store.StopRecording()
 
-	record := store.GetRecord()
+	record := store.SuccessfulEvents()
 	if !reflect.DeepEqual(record, savedEvents) {
 		t.Error("there should be events recorded:", record)
 	}
@@ -50,7 +50,7 @@ func TestEventStore(t *testing.T) {
 	// And then some more recording specific testing.
 
 	store.ResetTrace()
-	record = store.GetRecord()
+	record = store.SuccessfulEvents()
 	if len(record) != 0 {
 		t.Error("there should be no events recorded:", record)
 	}
@@ -74,7 +74,7 @@ func TestEventStore(t *testing.T) {
 		t.Error("there should be no error:", err)
 	}
 	aggregate1events = append(aggregate1events, event1)
-	record = store.GetRecord()
+	record = store.SuccessfulEvents()
 	if len(record) != 0 {
 		t.Error("there should be no events recorded:", record)
 	}


### PR DESCRIPTION
### Description

Fix to prevent possible dead lock in memory event store where publishing triggers consecutive actions on the same event store (which at that point is still locked).

Also fix a possible ordering error in the recorder when secondary events are saved as a result of the event store save action (sagas etc). Similar cause as the deadlock described above but with different results.

### Affected Components

- Event Store (memory)
- Event Store (recorder)

### Related Issues

### Solution and Design

### Steps to test and verify