### PR TITLE
Feature / Add function to find single entity with custom query to mongo repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,8 +25,11 @@ _testmain.go
 *.coverprofile
 coverage.out
 
+*.DS_Store
+
 # CI
 .env
 
 # Editors
 .vscode
+.idea

--- a/repo/mongodb/repo.go
+++ b/repo/mongodb/repo.go
@@ -37,8 +37,8 @@ import (
 // ErrModelNotSet is when a model factory is not set on the Repo.
 var ErrModelNotSet = errors.New("model not set")
 
-// ErrInvalidQuery is when a callback function returns a nil cursor.
-var ErrInvalidQuery = errors.New("no cursor")
+// ErrNoCursor is when a provided callback function returns a nil cursor.
+var ErrNoCursor = errors.New("no cursor")
 
 // Repo implements an MongoDB repository for entities.
 type Repo struct {
@@ -226,7 +226,7 @@ func (r *Repo) FindCustomIter(ctx context.Context, f func(context.Context, *mong
 
 	if cursor == nil {
 		return nil, &eh.RepoError{
-			Err: ErrInvalidQuery,
+			Err: ErrNoCursor,
 			Op:  eh.RepoOpFindQuery,
 		}
 	}
@@ -240,7 +240,7 @@ func (r *Repo) FindCustomIter(ctx context.Context, f func(context.Context, *mong
 // FindCustom uses a callback to specify a custom query for returning models.
 // It can also be used to do queries that does not map to the model by executing
 // the query in the callback and returning nil to block a second execution of
-// the same query in FindCustom. Expect a ErrInvalidQuery if returning a nil
+// the same query in FindCustom. Expect a ErrNoCursor if returning a nil
 // query from the callback.
 func (r *Repo) FindCustom(ctx context.Context, f func(context.Context, *mongo.Collection) (*mongo.Cursor, error)) ([]interface{}, error) {
 	if r.newEntity == nil {
@@ -260,7 +260,7 @@ func (r *Repo) FindCustom(ctx context.Context, f func(context.Context, *mongo.Co
 
 	if cursor == nil {
 		return nil, &eh.RepoError{
-			Err: ErrInvalidQuery,
+			Err: ErrNoCursor,
 			Op:  eh.RepoOpFindQuery,
 		}
 	}

--- a/repo/mongodb/repo_test.go
+++ b/repo/mongodb/repo_test.go
@@ -197,7 +197,7 @@ func extraRepoTests(t *testing.T, r *Repo) {
 		return c.FindOne(ctx, bson.M{"content": "modelCustomFoo"})
 	})
 	if !errors.As(err, &repoErr) || !errors.Is(repoErr.Err, eh.ErrEntityNotFound) {
-		t.Error("there should be a invalid query error:", err)
+		t.Error("there should be a entity not found error:", err)
 	}
 }
 

--- a/repo/mongodb/repo_test.go
+++ b/repo/mongodb/repo_test.go
@@ -110,7 +110,7 @@ func extraRepoTests(t *testing.T, r *Repo) {
 	_, err = r.FindCustom(ctx, func(ctx context.Context, c *mongo.Collection) (*mongo.Cursor, error) {
 		return nil, nil
 	})
-	if !errors.As(err, &repoErr) || repoErr.Err.Error() != "no cursor" {
+	if !errors.As(err, &repoErr) || !errors.Is(repoErr.Err, ErrInvalidQuery) {
 		t.Error("there should be a invalid query error:", err)
 	}
 
@@ -126,7 +126,7 @@ func extraRepoTests(t *testing.T, r *Repo) {
 		// Be sure to return nil to not execute the query again in FindCustom.
 		return nil, nil
 	})
-	if !errors.As(err, &repoErr) || repoErr.Err.Error() != "no cursor" {
+	if !errors.As(err, &repoErr) || !errors.Is(repoErr.Err, ErrInvalidQuery) {
 		t.Error("there should be a invalid query error:", err)
 	}
 
@@ -179,6 +179,25 @@ func extraRepoTests(t *testing.T, r *Repo) {
 	err = iter.Close(ctx)
 	if err != nil {
 		t.Error("there should be no error:", err)
+	}
+
+	// FindOneCustom by content.
+	singleResult, err := r.FindOneCustom(ctx, func(ctx context.Context, c *mongo.Collection) *mongo.SingleResult {
+		return c.FindOne(ctx, bson.M{"content": "modelCustom"})
+	})
+	if err != nil {
+		t.Error("there should be no error:", err)
+	}
+
+	if !reflect.DeepEqual(singleResult, modelCustom) {
+		t.Error("the item should be correct:", singleResult)
+	}
+
+	_, err = r.FindOneCustom(ctx, func(ctx context.Context, c *mongo.Collection) *mongo.SingleResult {
+		return c.FindOne(ctx, bson.M{"content": "modelCustomFoo"})
+	})
+	if !errors.As(err, &repoErr) || !errors.Is(repoErr.Err, eh.ErrEntityNotFound) {
+		t.Error("there should be a invalid query error:", err)
 	}
 }
 

--- a/repo/mongodb/repo_test.go
+++ b/repo/mongodb/repo_test.go
@@ -110,7 +110,7 @@ func extraRepoTests(t *testing.T, r *Repo) {
 	_, err = r.FindCustom(ctx, func(ctx context.Context, c *mongo.Collection) (*mongo.Cursor, error) {
 		return nil, nil
 	})
-	if !errors.As(err, &repoErr) || !errors.Is(repoErr.Err, ErrInvalidQuery) {
+	if !errors.As(err, &repoErr) || !errors.Is(repoErr.Err, ErrNoCursor) {
 		t.Error("there should be a invalid query error:", err)
 	}
 
@@ -126,7 +126,7 @@ func extraRepoTests(t *testing.T, r *Repo) {
 		// Be sure to return nil to not execute the query again in FindCustom.
 		return nil, nil
 	})
-	if !errors.As(err, &repoErr) || !errors.Is(repoErr.Err, ErrInvalidQuery) {
+	if !errors.As(err, &repoErr) || !errors.Is(repoErr.Err, ErrNoCursor) {
 		t.Error("there should be a invalid query error:", err)
 	}
 


### PR DESCRIPTION
### Description

Adds a function to find a single entity with a custom query. 
I found it rather annoying to use FindCustom in instances where I know that I query for a specific item with functionality like mongo projections, because there is still a need to check, for example, for the length of the response or checking for the custom "no cursor" error. 

Also fixes some linter warnings.

### Affected Components

- Mongo Repo

### Related Issues

### Solution and Design

Using the same approach as the FindCustom function, but expecting a mongo.SingleResult in the callback function.

### Steps to test and verify

I included some tests / extended the current extraRepoTests function.
