### PR TITLE
Fix / Add closers for graceful shutdown

### DIFF
--- a/eventbus.go
+++ b/eventbus.go
@@ -34,8 +34,8 @@ type EventBus interface {
 	// Errors returns an error channel where async handling errors are sent.
 	Errors() <-chan EventBusError
 
-	// Wait wait for all handlers to be cancelled by their context.
-	Wait()
+	// Close closes the EventBus and waits for all handlers to finish.
+	Close() error
 }
 
 // EventBusError is an async error containing the error returned from a handler

--- a/eventbus/acceptance_testing.go
+++ b/eventbus/acceptance_testing.go
@@ -64,7 +64,7 @@ func TestAddHandler(t *testing.T, bus1 eh.EventBus) {
 //   }
 //
 func AcceptanceTest(t *testing.T, bus1, bus2 eh.EventBus, timeout time.Duration) {
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx := context.Background()
 	ctx = mocks.WithContextOne(ctx, "testval")
 
 	// Without handler.
@@ -245,10 +245,14 @@ func AcceptanceTest(t *testing.T, bus1, bus2 eh.EventBus, timeout time.Duration)
 		}
 	}
 
-	// Cancel all handlers and wait.
-	cancel()
-	bus1.Wait()
-	bus2.Wait()
+	// TODO: Test context cancellation.
+
+	if err := bus1.Close(); err != nil {
+		t.Error("there should be no error:", err)
+	}
+	if err := bus2.Close(); err != nil {
+		t.Error("there should be no error:", err)
+	}
 }
 
 func checkBusErrors(t *testing.T, bus eh.EventBus) {
@@ -357,8 +361,9 @@ func benchmark(t bench, bus eh.EventBus, numAggregates, numHandlers, numEvents i
 
 	wg.Wait() // Wait for all events to be received.
 	t.StopTimer()
+	cancel() // Stop receiving goroutines.
 
-	// Cancel handler and wait.
-	cancel()
-	bus.Wait()
+	if err := bus.Close(); err != nil {
+		t.Error("there should be no error:", err)
+	}
 }

--- a/eventstore.go
+++ b/eventstore.go
@@ -28,6 +28,9 @@ type EventStore interface {
 
 	// Load loads all events for the aggregate id from the store.
 	Load(context.Context, uuid.UUID) ([]Event, error)
+
+	// Close closes the EventStore.
+	Close() error
 }
 
 // EventStoreError is an error in the event store.

--- a/eventstore/memory/eventstore.go
+++ b/eventstore/memory/eventstore.go
@@ -178,6 +178,11 @@ type aggregateRecord struct {
 	// Snapshot    eh.Aggregate
 }
 
+// Close implements the Close method of the eventhorizon.EventStore interface.
+func (s *EventStore) Close() error {
+	return nil
+}
+
 // copyEvent duplicates an event.
 func copyEvent(ctx context.Context, event eh.Event) (eh.Event, error) {
 	// Copy data if there is any.

--- a/eventstore/mongodb/eventmaintenance_test.go
+++ b/eventstore/mongodb/eventmaintenance_test.go
@@ -51,7 +51,7 @@ func TestEventStoreMaintenanceIntegration(t *testing.T) {
 	if store == nil {
 		t.Fatal("there should be a store")
 	}
-	defer store.Close(context.Background())
+	defer store.Close()
 
 	eventstore.MaintenanceAcceptanceTest(t, store, store, context.Background())
 }

--- a/eventstore/mongodb/eventstore.go
+++ b/eventstore/mongodb/eventstore.go
@@ -225,12 +225,9 @@ func (s *EventStore) Load(ctx context.Context, id uuid.UUID) ([]eh.Event, error)
 	return events, nil
 }
 
-// Close closes the database client.
-func (s *EventStore) Close(ctx context.Context) error {
-	if err := s.client.Disconnect(ctx); err != nil {
-		return fmt.Errorf("could not close DB connection: %w", err)
-	}
-	return nil
+// Close implements the Close method of the eventhorizon.EventStore interface.
+func (s *EventStore) Close() error {
+	return s.client.Disconnect(context.Background())
 }
 
 // aggregateRecord is the Database representation of an aggregate.

--- a/eventstore/mongodb/eventstore_test.go
+++ b/eventstore/mongodb/eventstore_test.go
@@ -55,7 +55,7 @@ func TestEventStoreIntegration(t *testing.T) {
 	if store == nil {
 		t.Fatal("there should be a store")
 	}
-	defer store.Close(context.Background())
+	defer store.Close()
 
 	eventstore.AcceptanceTest(t, store, context.Background())
 }
@@ -91,7 +91,7 @@ func TestWithEventHandlerIntegration(t *testing.T) {
 	if store == nil {
 		t.Fatal("there should be a store")
 	}
-	defer store.Close(context.Background())
+	defer store.Close()
 
 	ctx := context.Background()
 
@@ -159,7 +159,7 @@ func BenchmarkEventStore(b *testing.B) {
 	if store == nil {
 		b.Fatal("there should be a store")
 	}
-	defer store.Close(context.Background())
+	defer store.Close()
 
 	eventstore.Benchmark(b, store)
 }

--- a/eventstore/mongodb_v2/eventmaintenance_test.go
+++ b/eventstore/mongodb_v2/eventmaintenance_test.go
@@ -51,7 +51,7 @@ func TestEventStoreMaintenanceIntegration(t *testing.T) {
 	if store == nil {
 		t.Fatal("there should be a store")
 	}
-	defer store.Close(context.Background())
+	defer store.Close()
 
 	eventstore.MaintenanceAcceptanceTest(t, store, store, context.Background())
 }

--- a/eventstore/mongodb_v2/eventstore.go
+++ b/eventstore/mongodb_v2/eventstore.go
@@ -312,12 +312,9 @@ func (s *EventStore) Load(ctx context.Context, id uuid.UUID) ([]eh.Event, error)
 	return events, nil
 }
 
-// Close closes the database client.
-func (s *EventStore) Close(ctx context.Context) error {
-	if err := s.client.Disconnect(ctx); err != nil {
-		return fmt.Errorf("could not close DB connection: %w", err)
-	}
-	return nil
+// Close implements the Close method of the eventhorizon.EventStore interface.
+func (s *EventStore) Close() error {
+	return s.client.Disconnect(context.Background())
 }
 
 // stream is a stream of events, often containing the events for an aggregate.

--- a/eventstore/mongodb_v2/eventstore_test.go
+++ b/eventstore/mongodb_v2/eventstore_test.go
@@ -56,7 +56,7 @@ func TestEventStoreIntegration(t *testing.T) {
 		t.Fatal("there should be a store")
 	}
 
-	defer store.Close(context.Background())
+	defer store.Close()
 
 	eventstore.AcceptanceTest(t, store, context.Background())
 }
@@ -92,7 +92,7 @@ func TestWithEventHandlerIntegration(t *testing.T) {
 	if store == nil {
 		t.Fatal("there should be a store")
 	}
-	defer store.Close(context.Background())
+	defer store.Close()
 
 	ctx := context.Background()
 
@@ -164,7 +164,7 @@ func BenchmarkEventStore(b *testing.B) {
 		b.Fatal("there should be a store")
 	}
 
-	defer store.Close(context.Background())
+	defer store.Close()
 
 	eventstore.Benchmark(b, store)
 }

--- a/examples/guestlist/memory/memory_test.go
+++ b/examples/guestlist/memory/memory_test.go
@@ -163,6 +163,12 @@ func Example() {
 			l.NumGuests, l.NumAccepted, l.NumDeclined, l.NumConfirmed, l.NumDenied)
 	}
 
+	if err := invitationRepo.Close(); err != nil {
+		log.Println("error closing invitation repo:", err)
+	}
+	if err := guestListRepo.Close(); err != nil {
+		log.Println("error closing guest list repo:", err)
+	}
 	if err := eventStore.Close(); err != nil {
 		log.Println("error closing event store:", err)
 	}

--- a/examples/guestlist/memory/memory_test.go
+++ b/examples/guestlist/memory/memory_test.go
@@ -163,6 +163,9 @@ func Example() {
 			l.NumGuests, l.NumAccepted, l.NumDeclined, l.NumConfirmed, l.NumDenied)
 	}
 
+	if err := eventStore.Close(); err != nil {
+		log.Println("error closing event store:", err)
+	}
 	if err := eventBus.Close(); err != nil {
 		log.Println("error closing event bus:", err)
 	}

--- a/examples/guestlist/memory/memory_test.go
+++ b/examples/guestlist/memory/memory_test.go
@@ -59,8 +59,7 @@ func Example() {
 	guestListRepo := memory.NewRepo()
 	guestListRepo.SetEntityFactory(func() eh.Entity { return &guestlist.GuestList{} })
 
-	// Create a context with cancellation.
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx := context.Background()
 
 	// Setup a test utility waiter that waits for all 11 events to occur before
 	// evaluating results.
@@ -164,9 +163,9 @@ func Example() {
 			l.NumGuests, l.NumAccepted, l.NumDeclined, l.NumConfirmed, l.NumDenied)
 	}
 
-	// Cancel all handlers and wait.
-	cancel()
-	eventBus.Wait()
+	if err := eventBus.Close(); err != nil {
+		log.Println("error closing event bus:", err)
+	}
 
 	// Output:
 	// invitation: Athena - confirmed

--- a/examples/guestlist/mongodb/mongodb_test.go
+++ b/examples/guestlist/mongodb/mongodb_test.go
@@ -88,8 +88,7 @@ guest list: 4 invited - 3 accepted, 1 declined - 2 confirmed, 1 denied`)
 	}
 	guestListRepo.SetEntityFactory(func() eh.Entity { return &guestlist.GuestList{} })
 
-	// Create a context with cancellation.
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx := context.Background()
 
 	// Setup a test utility waiter that waits for all 11 events to occur before
 	// evaluating results.
@@ -198,9 +197,9 @@ guest list: 4 invited - 3 accepted, 1 declined - 2 confirmed, 1 denied`)
 			l.NumGuests, l.NumAccepted, l.NumDeclined, l.NumConfirmed, l.NumDenied)
 	}
 
-	// Cancel all handlers and wait.
-	cancel()
-	eventBus.Wait()
+	if err := eventBus.Close(); err != nil {
+		log.Println("error closing event bus:", err)
+	}
 
 	// Output:
 	// invitation: Athena - confirmed

--- a/examples/guestlist/mongodb/mongodb_test.go
+++ b/examples/guestlist/mongodb/mongodb_test.go
@@ -197,6 +197,12 @@ guest list: 4 invited - 3 accepted, 1 declined - 2 confirmed, 1 denied`)
 			l.NumGuests, l.NumAccepted, l.NumDeclined, l.NumConfirmed, l.NumDenied)
 	}
 
+	if err := invitationRepo.Close(); err != nil {
+		log.Println("error closing invitation repo:", err)
+	}
+	if err := guestListRepo.Close(); err != nil {
+		log.Println("error closing guest list repo:", err)
+	}
 	if err := eventStore.Close(); err != nil {
 		log.Println("error closing event store:", err)
 	}

--- a/examples/guestlist/mongodb/mongodb_test.go
+++ b/examples/guestlist/mongodb/mongodb_test.go
@@ -197,6 +197,9 @@ guest list: 4 invited - 3 accepted, 1 declined - 2 confirmed, 1 denied`)
 			l.NumGuests, l.NumAccepted, l.NumDeclined, l.NumConfirmed, l.NumDenied)
 	}
 
+	if err := eventStore.Close(); err != nil {
+		log.Println("error closing event store:", err)
+	}
 	if err := eventBus.Close(); err != nil {
 		log.Println("error closing event bus:", err)
 	}

--- a/examples/todomvc/backend/domains/todo/setup.go
+++ b/examples/todomvc/backend/domains/todo/setup.go
@@ -15,12 +15,12 @@ import (
 
 // SetupDomain sets up the Todo domain.
 func SetupDomain(
-	ctx context.Context,
 	commandBus *bus.CommandHandler,
 	eventStore eh.EventStore,
 	eventBus eh.EventBus,
 	repo eh.ReadWriteRepo,
 ) error {
+	ctx := context.Background()
 
 	// Set the entity factory for the base repo.
 	if memoryRepo := memory.IntoRepo(ctx, repo); memoryRepo != nil {

--- a/examples/todomvc/backend/handler/handler.go
+++ b/examples/todomvc/backend/handler/handler.go
@@ -29,7 +29,6 @@ import (
 // NewHandler returns a http.Handler that interacts exposes the command handler,
 // read repo and event bus to the frontend.
 func NewHandler(
-	ctx context.Context,
 	commandHandler eh.CommandHandler,
 	eventBus eh.EventBus,
 	todoRepo eh.ReadRepo,
@@ -40,7 +39,7 @@ func NewHandler(
 	// Add the event bus as a websocket that sends the events as JSON.
 	eventBusHandler := httputils.NewEventBusHandler()
 	observerMiddleware := observer.NewMiddleware(observer.NamedGroup("todomvc"))
-	eventBus.AddHandler(ctx, eh.MatchAll{},
+	eventBus.AddHandler(context.Background(), eh.MatchAll{},
 		eh.UseEventHandlerMiddleware(eventBusHandler, observerMiddleware))
 	h.Handle("/api/events/", eventBusHandler)
 

--- a/examples/todomvc/backend/handler/handler_test.go
+++ b/examples/todomvc/backend/handler/handler_test.go
@@ -43,11 +43,9 @@ import (
 )
 
 func TestStaticFiles(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
+	commandHandler, eventBus, todoRepo := NewTestSession()
 
-	commandHandler, eventBus, todoRepo := NewTestSession(ctx)
-
-	h, err := NewHandler(ctx, commandHandler, eventBus, todoRepo, "../../frontend")
+	h, err := NewHandler(commandHandler, eventBus, todoRepo, "../../frontend")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -59,9 +57,9 @@ func TestStaticFiles(t *testing.T) {
 		t.Error("there should be a 200 status for /")
 	}
 
-	// Cancel all handlers and wait.
-	cancel()
-	eventBus.Wait()
+	if err := eventBus.Close(); err != nil {
+		t.Error("there should be no error:", err)
+	}
 }
 
 func TestGetAll(t *testing.T) {
@@ -69,11 +67,9 @@ func TestGetAll(t *testing.T) {
 		return time.Date(2017, time.July, 10, 23, 0, 0, 0, time.UTC)
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
+	commandHandler, eventBus, todoRepo := NewTestSession()
 
-	commandHandler, eventBus, todoRepo := NewTestSession(ctx)
-
-	h, err := NewHandler(ctx, commandHandler, eventBus, todoRepo, "../../frontend")
+	h, err := NewHandler(commandHandler, eventBus, todoRepo, "../../frontend")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -87,6 +83,8 @@ func TestGetAll(t *testing.T) {
 	if w.Body.String() != `[]` {
 		t.Error("the body should be correct:", w.Body.String())
 	}
+
+	ctx := context.Background()
 
 	id := uuid.New()
 	if err := commandHandler.HandleCommand(ctx, &todo.Create{
@@ -119,9 +117,9 @@ func TestGetAll(t *testing.T) {
 		t.Error("the body should be correct:", w.Body.String())
 	}
 
-	// Cancel all handlers and wait.
-	cancel()
-	eventBus.Wait()
+	if err := eventBus.Close(); err != nil {
+		t.Error("there should be no error:", err)
+	}
 }
 
 func TestCreate(t *testing.T) {
@@ -129,11 +127,9 @@ func TestCreate(t *testing.T) {
 		return time.Date(2017, time.July, 10, 23, 0, 0, 0, time.UTC)
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
+	commandHandler, eventBus, todoRepo := NewTestSession()
 
-	commandHandler, eventBus, todoRepo := NewTestSession(ctx)
-
-	h, err := NewHandler(ctx, commandHandler, eventBus, todoRepo, "../../frontend")
+	h, err := NewHandler(commandHandler, eventBus, todoRepo, "../../frontend")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -149,6 +145,8 @@ func TestCreate(t *testing.T) {
 	if w.Body.Len() != 0 {
 		t.Error("the body should be correct:", w.Body.String())
 	}
+
+	ctx := context.Background()
 
 	waiter := waiter.NewEventHandler()
 	eventBus.AddHandler(ctx, eh.MatchEvents{todo.Created},
@@ -179,9 +177,9 @@ func TestCreate(t *testing.T) {
 		t.Log("expected:", expected)
 	}
 
-	// Cancel all handlers and wait.
-	cancel()
-	eventBus.Wait()
+	if err := eventBus.Close(); err != nil {
+		t.Error("there should be no error:", err)
+	}
 }
 
 func TestDelete(t *testing.T) {
@@ -189,14 +187,14 @@ func TestDelete(t *testing.T) {
 		return time.Date(2017, time.July, 10, 23, 0, 0, 0, time.UTC)
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
+	commandHandler, eventBus, todoRepo := NewTestSession()
 
-	commandHandler, eventBus, todoRepo := NewTestSession(ctx)
-
-	h, err := NewHandler(ctx, commandHandler, eventBus, todoRepo, "../../frontend")
+	h, err := NewHandler(commandHandler, eventBus, todoRepo, "../../frontend")
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	ctx := context.Background()
 
 	id := uuid.New()
 	if err := commandHandler.HandleCommand(ctx, &todo.Create{
@@ -231,9 +229,9 @@ func TestDelete(t *testing.T) {
 		t.Error("there should be a not found error:", err)
 	}
 
-	// Cancel all handlers and wait.
-	cancel()
-	eventBus.Wait()
+	if err := eventBus.Close(); err != nil {
+		t.Error("there should be no error:", err)
+	}
 }
 
 func TestAddItem(t *testing.T) {
@@ -241,14 +239,14 @@ func TestAddItem(t *testing.T) {
 		return time.Date(2017, time.July, 10, 23, 0, 0, 0, time.UTC)
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
+	commandHandler, eventBus, todoRepo := NewTestSession()
 
-	commandHandler, eventBus, todoRepo := NewTestSession(ctx)
-
-	h, err := NewHandler(ctx, commandHandler, eventBus, todoRepo, "../../frontend")
+	h, err := NewHandler(commandHandler, eventBus, todoRepo, "../../frontend")
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	ctx := context.Background()
 
 	id := uuid.New()
 	if err := commandHandler.HandleCommand(ctx, &todo.Create{
@@ -302,9 +300,9 @@ func TestAddItem(t *testing.T) {
 		t.Log("expected:", expected)
 	}
 
-	// Cancel all handlers and wait.
-	cancel()
-	eventBus.Wait()
+	if err := eventBus.Close(); err != nil {
+		t.Error("there should be no error:", err)
+	}
 }
 
 func TestRemoveItem(t *testing.T) {
@@ -312,14 +310,14 @@ func TestRemoveItem(t *testing.T) {
 		return time.Date(2017, time.July, 10, 23, 0, 0, 0, time.UTC)
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
+	commandHandler, eventBus, todoRepo := NewTestSession()
 
-	commandHandler, eventBus, todoRepo := NewTestSession(ctx)
-
-	h, err := NewHandler(ctx, commandHandler, eventBus, todoRepo, "../../frontend")
+	h, err := NewHandler(commandHandler, eventBus, todoRepo, "../../frontend")
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	ctx := context.Background()
 
 	id := uuid.New()
 	if err := commandHandler.HandleCommand(ctx, &todo.Create{
@@ -374,9 +372,9 @@ func TestRemoveItem(t *testing.T) {
 		t.Log("expected:", expected)
 	}
 
-	// Cancel all handlers and wait.
-	cancel()
-	eventBus.Wait()
+	if err := eventBus.Close(); err != nil {
+		t.Error("there should be no error:", err)
+	}
 }
 
 func TestRemoveCompleted(t *testing.T) {
@@ -384,14 +382,14 @@ func TestRemoveCompleted(t *testing.T) {
 		return time.Date(2017, time.July, 10, 23, 0, 0, 0, time.UTC)
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
+	commandHandler, eventBus, todoRepo := NewTestSession()
 
-	commandHandler, eventBus, todoRepo := NewTestSession(ctx)
-
-	h, err := NewHandler(ctx, commandHandler, eventBus, todoRepo, "../../frontend")
+	h, err := NewHandler(commandHandler, eventBus, todoRepo, "../../frontend")
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	ctx := context.Background()
 
 	id := uuid.New()
 	if err := commandHandler.HandleCommand(ctx, &todo.Create{
@@ -466,9 +464,9 @@ func TestRemoveCompleted(t *testing.T) {
 		t.Log("expected:", expected)
 	}
 
-	// Cancel all handlers and wait.
-	cancel()
-	eventBus.Wait()
+	if err := eventBus.Close(); err != nil {
+		t.Error("there should be no error:", err)
+	}
 }
 
 func TestSetItemDesc(t *testing.T) {
@@ -476,14 +474,14 @@ func TestSetItemDesc(t *testing.T) {
 		return time.Date(2017, time.July, 10, 23, 0, 0, 0, time.UTC)
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
+	commandHandler, eventBus, todoRepo := NewTestSession()
 
-	commandHandler, eventBus, todoRepo := NewTestSession(ctx)
-
-	h, err := NewHandler(ctx, commandHandler, eventBus, todoRepo, "../../frontend")
+	h, err := NewHandler(commandHandler, eventBus, todoRepo, "../../frontend")
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	ctx := context.Background()
 
 	id := uuid.New()
 	if err := commandHandler.HandleCommand(ctx, &todo.Create{
@@ -543,9 +541,9 @@ func TestSetItemDesc(t *testing.T) {
 		t.Log("expected:", expected)
 	}
 
-	// Cancel all handlers and wait.
-	cancel()
-	eventBus.Wait()
+	if err := eventBus.Close(); err != nil {
+		t.Error("there should be no error:", err)
+	}
 }
 
 func TestCheckItem(t *testing.T) {
@@ -553,14 +551,14 @@ func TestCheckItem(t *testing.T) {
 		return time.Date(2017, time.July, 10, 23, 0, 0, 0, time.UTC)
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
+	commandHandler, eventBus, todoRepo := NewTestSession()
 
-	commandHandler, eventBus, todoRepo := NewTestSession(ctx)
-
-	h, err := NewHandler(ctx, commandHandler, eventBus, todoRepo, "../../frontend")
+	h, err := NewHandler(commandHandler, eventBus, todoRepo, "../../frontend")
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	ctx := context.Background()
 
 	id := uuid.New()
 	if err := commandHandler.HandleCommand(ctx, &todo.Create{
@@ -631,9 +629,9 @@ func TestCheckItem(t *testing.T) {
 		t.Log("expected:", expected)
 	}
 
-	// Cancel all handlers and wait.
-	cancel()
-	eventBus.Wait()
+	if err := eventBus.Close(); err != nil {
+		t.Error("there should be no error:", err)
+	}
 }
 
 func TestCheckAllItems(t *testing.T) {
@@ -641,14 +639,14 @@ func TestCheckAllItems(t *testing.T) {
 		return time.Date(2017, time.July, 10, 23, 0, 0, 0, time.UTC)
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
+	commandHandler, eventBus, todoRepo := NewTestSession()
 
-	commandHandler, eventBus, todoRepo := NewTestSession(ctx)
-
-	h, err := NewHandler(ctx, commandHandler, eventBus, todoRepo, "../../frontend")
+	h, err := NewHandler(commandHandler, eventBus, todoRepo, "../../frontend")
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	ctx := context.Background()
 
 	id := uuid.New()
 	if err := commandHandler.HandleCommand(ctx, &todo.Create{
@@ -722,12 +720,12 @@ func TestCheckAllItems(t *testing.T) {
 		t.Log("expected:", expected)
 	}
 
-	// Cancel all handlers and wait.
-	cancel()
-	eventBus.Wait()
+	if err := eventBus.Close(); err != nil {
+		t.Error("there should be no error:", err)
+	}
 }
 
-func NewTestSession(ctx context.Context) (
+func NewTestSession() (
 	eh.CommandHandler,
 	eh.EventBus,
 	eh.ReadWriteRepo,
@@ -745,7 +743,7 @@ func NewTestSession(ctx context.Context) (
 
 	// Create the read repositories.
 	todoRepo := memory.NewRepo()
-	if err := todo.SetupDomain(ctx, commandBus, eventStore, eventBus, todoRepo); err != nil {
+	if err := todo.SetupDomain(commandBus, eventStore, eventBus, todoRepo); err != nil {
 		log.Println("could not setup domain:", err)
 	}
 
@@ -800,7 +798,7 @@ func NewIntegrationTestSession(ctx context.Context) (
 	}
 
 	// Setup the todo domain.
-	if err := todo.SetupDomain(ctx, commandBus, eventStore, eventBus, todoRepo); err != nil {
+	if err := todo.SetupDomain(commandBus, eventStore, eventBus, todoRepo); err != nil {
 		log.Println("could not setup domain:", err)
 	}
 

--- a/examples/todomvc/backend/main.go
+++ b/examples/todomvc/backend/main.go
@@ -214,6 +214,9 @@ func main() {
 
 	// Cancel all handlers and wait.
 	log.Println("waiting for handlers to finish")
+	if err := eventStore.Close(); err != nil {
+		log.Print("could not close event store: ", err)
+	}
 	if err := eventBus.Close(); err != nil {
 		log.Print("could not close event bus: ", err)
 	}

--- a/examples/todomvc/backend/main.go
+++ b/examples/todomvc/backend/main.go
@@ -214,6 +214,9 @@ func main() {
 
 	// Cancel all handlers and wait.
 	log.Println("waiting for handlers to finish")
+	if err := todoRepo.Close(); err != nil {
+		log.Print("could not close todo repo: ", err)
+	}
 	if err := eventStore.Close(); err != nil {
 		log.Print("could not close event store: ", err)
 	}

--- a/examples/todomvc/backend/main.go
+++ b/examples/todomvc/backend/main.go
@@ -91,7 +91,7 @@ func main() {
 	}
 	eventStore = tracingEventStore.NewEventStore(eventStore)
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx := context.Background()
 
 	// Add an event logger as an observer.
 	eventLogger := &EventLogger{}
@@ -112,7 +112,7 @@ func main() {
 	todoRepo = tracingRepo.NewRepo(todoRepo)
 
 	// Setup the Todo domain.
-	if err := todo.SetupDomain(ctx, commandBus, eventStore, eventBus, todoRepo); err != nil {
+	if err := todo.SetupDomain(commandBus, eventStore, eventBus, todoRepo); err != nil {
 		log.Fatal("could not setup Todo domain: ", err)
 	}
 
@@ -123,7 +123,7 @@ func main() {
 	)
 
 	// Setup the HTTP handler for commands, read repo and events.
-	h, err := handler.NewHandler(ctx, commandHandler, eventBus, todoRepo, "frontend")
+	h, err := handler.NewHandler(commandHandler, eventBus, todoRepo, "frontend")
 	if err != nil {
 		log.Fatal("could not create handler: ", err)
 	}
@@ -213,9 +213,10 @@ func main() {
 	<-srvClosed
 
 	// Cancel all handlers and wait.
-	cancel()
 	log.Println("waiting for handlers to finish")
-	eventBus.Wait()
+	if err := eventBus.Close(); err != nil {
+		log.Print("could not close event bus: ", err)
+	}
 
 	if err := traceCloser.Close(); err != nil {
 		log.Print("could not close tracer: ", err)

--- a/mocks/mocks.go
+++ b/mocks/mocks.go
@@ -363,8 +363,10 @@ func (b *EventBus) Errors() <-chan eh.EventBusError {
 	return make(chan eh.EventBusError)
 }
 
-// Wait implements the Wait method of the eventhorizon.EventBus interface.
-func (b *EventBus) Wait() {}
+// Close implements the Close method of the eventhorizon.EventBus interface.
+func (b *EventBus) Close() error {
+	return nil
+}
 
 // Repo is a mocked eventhorizon.ReadRepo, useful in testing.
 type Repo struct {

--- a/mocks/mocks.go
+++ b/mocks/mocks.go
@@ -328,6 +328,11 @@ func (m *EventStore) Replace(ctx context.Context, event eh.Event) error {
 	return nil
 }
 
+// Close implements the Close method of the eventhorizon.EventStore interface.
+func (m *EventStore) Close() error {
+	return nil
+}
+
 var _ = eh.EventBus(&EventBus{})
 
 // EventBus is a mocked eventhorizon.EventBus, useful in testing.

--- a/mocks/mocks.go
+++ b/mocks/mocks.go
@@ -333,8 +333,6 @@ func (m *EventStore) Close() error {
 	return nil
 }
 
-var _ = eh.EventBus(&EventBus{})
-
 // EventBus is a mocked eventhorizon.EventBus, useful in testing.
 type EventBus struct {
 	Events  []eh.Event
@@ -342,6 +340,8 @@ type EventBus struct {
 	// Used to simulate errors in PublishEvent.
 	Err error
 }
+
+var _ = eh.EventBus(&EventBus{})
 
 // HandlerType implements the HandlerType method of the eventhorizon.EventHandler interface.
 func (b *EventBus) HandlerType() eh.EventHandlerType {
@@ -440,6 +440,11 @@ func (r *Repo) Remove(ctx context.Context, id uuid.UUID) error {
 		return r.SaveErr
 	}
 	r.Entity = nil
+	return nil
+}
+
+// Close implements the Close method of the eventhorizon.ReadRepo interface.
+func (r *Repo) Close() error {
 	return nil
 }
 

--- a/repo.go
+++ b/repo.go
@@ -32,6 +32,9 @@ type ReadRepo interface {
 
 	// FindAll returns all entities in the repository.
 	FindAll(context.Context) ([]Entity, error)
+
+	// Close closes the ReadRepo.
+	Close() error
 }
 
 // WriteRepo is a write repository for entities.

--- a/repo/memory/repo.go
+++ b/repo/memory/repo.go
@@ -185,3 +185,8 @@ func (r *Repo) Remove(ctx context.Context, id uuid.UUID) error {
 func (r *Repo) SetEntityFactory(f func() eh.Entity) {
 	r.factoryFn = f
 }
+
+// Close implements the Close method of the eventhorizon.WriteRepo interface.
+func (r *Repo) Close() error {
+	return nil
+}

--- a/repo/mongodb/repo.go
+++ b/repo/mongodb/repo.go
@@ -352,7 +352,7 @@ func (r *Repo) Clear(ctx context.Context) error {
 	return nil
 }
 
-// Close closes a database session.
-func (r *Repo) Close(ctx context.Context) {
-	r.client.Disconnect(ctx)
+// Close implements the Close method of the eventhorizon.WriteRepo interface.
+func (r *Repo) Close() error {
+	return r.client.Disconnect(context.Background())
 }

--- a/repo/mongodb/repo_test.go
+++ b/repo/mongodb/repo_test.go
@@ -60,7 +60,7 @@ func TestReadRepoIntegration(t *testing.T) {
 	if r == nil {
 		t.Error("there should be a repository")
 	}
-	defer r.Close(context.Background())
+	defer r.Close()
 
 	r.SetEntityFactory(func() eh.Entity {
 		return &mocks.Model{}
@@ -193,7 +193,7 @@ func TestIntoRepo(t *testing.T) {
 	if err != nil {
 		t.Error("there should be no error:", err)
 	}
-	defer inner.Close(context.Background())
+	defer inner.Close()
 
 	outer := &mocks.Repo{ParentRepo: inner}
 	if r := IntoRepo(context.Background(), outer); r != inner {


### PR DESCRIPTION
### Description

- Add Close() to EventBus, remove Wait(). Previous behaviour of cancelling the handling context no longer works.
- Add Close() to EventStore.
- Add Close() to ReadRepo.

### Affected Components

- Event Bus
- Event Store
- Read Repo

### Related Issues

#123

### Solution and Design

Short description of the solution.

### Steps to test and verify

1. ...
