### PR TITLE
fix(eventstore/mongodb): pass context with transaction to inTx handler

### DIFF
--- a/eventstore/mongodb_v2/eventstore.go
+++ b/eventstore/mongodb_v2/eventstore.go
@@ -354,7 +354,7 @@ func (s *EventStore) Save(ctx context.Context, events []eh.Event, originalVersio
 
 		if s.eventHandlerInTX != nil {
 			for _, e := range events {
-				if err := s.eventHandlerInTX.HandleEvent(ctx, e); err != nil {
+				if err := s.eventHandlerInTX.HandleEvent(txCtx, e); err != nil {
 					return nil, fmt.Errorf("could not handle event in transaction: %w", err)
 				}
 			}


### PR DESCRIPTION
### Description

 pass context with transaction to `eventHandlerInTX`

### Affected Components

- Event Store, outbox

### Related Issues

### Solution and Design

passes the txCtx with transaction to handler instead of empty context

### Steps to test and verify

In handler that is assigned `WithEventHandlerInTX` write this below and you should get no session without this fix
```go 
func (c *myHandler)  HandleEvent(ctx context.Context, e eh.Event) error{
  session := mongodb.SessionFromContext(ctx)
  if session  == nil {
    fmt.Println("no session")
  } else {
     fmt.Printf("session: %v", session.ID())
  }
}
```

