### PR TITLE
Remove duplicate definition of MongoDB in docker-compose file

### DIFF
--- a/examples/todomvc/docker-compose.yml
+++ b/examples/todomvc/docker-compose.yml
@@ -24,15 +24,6 @@ services:
       MONGODB_REPLICA_SET_MODE: primary
       ALLOW_EMPTY_PASSWORD: "yes"
 
-  mongodb:
-    image: bitnami/mongodb:4.4
-    ports:
-      - 27017:27017
-    environment:
-      MONGODB_REPLICA_SET_MODE: primary
-      MONGODB_ADVERTISED_HOSTNAME: localhost # Needed to connect from localhost.
-      ALLOW_EMPTY_PASSWORD: "yes"
-
   redis:
     image: redis:6.2-alpine3.13
     ports:


### PR DESCRIPTION
### Description

Cannot start the Todo MVC example application

### Affected Components

- Examples

### Related Issues

#377

### Solution and Design

Remove the duplicate MongoDB service from docker-compose file

### Steps to test and verify

1. Navigate to `./examples/todomvc`
2. Run `docker-compose up`
