### PR TITLE
Fix / Return error in projector for removed models

### DIFF
--- a/eventhandler/projector/eventhandler.go
+++ b/eventhandler/projector/eventhandler.go
@@ -46,6 +46,8 @@ func (t Type) String() string {
 var (
 	// ErrModelNotSet is when a model factory is not set on the EventHandler.
 	ErrModelNotSet = errors.New("model not set")
+	// ErrModelRemoved is when a model has been removed.
+	ErrModelRemoved = errors.New("model removed")
 	// Returned if the model has not incremented its version as predicted.
 	ErrIncorrectProjectedEntityVersion = errors.New("incorrect projected entity version")
 )
@@ -249,6 +251,16 @@ retryOnce:
 				time.Sleep(100 * time.Millisecond)
 
 				goto retryOnce
+			}
+
+			if entityVersion == 0 && event.Version() > 1 {
+				return &Error{
+					Err:           ErrModelRemoved,
+					Projector:     h.projector.ProjectorType().String(),
+					Event:         event,
+					EntityID:      id,
+					EntityVersion: entityVersion,
+				}
 			}
 
 			return &Error{


### PR DESCRIPTION
### Description

Return `projector.ErrModelRemoved` in case the model was removed when projecting. This check only works if regular versioning is used as the removed status can't be discerned from a not-created entity that would begin on for example version 2.

### Affected Components

- Projector

### Related Issues

Fixes #362

### Solution and Design

Works by checking that the event is v1 if the model is v0, which means that the model did not exist in the store.

### Steps to test and verify
