### PR TITLE
Add custom collection names

### DIFF
--- a/eventstore/mongodb_v2/eventstore.go
+++ b/eventstore/mongodb_v2/eventstore.go
@@ -24,6 +24,7 @@ import (
 	"io"
 	"time"
 
+	"github.com/looplab/eventhorizon/mongoutils"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
@@ -192,12 +193,12 @@ func WithEventHandlerInTX(h eh.EventHandler) Option {
 // Will return an error if provided parameters are equal.
 func WithCollectionNames(eventsColl, streamsColl string) Option {
 	return func(s *EventStore) error {
-		if eventsColl == streamsColl {
+		if err := mongoutils.CheckCollectionName(eventsColl); err != nil {
+			return fmt.Errorf("events collection: %w", err)
+		} else if err := mongoutils.CheckCollectionName(streamsColl); err != nil {
+			return fmt.Errorf("streams collection: %w", err)
+		} else if eventsColl == streamsColl {
 			return fmt.Errorf("custom collection names are equal")
-		}
-
-		if eventsColl == "" || streamsColl == "" {
-			return fmt.Errorf("missing collection name")
 		}
 
 		db := s.events.Database()
@@ -211,8 +212,8 @@ func WithCollectionNames(eventsColl, streamsColl string) Option {
 // WithSnapshotCollectionName uses different collections from the default "snapshots" collections.
 func WithSnapshotCollectionName(snapshotColl string) Option {
 	return func(s *EventStore) error {
-		if snapshotColl == "" {
-			return fmt.Errorf("missing collection name")
+		if err := mongoutils.CheckCollectionName(snapshotColl); err != nil {
+			return fmt.Errorf("snapshot collection: %w", err)
 		}
 
 		db := s.events.Database()

--- a/eventstore/mongodb_v2/eventstore_test.go
+++ b/eventstore/mongodb_v2/eventstore_test.go
@@ -112,7 +112,7 @@ func TestWithCollectionNamesIntegration(t *testing.T) {
 	_, err = NewEventStore(url, db,
 		WithCollectionNames("", "my-collection"),
 	)
-	if err == nil || err.Error() != "error while applying option: missing collection name" {
+	if err == nil || err.Error() != "error while applying option: events collection: missing collection name" {
 		t.Fatal("there should be an error")
 	}
 
@@ -120,7 +120,21 @@ func TestWithCollectionNamesIntegration(t *testing.T) {
 	_, err = NewEventStore(url, db,
 		WithCollectionNames("my-collection", ""),
 	)
-	if err == nil || err.Error() != "error while applying option: missing collection name" {
+	if err == nil || err.Error() != "error while applying option: streams collection: missing collection name" {
+		t.Fatal("there should be an error")
+	}
+	// providing invalid streams collection names should result in an error
+	_, err = NewEventStore(url, db,
+		WithCollectionNames("my-collection", "name with spaces"),
+	)
+	if err == nil || err.Error() != "error while applying option: streams collection: invalid char in collection name (space)" {
+		t.Fatal("there should be an error")
+	}
+	// providing invalid events collection names should result in an error
+	_, err = NewEventStore(url, db,
+		WithCollectionNames("my collection", "a-good-name"),
+	)
+	if err == nil || err.Error() != "error while applying option: events collection: invalid char in collection name (space)" {
 		t.Fatal("there should be an error")
 	}
 }
@@ -155,7 +169,15 @@ func TestWithSnapshotCollectionNamesIntegration(t *testing.T) {
 	_, err = NewEventStore(url, db,
 		WithSnapshotCollectionName(""),
 	)
-	if err == nil || err.Error() != "error while applying option: missing collection name" {
+	if err == nil || err.Error() != "error while applying option: snapshot collection: missing collection name" {
+		t.Fatal("there should be an error")
+	}
+
+	// providing invalid snapshot collection names should result in an error
+	_, err = NewEventStore(url, db,
+		WithSnapshotCollectionName("no space-allowed"),
+	)
+	if err == nil || err.Error() != "error while applying option: snapshot collection: invalid char in collection name (space)" {
 		t.Fatal("there should be an error")
 	}
 }

--- a/mongoutils/checks.go
+++ b/mongoutils/checks.go
@@ -1,0 +1,22 @@
+package mongoutils
+
+import (
+	"errors"
+	"strings"
+)
+
+var (
+	ErrMissingCollectionName       = errors.New("missing collection name")
+	ErrInvalidCharInCollectionName = errors.New("invalid char in collection name (space)")
+)
+
+// CheckCollectionName checks if a collection name is valid for mongodb.
+// We only check on spaces because they are hard to see by humans.
+func CheckCollectionName(name string) error {
+	if name == "" {
+		return ErrMissingCollectionName
+	} else if strings.ContainsAny(name, " ") {
+		return ErrInvalidCharInCollectionName
+	}
+	return nil
+}

--- a/mongoutils/checks_test.go
+++ b/mongoutils/checks_test.go
@@ -1,0 +1,45 @@
+package mongoutils
+
+import (
+	"testing"
+)
+
+func TestCheckValidCollectionName(t *testing.T) {
+	type args struct {
+		name string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			"empty name",
+			args{
+				name: "",
+			},
+			true,
+		},
+		{
+			"valid name",
+			args{
+				name: "valid",
+			},
+			false,
+		},
+		{
+			"with spaces",
+			args{
+				name: "invalid name",
+			},
+			true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := CheckCollectionName(tt.args.name); (err != nil) != tt.wantErr {
+				t.Errorf("CheckCollectionName() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/outbox/mongodb/outbox.go
+++ b/outbox/mongodb/outbox.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	bsonCodec "github.com/looplab/eventhorizon/codec/bson"
+	"github.com/looplab/eventhorizon/mongoutils"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
@@ -130,8 +131,8 @@ func WithWatchToken(token string) Option {
 // WithCollectionName uses different collections from the default "outbox" collection.
 func WithCollectionName(outboxColl string) Option {
 	return func(s *Outbox) error {
-		if outboxColl == "" {
-			return fmt.Errorf("missing collection name")
+		if err := mongoutils.CheckCollectionName(outboxColl); err != nil {
+			return fmt.Errorf("outbox collection: %w", err)
 		}
 
 		s.outbox = s.outbox.Database().Collection(outboxColl)

--- a/outbox/mongodb/outbox.go
+++ b/outbox/mongodb/outbox.go
@@ -127,6 +127,19 @@ func WithWatchToken(token string) Option {
 	}
 }
 
+// WithCollectionName uses different collections from the default "outbox" collection.
+func WithCollectionName(outboxColl string) Option {
+	return func(s *Outbox) error {
+		if outboxColl == "" {
+			return fmt.Errorf("missing collection name")
+		}
+
+		s.outbox = s.outbox.Database().Collection(outboxColl)
+
+		return nil
+	}
+}
+
 // Client returns the MongoDB client used by the outbox. To use the outbox with
 // the EventStore it needs to be created with the same client.
 func (o *Outbox) Client() *mongo.Client {
@@ -139,7 +152,7 @@ func (o *Outbox) HandlerType() eh.EventHandlerType {
 }
 
 // AddHandler implements the AddHandler method of the eventhorizon.Outbox interface.
-func (o *Outbox) AddHandler(ctx context.Context, m eh.EventMatcher, h eh.EventHandler) error {
+func (o *Outbox) AddHandler(_ context.Context, m eh.EventMatcher, h eh.EventHandler) error {
 	if m == nil {
 		return eh.ErrMissingMatcher
 	}

--- a/outbox/mongodb/outbox_test.go
+++ b/outbox/mongodb/outbox_test.go
@@ -78,6 +78,25 @@ func TestWithCollectionNameIntegration(t *testing.T) {
 	}
 }
 
+func TestWithCollectionNameInvalidNames(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	url, db := makeDB(t)
+
+	nameWithSpaces := "foo outbox"
+	_, err := NewOutbox(url, db, WithCollectionName(nameWithSpaces))
+	if err == nil || err.Error() != "error while applying option: outbox collection: invalid char in collection name (space)" {
+		t.Fatal("there should be an error")
+	}
+
+	_, err = NewOutbox(url, db, WithCollectionName(""))
+	if err == nil || err.Error() != "error while applying option: outbox collection: missing collection name" {
+		t.Fatal("there should be an error")
+	}
+}
+
 func makeDB(t *testing.T) (string, string) {
 	// Use MongoDB in Docker with fallback to localhost.
 	url := os.Getenv("MONGODB_ADDR")

--- a/outbox/mongodb/outbox_test.go
+++ b/outbox/mongodb/outbox_test.go
@@ -20,23 +20,7 @@ func TestOutboxAddHandler(t *testing.T) {
 		t.Skip("skipping integration test")
 	}
 
-	// Use MongoDB in Docker with fallback to localhost.
-	url := os.Getenv("MONGODB_ADDR")
-	if url == "" {
-		url = "localhost:27017"
-	}
-
-	url = "mongodb://" + url
-
-	// Get a random DB name.
-	bs := make([]byte, 4)
-	if _, err := rand.Read(bs); err != nil {
-		t.Fatal(err)
-	}
-
-	db := "test-" + hex.EncodeToString(bs)
-
-	t.Log("using DB:", db)
+	url, db := makeDB(t)
 
 	o, err := NewOutbox(url, db)
 	if err != nil {
@@ -51,23 +35,7 @@ func TestOutboxIntegration(t *testing.T) {
 		t.Skip("skipping integration test")
 	}
 
-	// Use MongoDB in Docker with fallback to localhost.
-	url := os.Getenv("MONGODB_ADDR")
-	if url == "" {
-		url = "localhost:27017"
-	}
-
-	url = "mongodb://" + url
-
-	// Get a random DB name.
-	bs := make([]byte, 4)
-	if _, err := rand.Read(bs); err != nil {
-		t.Fatal(err)
-	}
-
-	db := "test-" + hex.EncodeToString(bs)
-
-	t.Log("using DB:", db)
+	url, db := makeDB(t)
 
 	// Shorter sweeps for testing
 	PeriodicSweepInterval = 2 * time.Second
@@ -85,6 +53,50 @@ func TestOutboxIntegration(t *testing.T) {
 	if err := o.Close(); err != nil {
 		t.Error("there should be no error:", err)
 	}
+}
+
+func TestWithCollectionNameIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	url, db := makeDB(t)
+
+	o, err := NewOutbox(url, db, WithCollectionName("foo-outbox"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer o.Close()
+
+	if o == nil {
+		t.Fatal("there should be a store")
+	}
+
+	if o.outbox.Name() != "foo-outbox" {
+		t.Fatal("collection name should use custom collection name")
+	}
+}
+
+func makeDB(t *testing.T) (string, string) {
+	// Use MongoDB in Docker with fallback to localhost.
+	url := os.Getenv("MONGODB_ADDR")
+	if url == "" {
+		url = "localhost:27017"
+	}
+
+	url = "mongodb://" + url
+
+	// Get a random DB name.
+	bs := make([]byte, 4)
+	if _, err := rand.Read(bs); err != nil {
+		t.Fatal(err)
+	}
+
+	db := "test-" + hex.EncodeToString(bs)
+
+	t.Log("using DB:", db)
+	return url, db
 }
 
 func BenchmarkOutbox(b *testing.B) {


### PR DESCRIPTION
### Description

Let use a custom name for Outbox and Snapshots collections.

### Affected Components

- mongodb.Outbox
- mongodb_v2.EventStore

### Related Issues

None

### Solution and Design

This is a replication of the available functionality to set event and streams collection names.

Added an Option to set the custom name:

- outbox.WithCollectionNames
- mongodb_v2.WithSnapshotCollectionName

The WithSnapshotCollectionName is added to kepp compatibility with exitent WithtCollectionName (and because I want to review if Snapshot should be part of this EventStore or should be another store).

### Steps to test and verify

1. Create an event store with custom name: ` NewEventStore(url, db,	WithSnapshotCollectionName("foo"))`
2. Check in database the collection created is `foo`

1. Create an outbox with custom name: ` NewOutbox(url, db, WithCollectionName("foo-outbox"))`
2. Check in database the collection created is `foo-outbox`

