### PR TITLE
Fix / Register tracing context manually

### DIFF
--- a/examples/todomvc/backend/handler/handler.go
+++ b/examples/todomvc/backend/handler/handler.go
@@ -72,7 +72,7 @@ func NewHandler(
 
 	// Simple HTTP request logging middleware as final handler.
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		log.Println(r.Method, r.URL)
+		log.Printf("%s %s\n", r.Method, r.URL.EscapedPath())
 		h.ServeHTTP(w, r)
 	})
 

--- a/examples/todomvc/backend/main.go
+++ b/examples/todomvc/backend/main.go
@@ -77,6 +77,8 @@ func main() {
 		log.Fatal("could not create tracer: ", err)
 	}
 
+	tracing.RegisterContext()
+
 	// Create the outbox that will project and publish events.
 	var outbox eh.Outbox
 

--- a/tracing/context.go
+++ b/tracing/context.go
@@ -29,7 +29,17 @@ const (
 	tracingSpanKeyStr = "eh_tracing_span"
 )
 
-func init() {
+// RegisterContext registers the tracing span to be marshaled/unmarshaled on the
+// context. This enables propagation of the tracing spans for backends that
+// supports it (like Jaeger).
+//
+// For usage with Elastic APM which doesn't support submitting of child spans
+// for the same parent span multiple times outside of a single transaction don't
+// register the context. This will provide a new context upon handling in the
+// event bus or outbox, which currently is the best Elastic APM can support.
+//
+// See: https://github.com/elastic/apm/issues/122
+func RegisterContext() {
 	eh.RegisterContextMarshaler(func(ctx context.Context, vals map[string]interface{}) {
 		if span := opentracing.SpanFromContext(ctx); span != nil {
 			tracer := opentracing.GlobalTracer()

--- a/tracing/eventbus_test.go
+++ b/tracing/eventbus_test.go
@@ -22,6 +22,10 @@ import (
 	"github.com/looplab/eventhorizon/eventbus/local"
 )
 
+func init() {
+	RegisterContext()
+}
+
 // NOTE: Not named "Integration" to enable running with the unit tests.
 func TestEventBusAddHandler(t *testing.T) {
 	if testing.Short() {


### PR DESCRIPTION
### Description

This should enable Elastic APM to register tracing of events in outbox and event bus handlers.

NOTE: Users of Jaeger will need to call `tracing.RegisterContext()` manually.

The reason for adding this is described in this issue: https://github.com/elastic/apm/issues/122

### Affected Components

- Tracing

### Related Issues

### Solution and Design

### Steps to test and verify
