### PR TITLE
Fix / Event store errors, MongoDB v2 event store bug

### DIFF
--- a/eventstore.go
+++ b/eventstore.go
@@ -16,6 +16,7 @@ package eventhorizon
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -33,6 +34,21 @@ type EventStore interface {
 	// Close closes the EventStore.
 	Close() error
 }
+
+var (
+	// Missing events for save operation.
+	ErrMissingEvents = errors.New("missing events")
+	// Events in the same save operation is for different aggregate IDs.
+	ErrMismatchedEventAggregateIDs = errors.New("mismatched event aggregate IDs")
+	// Events in the same save operation is for different aggregate types.
+	ErrMismatchedEventAggregateTypes = errors.New("mismatched event aggregate types")
+	// Events in the same operation have non-serial versions or is not matching the original version.
+	ErrIncorrectEventVersion = errors.New("incorrect event version")
+	// Other events has been saved for this aggregate since the operation started.
+	ErrEventConflictFromOtherSave = errors.New("event conflict from other save")
+	// No matching event could be found (for maintenance operations etc).
+	ErrEventNotFound = errors.New("event not found")
+)
 
 // EventStoreOperation is the operation done when an error happened.
 type EventStoreOperation string

--- a/eventstore/maintenance_testing.go
+++ b/eventstore/maintenance_testing.go
@@ -68,7 +68,7 @@ func MaintenanceAcceptanceTest(t *testing.T, store eh.EventStore, storeMaintenan
 	eventStoreErr := &eh.EventStoreError{}
 
 	err = storeMaintenance.Replace(ctx, eventWithInvalidVersion)
-	if !errors.As(err, &eventStoreErr) || eventStoreErr.Err.Error() != "could not find original event" {
+	if !errors.As(err, &eventStoreErr) || !errors.Is(err, eh.ErrEventNotFound) {
 		t.Error("there should be a event store error:", err)
 	}
 

--- a/eventstore/memory/eventmaintenance.go
+++ b/eventstore/memory/eventmaintenance.go
@@ -65,7 +65,7 @@ func (s *EventStore) Replace(ctx context.Context, event eh.Event) error {
 
 	if idx == -1 {
 		return &eh.EventStoreError{
-			Err:         fmt.Errorf("could not find original event"),
+			Err:         eh.ErrEventNotFound,
 			Op:          eh.EventStoreOpReplace,
 			AggregateID: id,
 			Events:      []eh.Event{event},

--- a/eventstore/memory/eventstore.go
+++ b/eventstore/memory/eventstore.go
@@ -90,7 +90,7 @@ func (s *EventStore) save(ctx context.Context, events []eh.Event, originalVersio
 
 	if len(events) == 0 {
 		return &eh.EventStoreError{
-			Err: fmt.Errorf("no events"),
+			Err: eh.ErrMissingEvents,
 			Op:  eh.EventStoreOpSave,
 		}
 	}
@@ -105,7 +105,7 @@ func (s *EventStore) save(ctx context.Context, events []eh.Event, originalVersio
 		// Only accept events belonging to the same aggregate.
 		if event.AggregateID() != id {
 			return &eh.EventStoreError{
-				Err:              fmt.Errorf("event has different aggregate ID"),
+				Err:              eh.ErrMismatchedEventAggregateIDs,
 				Op:               eh.EventStoreOpSave,
 				AggregateType:    at,
 				AggregateID:      id,
@@ -116,7 +116,7 @@ func (s *EventStore) save(ctx context.Context, events []eh.Event, originalVersio
 
 		if event.AggregateType() != at {
 			return &eh.EventStoreError{
-				Err:              fmt.Errorf("event has different aggregate type"),
+				Err:              eh.ErrMismatchedEventAggregateTypes,
 				Op:               eh.EventStoreOpSave,
 				AggregateType:    at,
 				AggregateID:      id,
@@ -128,7 +128,7 @@ func (s *EventStore) save(ctx context.Context, events []eh.Event, originalVersio
 		// Only accept events that apply to the correct aggregate version.
 		if event.Version() != originalVersion+i+1 {
 			return &eh.EventStoreError{
-				Err:              fmt.Errorf("invalid event version"),
+				Err:              eh.ErrIncorrectEventVersion,
 				Op:               eh.EventStoreOpSave,
 				AggregateType:    at,
 				AggregateID:      id,
@@ -169,7 +169,7 @@ func (s *EventStore) save(ctx context.Context, events []eh.Event, originalVersio
 		if aggregate, ok := s.db[id]; ok {
 			if aggregate.Version != originalVersion {
 				return &eh.EventStoreError{
-					Err:              fmt.Errorf("invalid original aggregate version, new version: %d", aggregate.Version),
+					Err:              eh.ErrEventConflictFromOtherSave,
 					Op:               eh.EventStoreOpSave,
 					AggregateType:    at,
 					AggregateID:      id,

--- a/eventstore/mongodb/eventmaintenance.go
+++ b/eventstore/mongodb/eventmaintenance.go
@@ -80,7 +80,7 @@ func (s *EventStore) Replace(ctx context.Context, event eh.Event) error {
 		}
 	} else if r.MatchedCount == 0 {
 		return &eh.EventStoreError{
-			Err:              fmt.Errorf("could not find original event"),
+			Err:              eh.ErrEventNotFound,
 			Op:               eh.EventStoreOpReplace,
 			AggregateType:    at,
 			AggregateID:      id,

--- a/eventstore/mongodb/eventstore.go
+++ b/eventstore/mongodb/eventstore.go
@@ -98,7 +98,7 @@ func WithEventHandler(h eh.EventHandler) Option {
 func (s *EventStore) Save(ctx context.Context, events []eh.Event, originalVersion int) error {
 	if len(events) == 0 {
 		return &eh.EventStoreError{
-			Err: fmt.Errorf("no events"),
+			Err: eh.ErrMissingEvents,
 			Op:  eh.EventStoreOpSave,
 		}
 	}
@@ -113,7 +113,7 @@ func (s *EventStore) Save(ctx context.Context, events []eh.Event, originalVersio
 		// Only accept events belonging to the same aggregate.
 		if event.AggregateID() != id {
 			return &eh.EventStoreError{
-				Err:              fmt.Errorf("event has different aggregate ID"),
+				Err:              eh.ErrMismatchedEventAggregateIDs,
 				Op:               eh.EventStoreOpSave,
 				AggregateType:    at,
 				AggregateID:      id,
@@ -124,7 +124,7 @@ func (s *EventStore) Save(ctx context.Context, events []eh.Event, originalVersio
 
 		if event.AggregateType() != at {
 			return &eh.EventStoreError{
-				Err:              fmt.Errorf("event has different aggregate type"),
+				Err:              eh.ErrMismatchedEventAggregateTypes,
 				Op:               eh.EventStoreOpSave,
 				AggregateType:    at,
 				AggregateID:      id,
@@ -136,7 +136,7 @@ func (s *EventStore) Save(ctx context.Context, events []eh.Event, originalVersio
 		// Only accept events that apply to the correct aggregate version.
 		if event.Version() != originalVersion+i+1 {
 			return &eh.EventStoreError{
-				Err:              fmt.Errorf("invalid event version"),
+				Err:              eh.ErrIncorrectEventVersion,
 				Op:               eh.EventStoreOpSave,
 				AggregateType:    at,
 				AggregateID:      id,
@@ -203,7 +203,7 @@ func (s *EventStore) Save(ctx context.Context, events []eh.Event, originalVersio
 			}
 		} else if r.MatchedCount == 0 {
 			return &eh.EventStoreError{
-				Err:              fmt.Errorf("invalid original aggregate version, new version %d", originalVersion),
+				Err:              eh.ErrEventConflictFromOtherSave,
 				Op:               eh.EventStoreOpSave,
 				AggregateType:    at,
 				AggregateID:      id,

--- a/eventstore/mongodb_v2/eventmaintenance.go
+++ b/eventstore/mongodb_v2/eventmaintenance.go
@@ -70,7 +70,7 @@ func (s *EventStore) Replace(ctx context.Context, event eh.Event) error {
 		})
 		if res.Err() != nil {
 			if res.Err() == mongo.ErrNoDocuments {
-				return nil, fmt.Errorf("could not find original event")
+				return nil, eh.ErrEventNotFound
 			}
 
 			return nil, fmt.Errorf("could not find original event: %w", res.Err())

--- a/eventstore/mongodb_v2/eventstore.go
+++ b/eventstore/mongodb_v2/eventstore.go
@@ -123,7 +123,7 @@ func WithEventHandler(h eh.EventHandler) Option {
 func (s *EventStore) Save(ctx context.Context, events []eh.Event, originalVersion int) error {
 	if len(events) == 0 {
 		return &eh.EventStoreError{
-			Err: fmt.Errorf("no events"),
+			Err: eh.ErrMissingEvents,
 			Op:  eh.EventStoreOpSave,
 		}
 	}
@@ -138,7 +138,7 @@ func (s *EventStore) Save(ctx context.Context, events []eh.Event, originalVersio
 		// Only accept events belonging to the same aggregate.
 		if event.AggregateID() != id {
 			return &eh.EventStoreError{
-				Err:              fmt.Errorf("event has different aggregate ID"),
+				Err:              eh.ErrMismatchedEventAggregateIDs,
 				Op:               eh.EventStoreOpSave,
 				AggregateType:    at,
 				AggregateID:      id,
@@ -149,7 +149,7 @@ func (s *EventStore) Save(ctx context.Context, events []eh.Event, originalVersio
 
 		if event.AggregateType() != at {
 			return &eh.EventStoreError{
-				Err:              fmt.Errorf("event has different aggregate type"),
+				Err:              eh.ErrMismatchedEventAggregateTypes,
 				Op:               eh.EventStoreOpSave,
 				AggregateType:    at,
 				AggregateID:      id,
@@ -161,7 +161,7 @@ func (s *EventStore) Save(ctx context.Context, events []eh.Event, originalVersio
 		// Only accept events that apply to the correct aggregate version.
 		if event.Version() != originalVersion+i+1 {
 			return &eh.EventStoreError{
-				Err:              fmt.Errorf("invalid event version"),
+				Err:              eh.ErrIncorrectEventVersion,
 				Op:               eh.EventStoreOpSave,
 				AggregateType:    at,
 				AggregateID:      id,
@@ -285,7 +285,7 @@ func (s *EventStore) Save(ctx context.Context, events []eh.Event, originalVersio
 			); err != nil {
 				return nil, fmt.Errorf("could not update stream: %w", err)
 			} else if r.MatchedCount == 0 {
-				return nil, fmt.Errorf("invalid original aggregate version, new version %d", originalVersion)
+				return nil, eh.ErrEventConflictFromOtherSave
 			}
 		}
 


### PR DESCRIPTION
### Description

Fix bug where MongoDB v2 event store did not check the original version.
Add back validation error for event store save operation.

### Affected Components

- Event Store, memory and MongoDB v1 and v2

### Related Issues

### Solution and Design

### Steps to test and verify
