### PR TITLE
Avoid reusing variable name + ensure not nil check

### DIFF
--- a/eventstore.go
+++ b/eventstore.go
@@ -107,8 +107,8 @@ func (e *EventStoreError) Error() string {
 
 	if len(e.Events) > 0 {
 		var es []string
-		for _, e := range e.Events {
-			es = append(es, e.String())
+		for _, ev := range e.Events {
+			es = append(es, ev.String())
 		}
 
 		str += " [" + strings.Join(es, ", ") + "]"

--- a/eventstore.go
+++ b/eventstore.go
@@ -108,7 +108,11 @@ func (e *EventStoreError) Error() string {
 	if len(e.Events) > 0 {
 		var es []string
 		for _, ev := range e.Events {
-			es = append(es, ev.String())
+			if ev != nil {
+				es = append(es, ev.String())
+			} else {
+				es = append(es, "nil event")
+			}
 		}
 
 		str += " [" + strings.Join(es, ", ") + "]"


### PR DESCRIPTION
### Description

- Avoid reusing the `e` variable name.
- Ensure the `ev` is non-nil before calling `.String()`


### Affected Components

- EventstoreError

### Related Issues

### Solution and Design

### Steps to test and verify

