### PR TITLE
Fix / Cancel early when handling commands

### DIFF
--- a/commandhandler/aggregate/commandhandler.go
+++ b/commandhandler/aggregate/commandhandler.go
@@ -55,6 +55,12 @@ func NewCommandHandler(t eh.AggregateType, store eh.AggregateStore) (*CommandHan
 // HandleCommand handles a command with the registered aggregate.
 // Returns ErrAggregateNotFound if no aggregate could be found.
 func (h *CommandHandler) HandleCommand(ctx context.Context, cmd eh.Command) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+
 	if err := eh.CheckCommand(cmd); err != nil {
 		return err
 	}

--- a/commandhandler/bus/commandhandler.go
+++ b/commandhandler/bus/commandhandler.go
@@ -45,6 +45,12 @@ func NewCommandHandler() *CommandHandler {
 
 // HandleCommand handles a command with a handler capable of handling it.
 func (h *CommandHandler) HandleCommand(ctx context.Context, cmd eh.Command) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+
 	if err := eh.CheckCommand(cmd); err != nil {
 		return err
 	}


### PR DESCRIPTION
### Description

Sometimes when a saga tries to run a command during session shutdown it results in an unclear error, often during loading of events from the DB. By detecting a cancelled context earlier the error will for example say "could not run saga: canceled".

### Affected Components

- Command handler, bus and aggregate

### Related Issues

### Solution and Design

### Steps to test and verify
