### PR TITLE
Eventstore snapshot

### DIFF
--- a/aggregate.go
+++ b/aggregate.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/looplab/eventhorizon/uuid"
 )
@@ -56,6 +57,13 @@ type AggregateStore interface {
 
 	// Save saves the uncommitted events for an aggregate.
 	Save(context.Context, Aggregate) error
+}
+
+// SnapshotStrategy determines if a snapshot should be taken or not.
+type SnapshotStrategy interface {
+	ShouldTakeSnapshot(lastSnapshotVersion int,
+		lastSnapshotTimestamp time.Time,
+		event Event) bool
 }
 
 var (
@@ -148,7 +156,8 @@ func (e *AggregateError) Cause() error {
 // used to create concrete aggregate types when loading from the database.
 //
 // An example would be:
-//     RegisterAggregate(func(id UUID) Aggregate { return &MyAggregate{id} })
+//
+//	RegisterAggregate(func(id UUID) Aggregate { return &MyAggregate{id} })
 func RegisterAggregate(factory func(uuid.UUID) Aggregate) {
 	// Check that the created aggregate matches the registered type.
 	// TODO: Explore the use of reflect/gob for creating concrete types without

--- a/aggregatestore/events/snapshotstrategy.go
+++ b/aggregatestore/events/snapshotstrategy.go
@@ -1,0 +1,65 @@
+// Copyright (c) 2021 - The Event Horizon authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package events
+
+import (
+	"time"
+
+	eh "github.com/looplab/eventhorizon"
+)
+
+// NoSnapshotStrategy no snapshot should be taken.
+type NoSnapshotStrategy struct {
+}
+
+func (s *NoSnapshotStrategy) ShouldTakeSnapshot(_ int,
+	_ time.Time,
+	_ eh.Event) bool {
+	return false
+}
+
+// EveryNumberEventSnapshotStrategy use to take a snapshot every n number of events.
+type EveryNumberEventSnapshotStrategy struct {
+	snapshotThreshold int
+}
+
+func NewEveryNumberEventSnapshotStrategy(threshold int) *EveryNumberEventSnapshotStrategy {
+	return &EveryNumberEventSnapshotStrategy{
+		snapshotThreshold: threshold,
+	}
+}
+
+func (s *EveryNumberEventSnapshotStrategy) ShouldTakeSnapshot(lastSnapshotVersion int,
+	_ time.Time,
+	event eh.Event) bool {
+	return event.Version()-lastSnapshotVersion >= s.snapshotThreshold
+}
+
+// PeriodSnapshotStrategy use to take a snapshot every time a period has elapsed, for example every hour.
+type PeriodSnapshotStrategy struct {
+	snapshotThreshold time.Duration
+}
+
+func NewPeriodSnapshotStrategy(threshold time.Duration) *PeriodSnapshotStrategy {
+	return &PeriodSnapshotStrategy{
+		snapshotThreshold: threshold,
+	}
+}
+
+func (s *PeriodSnapshotStrategy) ShouldTakeSnapshot(_ int,
+	lastSnapshotTimestamp time.Time,
+	event eh.Event) bool {
+	return event.Timestamp().Sub(lastSnapshotTimestamp) >= s.snapshotThreshold
+}

--- a/aggregatestore/events/snapshotstrategy_test.go
+++ b/aggregatestore/events/snapshotstrategy_test.go
@@ -1,0 +1,70 @@
+// Copyright (c) 2021 - The Event Horizon authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package events
+
+import (
+	"testing"
+	"time"
+
+	eh "github.com/looplab/eventhorizon"
+	"github.com/looplab/eventhorizon/mocks"
+	"github.com/looplab/eventhorizon/uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNoSnapshotStrategy_ShouldNotTakeSnapshot(t *testing.T) {
+	strategy := NoSnapshotStrategy{}
+
+	timestamp := time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)
+	result := strategy.ShouldTakeSnapshot(1, timestamp, eh.NewEvent(mocks.EventType, &mocks.EventData{Content: "event"}, timestamp))
+
+	assert.False(t, result)
+}
+
+func TestEveryNumberEventSnapshotStrategy_ShouldTakeSnapshot(t *testing.T) {
+	strategy := NewEveryNumberEventSnapshotStrategy(2)
+
+	timestamp := time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)
+	lastEvt := eh.NewEvent(mocks.EventType,
+		&mocks.EventData{Content: "event"}, timestamp,
+		eh.ForAggregate("testAgg", uuid.New(), 4))
+
+	result := strategy.ShouldTakeSnapshot(2, timestamp, lastEvt)
+
+	assert.True(t, result)
+
+	result = strategy.ShouldTakeSnapshot(3, timestamp, lastEvt)
+
+	assert.False(t, result)
+}
+
+func TestPeriodSnapshotStrategy_ShouldTakeSnapshot(t *testing.T) {
+	strategy := NewPeriodSnapshotStrategy(10 * time.Minute)
+
+	timestamp := time.Date(2009, time.November, 10, 23, 20, 0, 0, time.UTC)
+	lastEvt := eh.NewEvent(mocks.EventType,
+		&mocks.EventData{Content: "event"}, timestamp,
+		eh.ForAggregate("testAgg", uuid.New(), 4))
+
+	snapshotTimestamp := time.Date(2009, time.November, 10, 23, 10, 0, 0, time.UTC)
+	result := strategy.ShouldTakeSnapshot(10, snapshotTimestamp, lastEvt)
+
+	assert.True(t, result)
+
+	snapshotTimestamp = time.Date(2009, time.November, 10, 23, 15, 0, 0, time.UTC)
+	result = strategy.ShouldTakeSnapshot(10, snapshotTimestamp, lastEvt)
+
+	assert.False(t, result)
+}

--- a/commandhandler/aggregate/commandhandler_test.go
+++ b/commandhandler/aggregate/commandhandler_test.go
@@ -28,6 +28,7 @@ import (
 func TestNewCommandHandler(t *testing.T) {
 	store := &mocks.AggregateStore{
 		Aggregates: make(map[uuid.UUID]eh.Aggregate),
+		Snapshots:  make(map[uuid.UUID]eh.Snapshot),
 	}
 
 	h, err := NewCommandHandler(mocks.AggregateType, store)
@@ -76,6 +77,7 @@ func TestCommandHandler(t *testing.T) {
 func TestCommandHandler_AggregateNotFound(t *testing.T) {
 	store := &mocks.AggregateStore{
 		Aggregates: map[uuid.UUID]eh.Aggregate{},
+		Snapshots:  make(map[uuid.UUID]eh.Snapshot),
 	}
 
 	h, err := NewCommandHandler(mocks.AggregateType, store)
@@ -155,6 +157,7 @@ func BenchmarkCommandHandler(b *testing.B) {
 		Aggregates: map[uuid.UUID]eh.Aggregate{
 			a.EntityID(): a,
 		},
+		Snapshots: make(map[uuid.UUID]eh.Snapshot),
 	}
 
 	h, err := NewCommandHandler(mocks.AggregateType, store)
@@ -183,6 +186,7 @@ func createAggregateAndHandler(t *testing.T) (*mocks.Aggregate, *CommandHandler,
 		Aggregates: map[uuid.UUID]eh.Aggregate{
 			a.EntityID(): a,
 		},
+		Snapshots: make(map[uuid.UUID]eh.Snapshot),
 	}
 
 	h, err := NewCommandHandler(mocks.AggregateType, store)

--- a/eventstore.go
+++ b/eventstore.go
@@ -31,8 +31,17 @@ type EventStore interface {
 	// Load loads all events for the aggregate id from the store.
 	Load(context.Context, uuid.UUID) ([]Event, error)
 
+	// LoadFrom loads all events from version for the aggregate id from the store.
+	LoadFrom(ctx context.Context, id uuid.UUID, version int) ([]Event, error)
+
 	// Close closes the EventStore.
 	Close() error
+}
+
+// SnapshotStore is an interface for snapshot store.
+type SnapshotStore interface {
+	LoadSnapshot(ctx context.Context, id uuid.UUID) (*Snapshot, error)
+	SaveSnapshot(ctx context.Context, id uuid.UUID, snapshot Snapshot) error
 }
 
 var (
@@ -64,6 +73,11 @@ const (
 	EventStoreOpRename = "rename"
 	// Errors during clearing of the event store.
 	EventStoreOpClear = "clear"
+
+	// Errors during loading of snapshot.
+	EventStoreOpLoadSnapshot = "load_snapshot"
+	// Errors during saving of snapshot.
+	EventStoreOpSaveSnapshot = "save_snapshot"
 )
 
 // EventStoreError is an error in the event store.

--- a/eventstore/acceptance_testing.go
+++ b/eventstore/acceptance_testing.go
@@ -25,17 +25,17 @@ import (
 	eh "github.com/looplab/eventhorizon"
 	"github.com/looplab/eventhorizon/mocks"
 	"github.com/looplab/eventhorizon/uuid"
+	"github.com/stretchr/testify/assert"
 )
 
 // AcceptanceTest is the acceptance test that all implementations of EventStore
 // should pass. It should manually be called from a test case in each
 // implementation:
 //
-//   func TestEventStore(t *testing.T) {
-//       store := NewEventStore()
-//       eventstore.AcceptanceTest(t, store, context.Background())
-//   }
-//
+//	func TestEventStore(t *testing.T) {
+//	    store := NewEventStore()
+//	    eventstore.AcceptanceTest(t, store, context.Background())
+//	}
 func AcceptanceTest(t *testing.T, store eh.EventStore, ctx context.Context) []eh.Event {
 	savedEvents := []eh.Event{}
 
@@ -212,6 +212,78 @@ func AcceptanceTest(t *testing.T, store eh.EventStore, ctx context.Context) []eh
 	}
 
 	return savedEvents
+}
+
+func SnapshotAcceptanceTest(t *testing.T, store eh.EventStore, ctx context.Context) {
+	snapshotStore, ok := store.(eh.SnapshotStore)
+	if !ok {
+		return
+	}
+
+	id := uuid.New()
+
+	eventStoreErr := &eh.EventStoreError{}
+
+	err := snapshotStore.SaveSnapshot(ctx, id, eh.Snapshot{})
+	if !errors.As(err, &eventStoreErr) {
+		t.Error("there should be a event store error:", err)
+	}
+
+	err = snapshotStore.SaveSnapshot(ctx, id, eh.Snapshot{
+		AggregateType: "test",
+	})
+	if !errors.As(err, &eventStoreErr) {
+		t.Error("there should be a event store error:", err)
+	}
+
+	type TestData struct {
+		Data string
+	}
+
+	snapshot := eh.Snapshot{
+		Version:       1,
+		AggregateType: "test",
+		Timestamp:     time.Now(),
+		State: &TestData{
+			Data: "this is incredible data",
+		},
+	}
+
+	eh.RegisterSnapshotData("test", func(uuid.UUID) eh.SnapshotData { return &TestData{} })
+
+	if err := snapshotStore.SaveSnapshot(ctx, id, snapshot); err != nil {
+		t.Error("there should not be an error")
+	}
+
+	loaded, err := snapshotStore.LoadSnapshot(ctx, uuid.New())
+	if loaded != nil {
+		t.Error("snapshot should be nil, it doesnt exists")
+	}
+
+	loaded, err = snapshotStore.LoadSnapshot(ctx, id)
+	if err != nil {
+		t.Error("there should  be an error")
+	}
+
+	assert.Equal(t, snapshot.Version, loaded.Version)
+	assert.Equal(t, snapshot.AggregateType, loaded.AggregateType)
+	assert.Equal(t, snapshot.State, loaded.State)
+
+	snapshot.State = &TestData{
+		Data: "this is new incredible data",
+	}
+	if err := snapshotStore.SaveSnapshot(ctx, id, snapshot); err != nil {
+		t.Error("there should not be a error")
+	}
+
+	loaded, err = snapshotStore.LoadSnapshot(ctx, id)
+	if err != nil {
+		t.Error("there should not be a error")
+	}
+
+	assert.Equal(t, snapshot.Version, loaded.Version)
+	assert.Equal(t, snapshot.AggregateType, loaded.AggregateType)
+	assert.Equal(t, snapshot.State, loaded.State)
 }
 
 func eventsToString(events []eh.Event) string {

--- a/eventstore/acceptance_testing.go
+++ b/eventstore/acceptance_testing.go
@@ -269,6 +269,8 @@ func SnapshotAcceptanceTest(t *testing.T, store eh.EventStore, ctx context.Conte
 	assert.Equal(t, snapshot.AggregateType, loaded.AggregateType)
 	assert.Equal(t, snapshot.State, loaded.State)
 
+	snapshot.Version += 1
+	snapshot.Timestamp = time.Now()
 	snapshot.State = &TestData{
 		Data: "this is new incredible data",
 	}

--- a/eventstore/mongodb_v2/eventstore.go
+++ b/eventstore/mongodb_v2/eventstore.go
@@ -618,6 +618,8 @@ func (s *EventStore) Close() error {
 type SnapshotRecord struct {
 	Id            uuid.UUID        `bson:"_id"`
 	RawData       []byte           `bson:"data"`
+	Timestamp     time.Time        `bson:"timestamp"`
+	Version       int              `bson:"version"`
 	AggregateType eh.AggregateType `bson:"aggregate_type"`
 }
 

--- a/eventstore/mongodb_v2/eventstore.go
+++ b/eventstore/mongodb_v2/eventstore.go
@@ -15,12 +15,18 @@
 package mongodb_v2
 
 import (
+	"bytes"
+	"compress/gzip"
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"time"
 
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
 	mongoOptions "go.mongodb.org/mongo-driver/mongo/options"
 	"go.mongodb.org/mongo-driver/mongo/readconcern"
 	"go.mongodb.org/mongo-driver/mongo/readpref"
@@ -37,13 +43,15 @@ import (
 // for all events and another to keep track of all aggregates/streams. It also
 // keep tracks of the global position of events, stored as metadata.
 type EventStore struct {
-	client                *mongo.Client
-	clientOwnership       clientOwnership
-	db                    *mongo.Database
-	events                *mongo.Collection
-	streams               *mongo.Collection
-	eventHandlerAfterSave eh.EventHandler
-	eventHandlerInTX      eh.EventHandler
+	client                  *mongo.Client
+	clientOwnership         clientOwnership
+	db                      *mongo.Database
+	events                  *mongo.Collection
+	streams                 *mongo.Collection
+	snapshots               *mongo.Collection
+	eventHandlerAfterSave   eh.EventHandler
+	eventHandlerInTX        eh.EventHandler
+	skipNonRegisteredEvents bool
 }
 
 type clientOwnership int
@@ -85,6 +93,7 @@ func newEventStoreWithClient(client *mongo.Client, clientOwnership clientOwnersh
 		db:              db,
 		events:          db.Collection("events"),
 		streams:         db.Collection("streams"),
+		snapshots:       db.Collection("snapshots"),
 	}
 
 	for _, option := range options {
@@ -101,6 +110,12 @@ func newEventStoreWithClient(client *mongo.Client, clientOwnership clientOwnersh
 
 	if _, err := s.events.Indexes().CreateOne(ctx, mongo.IndexModel{
 		Keys: bson.M{"aggregate_id": 1},
+	}); err != nil {
+		return nil, fmt.Errorf("could not ensure events index: %w", err)
+	}
+
+	if _, err := s.events.Indexes().CreateOne(ctx, mongo.IndexModel{
+		Keys: bson.M{"version": 1},
 	}); err != nil {
 		return nil, fmt.Errorf("could not ensure events index: %w", err)
 	}
@@ -398,6 +413,24 @@ func (s *EventStore) Load(ctx context.Context, id uuid.UUID) ([]eh.Event, error)
 		}
 	}
 
+	return s.loadFromCursor(ctx, id, cursor)
+}
+
+// LoadFrom implements LoadFrom method of the eventhorizon.SnapshotStore interface.
+func (s *EventStore) LoadFrom(ctx context.Context, id uuid.UUID, version int) ([]eh.Event, error) {
+	cursor, err := s.events.Find(ctx, bson.M{"aggregate_id": id, "version": bson.M{"$gte": version}})
+	if err != nil {
+		return nil, &eh.EventStoreError{
+			Err:         fmt.Errorf("could not find event: %w", err),
+			Op:          eh.EventStoreOpLoad,
+			AggregateID: id,
+		}
+	}
+
+	return s.loadFromCursor(ctx, id, cursor)
+}
+
+func (s *EventStore) loadFromCursor(ctx context.Context, id uuid.UUID, cursor *mongo.Cursor) ([]eh.Event, error) {
 	var events []eh.Event
 
 	for cursor.Next(ctx) {
@@ -464,6 +497,114 @@ func (s *EventStore) Load(ctx context.Context, id uuid.UUID) ([]eh.Event, error)
 	return events, nil
 }
 
+func (s *EventStore) LoadSnapshot(ctx context.Context, id uuid.UUID) (*eh.Snapshot, error) {
+	result := s.snapshots.FindOne(ctx, bson.M{"_id": id})
+	if err := result.Err(); err != nil {
+		if errors.Is(err, mongo.ErrNoDocuments) {
+			return nil, nil
+		}
+
+		return nil, err
+	}
+
+	var (
+		record   = new(SnapshotRecord)
+		snapshot = new(eh.Snapshot)
+		err      error
+	)
+
+	if err := result.Decode(record); err != nil {
+		return nil, &eh.EventStoreError{
+			Err:         fmt.Errorf("could not decode snapshot: %w", err),
+			Op:          eh.EventStoreOpLoadSnapshot,
+			AggregateID: id,
+		}
+	}
+
+	if snapshot.State, err = eh.CreateSnapshotData(record.Id, record.AggregateType); err != nil {
+		return nil, &eh.EventStoreError{
+			Err:         fmt.Errorf("could not decode snapshot: %w", err),
+			Op:          eh.EventStoreOpLoadSnapshot,
+			AggregateID: id,
+		}
+	}
+
+	if err = record.decompress(); err != nil {
+		return nil, &eh.EventStoreError{
+			Err:         fmt.Errorf("could not decompress snapshot: %w", err),
+			Op:          eh.EventStoreOpLoadSnapshot,
+			AggregateID: id,
+		}
+	}
+
+	if err = json.Unmarshal(record.RawData, snapshot); err != nil {
+		return nil, &eh.EventStoreError{
+			Err:         fmt.Errorf("could not decode snapshot: %w", err),
+			Op:          eh.EventStoreOpLoadSnapshot,
+			AggregateID: id,
+		}
+	}
+
+	return snapshot, nil
+}
+
+func (s *EventStore) SaveSnapshot(ctx context.Context, id uuid.UUID, snapshot eh.Snapshot) (err error) {
+	if snapshot.AggregateType == "" {
+		return &eh.EventStoreError{
+			Err:           fmt.Errorf("aggregate type is empty"),
+			Op:            eh.EventStoreOpSaveSnapshot,
+			AggregateID:   id,
+			AggregateType: snapshot.AggregateType,
+		}
+	}
+
+	if snapshot.State == nil {
+		return &eh.EventStoreError{
+			Err:           fmt.Errorf("snapshots state is nil"),
+			Op:            eh.EventStoreOpSaveSnapshot,
+			AggregateID:   id,
+			AggregateType: snapshot.AggregateType,
+		}
+	}
+
+	record := SnapshotRecord{
+		Id:            id,
+		AggregateType: snapshot.AggregateType,
+		Timestamp:     time.Now(),
+		Version:       snapshot.Version,
+	}
+
+	if record.RawData, err = json.Marshal(snapshot); err != nil {
+		return
+	}
+
+	if err = record.compress(); err != nil {
+		return &eh.EventStoreError{
+			Err:         fmt.Errorf("could not compress snapshot: %w", err),
+			Op:          eh.EventStoreOpSaveSnapshot,
+			AggregateID: id,
+		}
+	}
+
+	if _, err := s.snapshots.UpdateOne(ctx,
+		bson.M{
+			"_id": id.String(),
+		},
+		bson.M{
+			"$set": record,
+		},
+		options.Update().SetUpsert(true),
+	); err != nil {
+		return &eh.EventStoreError{
+			Err:         fmt.Errorf("could not save snapshot: %w", err),
+			Op:          eh.EventStoreOpSaveSnapshot,
+			AggregateID: id,
+		}
+	}
+
+	return nil
+}
+
 // Close implements the Close method of the eventhorizon.EventStore interface.
 func (s *EventStore) Close() error {
 	if s.clientOwnership == externalClient {
@@ -472,6 +613,46 @@ func (s *EventStore) Close() error {
 	}
 
 	return s.client.Disconnect(context.Background())
+}
+
+type SnapshotRecord struct {
+	Id            uuid.UUID        `bson:"_id"`
+	RawData       []byte           `bson:"data"`
+	AggregateType eh.AggregateType `bson:"aggregate_type"`
+}
+
+func (r *SnapshotRecord) decompress() error {
+	byteReader := bytes.NewReader(r.RawData)
+	reader, err := gzip.NewReader(byteReader)
+
+	if err != nil {
+		return err
+	}
+
+	r.RawData, err = io.ReadAll(reader)
+
+	return err
+}
+
+func (r *SnapshotRecord) compress() error {
+	var b bytes.Buffer
+	w := gzip.NewWriter(&b)
+
+	if _, err := w.Write(r.RawData); err != nil {
+		return err //nolint:wrapcheck
+	}
+
+	if err := w.Flush(); err != nil {
+		return err //nolint:wrapcheck
+	}
+
+	if err := w.Close(); err != nil {
+		return err //nolint:wrapcheck
+	}
+
+	r.RawData = b.Bytes()
+
+	return nil
 }
 
 // stream is a stream of events, often containing the events for an aggregate.

--- a/eventstore/mongodb_v2/eventstore_test.go
+++ b/eventstore/mongodb_v2/eventstore_test.go
@@ -62,6 +62,8 @@ func TestEventStoreIntegration(t *testing.T) {
 
 	eventstore.AcceptanceTest(t, store, context.Background())
 
+	eventstore.SnapshotAcceptanceTest(t, store, context.Background())
+
 	if err := store.Close(); err != nil {
 		t.Error("there should be no error:", err)
 	}

--- a/middleware/commandhandler/scheduler/middleware_test.go
+++ b/middleware/commandhandler/scheduler/middleware_test.go
@@ -128,7 +128,7 @@ func TestMiddleware_PersistedIntegration(t *testing.T) {
 		addr = "localhost:27017"
 	}
 
-	url := "mongodb://" + addr
+	url := "mongodb://" + addr + "/?readPreference=primary&directConnection=true&ssl=false"
 
 	// Get a random DB name.
 	b := make([]byte, 4)

--- a/namespace/eventstore.go
+++ b/namespace/eventstore.go
@@ -35,25 +35,27 @@ type EventStore struct {
 // function to create new event stores for the provided namespace.
 //
 // Usage:
-//    eventStore := NewEventStore(func(ns string) (eh.EventStore, error) {
-//        s, err := mongodb.NewEventStore("mongodb://", ns)
-//        if err != nil {
-//            return nil, err
-//        }
-//        return s, nil
-//    })
+//
+//	eventStore := NewEventStore(func(ns string) (eh.EventStore, error) {
+//	    s, err := mongodb.NewEventStore("mongodb://", ns)
+//	    if err != nil {
+//	        return nil, err
+//	    }
+//	    return s, nil
+//	})
 //
 // Usage shared DB client:
-//    client, err := mongo.Connect(ctx)
-//    ...
 //
-//    eventStore := NewEventStore(func(ns string) (eh.EventStore, error) {
-//        s, err := mongodb.NewEventStoreWithClient(client, ns)
-//        if err != nil {
-//            return nil, err
-//        }
-//        return s, nil
-//    })
+//	client, err := mongo.Connect(ctx)
+//	...
+//
+//	eventStore := NewEventStore(func(ns string) (eh.EventStore, error) {
+//	    s, err := mongodb.NewEventStoreWithClient(client, ns)
+//	    if err != nil {
+//	        return nil, err
+//	    }
+//	    return s, nil
+//	})
 func NewEventStore(factory func(ns string) (eh.EventStore, error)) *EventStore {
 	return &EventStore{
 		eventStores:   map[string]eh.EventStore{},
@@ -91,6 +93,16 @@ func (s *EventStore) Load(ctx context.Context, id uuid.UUID) ([]eh.Event, error)
 	}
 
 	return store.Load(ctx, id)
+}
+
+// LoadFrom loads all events from version for the aggregate id from the store.
+func (s *EventStore) LoadFrom(ctx context.Context, id uuid.UUID, version int) ([]eh.Event, error) {
+	store, err := s.eventStore(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return store.LoadFrom(ctx, id, version)
 }
 
 // Close implements the Close method of the eventhorizon.EventStore interface.

--- a/snapshot.go
+++ b/snapshot.go
@@ -1,0 +1,77 @@
+// Copyright (c) 2021 - The Event Horizon authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package eventhorizon
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+)
+
+// Snapshotable is an interface for creating and applying a Snapshot record.
+type Snapshotable interface {
+	CreateSnapshot() *Snapshot
+	ApplySnapshot(snapshot *Snapshot)
+}
+
+// Snapshot is a recording of the state of an aggregate at a point in time
+type Snapshot struct {
+	Version       int
+	AggregateType AggregateType
+	Timestamp     time.Time
+	State         interface{}
+}
+
+var snapshotDataFactories = make(map[AggregateType]func(uuid2 uuid.UUID) SnapshotData)
+
+type SnapshotData interface{}
+
+var snapshotDataFactoriesMu sync.RWMutex
+
+var ErrSnapshotDataNotRegistered = errors.New("snapshot data not registered")
+
+// RegisterSnapshotData registers an snapshot factory for a type. The factory is
+// used to create concrete snapshot state type when unmarshalling.
+//
+// An example would be:
+//
+//	RegisterSnapshotData("aggregateType1", func() SnapshotData { return &MySnapshotData{} })
+func RegisterSnapshotData(aggregateType AggregateType, factory func() SnapshotData) {
+	if aggregateType == AggregateType("") {
+		panic("eventhorizon: attempt to register empty aggregate type")
+	}
+
+	snapshotDataFactoriesMu.Lock()
+	defer snapshotDataFactoriesMu.Unlock()
+
+	if _, ok := snapshotDataFactories[aggregateType]; ok {
+		panic(fmt.Sprintf("eventhorizon: registering duplicate types for %q", aggregateType))
+	}
+
+	snapshotDataFactories[aggregateType] = factory
+}
+
+// CreateSnapshotData create a concrete instance using the registered snapshot factories.
+func CreateSnapshotData(AggregateID uuid.UUID, aggregateType AggregateType) (SnapshotData, error) {
+	snapshotDataFactoriesMu.RLock()
+	defer snapshotDataFactoriesMu.RUnlock()
+
+	if factory, ok := snapshotDataFactories[aggregateType]; ok {
+		return factory(AggregateID), nil
+	}
+
+	return nil, ErrSnapshotDataNotRegistered
+}

--- a/snapshot.go
+++ b/snapshot.go
@@ -19,6 +19,8 @@ import (
 	"fmt"
 	"sync"
 	"time"
+
+	"github.com/looplab/eventhorizon/uuid"
 )
 
 // Snapshotable is an interface for creating and applying a Snapshot record.
@@ -49,7 +51,7 @@ var ErrSnapshotDataNotRegistered = errors.New("snapshot data not registered")
 // An example would be:
 //
 //	RegisterSnapshotData("aggregateType1", func() SnapshotData { return &MySnapshotData{} })
-func RegisterSnapshotData(aggregateType AggregateType, factory func() SnapshotData) {
+func RegisterSnapshotData(aggregateType AggregateType, factory func(id uuid.UUID) SnapshotData) {
 	if aggregateType == AggregateType("") {
 		panic("eventhorizon: attempt to register empty aggregate type")
 	}


### PR DESCRIPTION
### Description

This adds snapshot capability to eventstore and aggregatestore. With given strategy saves a snapshot of aggregate and loads next time and remaining events wich can increase load times of long-living aggregates

### Affected Components

- Event Store(Mongodb, memory)
- AggregateSttore

### Related Issues

None

### Solution and Design
A eventstore implemtation can now implement `eh.SnapshotStore` an now store snaphots of current state in aggregate.

every aggregate that want to be snapshotted needs to implement `eh.Snapshotable` 

```go
type Snapshotable interface {
	CreateSnapshot() *Snapshot
	ApplySnapshot(snapshot *Snapshot)
}
```
#### Loading
When aggretate i requested to be loaded the store checks if aggretate implements `eh.Snapshotable` and tries to find latest snapshot for aggregate. Loads and applies snapshot then loads all events that is not applies in current snapshot.

#### Saving
When aggretate i requested to be saved the store checks if aggretate implements `eh.Snapshotable` and if the strategy return true we create a snapshot ans saves it alongside the events.

### Steps to test and verify

1. Add Strategy to aggregatestore
    - `EveryNumberEventSnapshotStrateg`  <- set to every *1*  
    - `PeriodSnapshotStrategy` 
    - `NoSnapshotStrategy`
2. Implement `ehSnapshotable` in longliving aggregate
3. check mongo db snapshot collection
