### PR TITLE
Sort events before applying them to aggregate

### DIFF
--- a/aggregatestore/events/aggregatestore.go
+++ b/aggregatestore/events/aggregatestore.go
@@ -229,7 +229,7 @@ func (r *AggregateStore) takeSnapshot(ctx context.Context, agg eh.Aggregate, las
 }
 
 func (r *AggregateStore) applyEvents(ctx context.Context, a VersionedAggregate, events []eh.Event) error {
-	for _, event := range events {
+	for _, event := range sortEventsByVersion(events) {
 		if event.AggregateType() != a.AggregateType() {
 			return ErrMismatchedEventType
 		}
@@ -242,4 +242,44 @@ func (r *AggregateStore) applyEvents(ctx context.Context, a VersionedAggregate, 
 	}
 
 	return nil
+}
+
+func sortEventsByVersion(events []eh.Event) []eh.Event {
+	if len(events) == 0 {
+		return events
+	}
+
+	min, max := findMinAndMaxVersions(events)
+	sortedEvents := make([]eh.Event, max-min+1)
+	for _, event := range events {
+		sortedEvents[event.Version()-min] = event
+	}
+
+	if len(sortedEvents) == len(events) {
+		return sortedEvents
+	}
+
+	// remove version gaps (this should not happen)
+	i := 0
+	for _, event := range sortedEvents {
+		if event != nil {
+			sortedEvents[i] = event
+			i++
+		}
+	}
+	return sortedEvents[:i]
+}
+
+func findMinAndMaxVersions(events []eh.Event) (int, int) {
+	min := events[0].Version()
+	max := min
+	for _, event := range events {
+		v := event.Version()
+		if v < min {
+			min = v
+		} else if v > max {
+			max = v
+		}
+	}
+	return min, max
 }

--- a/aggregatestore/events/aggregatestore_sort_test.go
+++ b/aggregatestore/events/aggregatestore_sort_test.go
@@ -1,0 +1,177 @@
+// Copyright (c) 2014 - The Event Horizon authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package events
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	eh "github.com/looplab/eventhorizon"
+	"github.com/looplab/eventhorizon/mocks"
+	"github.com/looplab/eventhorizon/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_findMinAndMaxVersions(t *testing.T) {
+	tests := []struct {
+		name    string
+		events  []eh.Event
+		wantMin int
+		wantMax int
+	}{
+		{
+			name: "one event",
+			events: []eh.Event{
+				eh.NewEvent("test", &mocks.EventData{}, time.Now(), eh.ForAggregate("test", uuid.New(), 1)),
+			},
+			wantMin: 1,
+			wantMax: 1,
+		},
+		{
+			name: "sorted events",
+			events: []eh.Event{
+				eh.NewEvent("test", &mocks.EventData{}, time.Now(), eh.ForAggregate("test", uuid.New(), 1)),
+				eh.NewEvent("test", &mocks.EventData{}, time.Now(), eh.ForAggregate("test", uuid.New(), 2)),
+				eh.NewEvent("test", &mocks.EventData{}, time.Now(), eh.ForAggregate("test", uuid.New(), 3)),
+			},
+			wantMin: 1,
+			wantMax: 3,
+		},
+		{
+			name: "unsorted events",
+			events: []eh.Event{
+				eh.NewEvent("test", &mocks.EventData{}, time.Now(), eh.ForAggregate("test", uuid.New(), 13)),
+				eh.NewEvent("test", &mocks.EventData{}, time.Now(), eh.ForAggregate("test", uuid.New(), 11)),
+				eh.NewEvent("test", &mocks.EventData{}, time.Now(), eh.ForAggregate("test", uuid.New(), 12)),
+			},
+			wantMin: 11,
+			wantMax: 13,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, got1 := findMinAndMaxVersions(tt.events)
+			assert.Equalf(t, tt.wantMin, got, "findMinAndMaxVersions(%v)", tt.events)
+			assert.Equalf(t, tt.wantMax, got1, "findMinAndMaxVersions(%v)", tt.events)
+		})
+	}
+}
+
+func Test_sortEventsByVersion(t *testing.T) {
+	tests := []struct {
+		name   string
+		events []eh.Event
+	}{
+		{
+			name:   "no events",
+			events: []eh.Event{},
+		},
+		{
+			name: "one event",
+			events: []eh.Event{
+				eh.NewEvent("test", &mocks.EventData{}, time.Now(), eh.ForAggregate("test", uuid.New(), 1)),
+			},
+		},
+		{
+			name: "one event with bigger version",
+			events: []eh.Event{
+				eh.NewEvent("test", &mocks.EventData{}, time.Now(), eh.ForAggregate("test", uuid.New(), 17)),
+			},
+		},
+		{
+			name: "two sorted events",
+			events: []eh.Event{
+				eh.NewEvent("test", &mocks.EventData{}, time.Now(), eh.ForAggregate("test", uuid.New(), 41)),
+				eh.NewEvent("test", &mocks.EventData{}, time.Now(), eh.ForAggregate("test", uuid.New(), 42)),
+			},
+		},
+		{
+			name: "two unsorted events",
+			events: []eh.Event{
+				eh.NewEvent("test", &mocks.EventData{}, time.Now(), eh.ForAggregate("test", uuid.New(), 42)),
+				eh.NewEvent("test", &mocks.EventData{}, time.Now(), eh.ForAggregate("test", uuid.New(), 41)),
+			},
+		},
+		{
+			name: "several events with version gaps",
+			events: []eh.Event{
+				eh.NewEvent("test", &mocks.EventData{}, time.Now(), eh.ForAggregate("test", uuid.New(), 11)),
+				eh.NewEvent("test", &mocks.EventData{}, time.Now(), eh.ForAggregate("test", uuid.New(), 12)),
+				eh.NewEvent("test", &mocks.EventData{}, time.Now(), eh.ForAggregate("test", uuid.New(), 14)),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := sortEventsByVersion(tt.events)
+
+			require.ElementsMatchf(t, tt.events, got, "same elements in sortEventsByVersion(%v)", tt.events)
+			// they are sorted
+			for i := 1; i < len(got); i++ {
+				assert.Truef(t, got[i-1].Version() < got[i].Version(), "sorted elements in sortEventsByVersion(%v)", tt.events)
+			}
+		})
+	}
+}
+
+const Sorted = true
+const Unsorted = false
+
+func BenchmarkSort(b *testing.B) {
+	benchmarkSort(b, Sorted)
+}
+func BenchmarkSortUnsorted(b *testing.B) {
+	fmt.Println("BenchmarkSortUnsorted")
+	benchmarkSort(b, Unsorted)
+}
+
+var sortedEvents []eh.Event
+
+func benchmarkSort(b *testing.B, sorted bool) {
+	// Use same data for all benchmarks to not influence times.
+	data := &mocks.EventData{}
+	aggId := uuid.New()
+	now := time.Now()
+
+	for eventCount := 1; eventCount <= 1000; eventCount *= 10 {
+
+		events := make([]eh.Event, eventCount, eventCount)
+
+		if sorted {
+			for i := 0; i < eventCount; i++ {
+				events[i] = eh.NewEvent("test", data, now, eh.ForAggregate("test", aggId, i+7))
+			}
+		} else {
+			for i := 0; i < eventCount; i++ {
+				events[i] = eh.NewEvent("test", data, now, eh.ForAggregate("test", aggId, eventCount-i+7))
+			}
+		}
+
+		b.Run(fmt.Sprintf("sortEventsByVersion-%d", eventCount), func(b *testing.B) {
+			var evs []eh.Event
+			for i := 0; i < b.N; i++ {
+				evs = sortEventsByVersion(events)
+			}
+			sortedEvents = evs
+		})
+
+		// check to force the compiler optimisation to not remove the variable
+		if len(sortedEvents) != eventCount {
+			b.Errorf("sortedEvents has wrong length: %d", len(sortedEvents))
+		}
+	}
+}


### PR DESCRIPTION
### Description

When an aggregate is materialized, events are read from the event source. In the case of the MongoDB implementation, the way they are read does not guarrants the event order.

This change sort events before applying them.

### Affected Components

- aggregatestore.events.AggregateStore

### Related Issues

#409 

### Solution and Design

Events are sorted by version number before being applied. Because version number is an integer between A and B, being A the first version read, and B the last, the sort uses the version position to insert in an slice of size B-A+1.

Solution was benchmarked:

```
$go test -bench=. -run=^# -benchtime 10s -cpu 1 -benchmem
goos: linux
goarch: amd64
pkg: github.com/looplab/eventhorizon/aggregatestore/events
cpu: 11th Gen Intel(R) Core(TM) i7-1165G7 @ 2.80GHz
BenchmarkSort/sortEventsByVersion-1             218145657             55.39 ns/op           16 B/op          1 allocs/op
BenchmarkSort/sortEventsByVersion-10             53875314             216.9 ns/op          160 B/op          1 allocs/op
BenchmarkSort/sortEventsByVersion-100             7211017              1639 ns/op         1792 B/op          1 allocs/op
BenchmarkSort/sortEventsByVersion-1000             627288             18589 ns/op        16384 B/op          1 allocs/op
BenchmarkSortUnsorted
BenchmarkSortUnsorted/sortEventsByVersion-1     220128056             54.52 ns/op           16 B/op          1 allocs/op
BenchmarkSortUnsorted/sortEventsByVersion-10     54352377             219.1 ns/op          160 B/op          1 allocs/op
BenchmarkSortUnsorted/sortEventsByVersion-100     7374812              1629 ns/op         1792 B/op          1 allocs/op
BenchmarkSortUnsorted/sortEventsByVersion-1000     657199             18231 ns/op        16384 B/op          1 allocs/op
PASS
ok      github.com/looplab/eventhorizon/aggregatestore/events   110.407s
```

### Steps to test and verify

aggregatestore_sort_test.go was added.

You can also configure an aggregate with a MongoDB-2 event store.

1. Create an aggregate
2. Execute a command in aggregate that generates one or more events
3. Repeat 2 several times
4. No errors should be detected
5. 