### PR TITLE
Feature / custom mongodb event collection names

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -19,3 +19,4 @@ Michael E Brown
 Oleg Yashchuk
 Bradley Weston
 Johannes Kolata
+Maximilian Breida

--- a/eventstore/mongodb/eventstore.go
+++ b/eventstore/mongodb/eventstore.go
@@ -130,6 +130,10 @@ func WithEventHandlerInTX(h eh.EventHandler) Option {
 // WithCollectionName uses a different event collection than the default "events".
 func WithCollectionName(eventsColl string) Option {
 	return func(s *EventStore) error {
+		if eventsColl == "" {
+			return fmt.Errorf("missing collection name")
+		}
+
 		s.aggregates = s.db.Collection(eventsColl)
 
 		return nil

--- a/eventstore/mongodb/eventstore.go
+++ b/eventstore/mongodb/eventstore.go
@@ -127,10 +127,10 @@ func WithEventHandlerInTX(h eh.EventHandler) Option {
 	}
 }
 
-// WithCustomEventsCollectionName uses a different event collection than the default "events".
-func WithCustomEventsCollectionName(collName string) Option {
+// WithCollectionName uses a different event collection than the default "events".
+func WithCollectionName(eventsColl string) Option {
 	return func(s *EventStore) error {
-		s.aggregates = s.db.Collection(collName)
+		s.aggregates = s.db.Collection(eventsColl)
 
 		return nil
 	}

--- a/eventstore/mongodb/eventstore.go
+++ b/eventstore/mongodb/eventstore.go
@@ -38,6 +38,7 @@ import (
 // as values.
 type EventStore struct {
 	client                *mongo.Client
+	db                    *mongo.Database
 	aggregates            *mongo.Collection
 	eventHandlerAfterSave eh.EventHandler
 	eventHandlerInTX      eh.EventHandler
@@ -59,14 +60,17 @@ func NewEventStore(uri, db string, options ...Option) (*EventStore, error) {
 }
 
 // NewEventStoreWithClient creates a new EventStore with a client.
-func NewEventStoreWithClient(client *mongo.Client, db string, options ...Option) (*EventStore, error) {
+func NewEventStoreWithClient(client *mongo.Client, dbName string, options ...Option) (*EventStore, error) {
 	if client == nil {
 		return nil, fmt.Errorf("missing DB client")
 	}
 
+	db := client.Database(dbName)
+
 	s := &EventStore{
 		client:     client,
-		aggregates: client.Database(db).Collection("events"),
+		db:         db,
+		aggregates: db.Collection("events"),
 	}
 
 	for _, option := range options {
@@ -118,6 +122,15 @@ func WithEventHandlerInTX(h eh.EventHandler) Option {
 		}
 
 		s.eventHandlerInTX = h
+
+		return nil
+	}
+}
+
+// WithCustomEventsCollectionName uses a different event collection than the default "events".
+func WithCustomEventsCollectionName(collName string) Option {
+	return func(s *EventStore) error {
+		s.aggregates = s.db.Collection(collName)
 
 		return nil
 	}

--- a/eventstore/mongodb/eventstore_test.go
+++ b/eventstore/mongodb/eventstore_test.go
@@ -65,6 +65,51 @@ func TestEventStoreIntegration(t *testing.T) {
 	eventstore.AcceptanceTest(t, store, context.Background())
 }
 
+func TestWithCustomEventsCollectionNameIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	// Use MongoDB in Docker with fallback to localhost.
+	url := os.Getenv("MONGODB_ADDR")
+	if url == "" {
+		url = "localhost:27017"
+	}
+
+	url = "mongodb://" + url
+
+	// Get a random DB name.
+	b := make([]byte, 4)
+	if _, err := rand.Read(b); err != nil {
+		t.Fatal(err)
+	}
+
+	db := "test-" + hex.EncodeToString(b)
+	collName := "foo_events"
+
+	t.Log("using DB:", db)
+
+	h := &mocks.EventBus{}
+
+	store, err := NewEventStore(url, db,
+		WithEventHandler(h),
+		WithCustomEventsCollectionName(collName),
+	)
+	if err != nil {
+		t.Fatal("there should be no error:", err)
+	}
+
+	if store == nil {
+		t.Fatal("there should be a store")
+	}
+
+	defer store.Close()
+
+	if store.aggregates.Name() != collName {
+		t.Fatal("events collection should use custom collection name")
+	}
+}
+
 func TestWithEventHandlerIntegration(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test")

--- a/eventstore/mongodb/eventstore_test.go
+++ b/eventstore/mongodb/eventstore_test.go
@@ -65,7 +65,7 @@ func TestEventStoreIntegration(t *testing.T) {
 	eventstore.AcceptanceTest(t, store, context.Background())
 }
 
-func TestWithCustomEventsCollectionNameIntegration(t *testing.T) {
+func TestWithCollectionNameIntegration(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test")
 	}
@@ -89,11 +89,8 @@ func TestWithCustomEventsCollectionNameIntegration(t *testing.T) {
 
 	t.Log("using DB:", db)
 
-	h := &mocks.EventBus{}
-
 	store, err := NewEventStore(url, db,
-		WithEventHandler(h),
-		WithCustomEventsCollectionName(collName),
+		WithCollectionName(collName),
 	)
 	if err != nil {
 		t.Fatal("there should be no error:", err)

--- a/eventstore/mongodb/eventstore_test.go
+++ b/eventstore/mongodb/eventstore_test.go
@@ -105,6 +105,14 @@ func TestWithCollectionNameIntegration(t *testing.T) {
 	if store.aggregates.Name() != collName {
 		t.Fatal("events collection should use custom collection name")
 	}
+
+	// providing empty collection names should result in an error
+	_, err = NewEventStore(url, db,
+		WithCollectionName(""),
+	)
+	if err == nil || err.Error() != "error while applying option: missing collection name" {
+		t.Fatal("there should be an error")
+	}
 }
 
 func TestWithEventHandlerIntegration(t *testing.T) {

--- a/eventstore/mongodb_v2/eventstore.go
+++ b/eventstore/mongodb_v2/eventstore.go
@@ -16,7 +16,6 @@ package mongodb_v2
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"time"
 
@@ -33,9 +32,6 @@ import (
 	eh "github.com/looplab/eventhorizon"
 	"github.com/looplab/eventhorizon/uuid"
 )
-
-// ErrCollectionNamesEqual is when provided custom collection names are equal.
-var ErrCollectionNamesEqual = errors.New("custom collection names are equal")
 
 // EventStore is an eventhorizon.EventStore for MongoDB, using one collection
 // for all events and another to keep track of all aggregates/streams. It also
@@ -159,7 +155,11 @@ func WithEventHandlerInTX(h eh.EventHandler) Option {
 func WithCollectionNames(eventsColl, streamsColl string) Option {
 	return func(s *EventStore) error {
 		if eventsColl == streamsColl {
-			return ErrCollectionNamesEqual
+			return fmt.Errorf("custom collection names are equal")
+		}
+
+		if eventsColl == "" || streamsColl == "" {
+			return fmt.Errorf("missing collection name")
 		}
 
 		s.events = s.db.Collection(eventsColl)

--- a/eventstore/mongodb_v2/eventstore.go
+++ b/eventstore/mongodb_v2/eventstore.go
@@ -38,6 +38,7 @@ import (
 // keep tracks of the global position of events, stored as metadata.
 type EventStore struct {
 	client                *mongo.Client
+	db                    *mongo.Database
 	events                *mongo.Collection
 	streams               *mongo.Collection
 	eventHandlerAfterSave eh.EventHandler
@@ -68,6 +69,7 @@ func NewEventStoreWithClient(client *mongo.Client, dbName string, options ...Opt
 	db := client.Database(dbName)
 	s := &EventStore{
 		client:  client,
+		db:      db,
 		events:  db.Collection("events"),
 		streams: db.Collection("streams"),
 	}
@@ -143,6 +145,15 @@ func WithEventHandlerInTX(h eh.EventHandler) Option {
 		}
 
 		s.eventHandlerInTX = h
+
+		return nil
+	}
+}
+
+// WithCustomEventsCollectionName uses a different event collection than the default "events".
+func WithCustomEventsCollectionName(collName string) Option {
+	return func(s *EventStore) error {
+		s.events = s.db.Collection(collName)
 
 		return nil
 	}

--- a/eventstore/mongodb_v2/eventstore_test.go
+++ b/eventstore/mongodb_v2/eventstore_test.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
-	"errors"
 	"os"
 	"testing"
 	"time"
@@ -112,10 +111,27 @@ func TestWithCollectionNamesIntegration(t *testing.T) {
 		t.Fatal("streams collection should use custom collection name")
 	}
 
+	// providing the same collection name should result in an error
 	_, err = NewEventStore(url, db,
 		WithCollectionNames("my-collection", "my-collection"),
 	)
-	if !errors.Is(err, ErrCollectionNamesEqual) {
+	if err == nil || err.Error() != "error while applying option: custom collection names are equal" {
+		t.Fatal("there should be an error")
+	}
+
+	// providing empty collection names should result in an error
+	_, err = NewEventStore(url, db,
+		WithCollectionNames("", "my-collection"),
+	)
+	if err == nil || err.Error() != "error while applying option: missing collection name" {
+		t.Fatal("there should be an error")
+	}
+
+	// providing empty collection names should result in an error
+	_, err = NewEventStore(url, db,
+		WithCollectionNames("my-collection", ""),
+	)
+	if err == nil || err.Error() != "error while applying option: missing collection name" {
 		t.Fatal("there should be an error")
 	}
 }

--- a/eventstore/mongodb_v2/eventstore_test.go
+++ b/eventstore/mongodb_v2/eventstore_test.go
@@ -65,7 +65,7 @@ func TestEventStoreIntegration(t *testing.T) {
 	eventstore.AcceptanceTest(t, store, context.Background())
 }
 
-func TestWithCustomCollectionNamesIntegration(t *testing.T) {
+func TestWithCustomEventsCollectionNameIntegration(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test")
 	}


### PR DESCRIPTION
### Description

This PR adds the ability to configure in which collection the mongo event store saves events. This would be useful, for example, when I use the namespace package and want to store events in different collections for each tenant. Currently I can only separate them on a "per database" basis.

### Affected Components

- Event Store (Mongo v1, Mongo v2)

### Related Issues

Closes #328 

### Solution and Design

Using an optional function to provide the custom collection name.

### Steps to test and verify

1. Run the TestWithCollectionNameIntegration tests in eventstore/mongodb and eventstore/mongodb_v2.
