### PR TITLE
Fix setting aggregate version after snapshot was loaded

### DIFF
--- a/aggregatestore/events/aggregatestore.go
+++ b/aggregatestore/events/aggregatestore.go
@@ -121,6 +121,7 @@ func (r *AggregateStore) Load(ctx context.Context, aggregateType eh.AggregateTyp
 		if snapshot != nil {
 			sa.ApplySnapshot(snapshot)
 			fromVersion = snapshot.Version + 1
+			a.SetAggregateVersion(snapshot.Version)
 		}
 	}
 


### PR DESCRIPTION
### Description

When an aggregate is loaded from a Snapshot, and no additional events are applied, the version is left in 0.

### Affected Components

- events.AggregateStore

### Related Issues

#414 

### Solution and Design

After the snapshot was read from DB and applied to the Aggregate, the aggregate version is set to the corresponding to the Snapshot:

```go
a.SetAggregateVersion(snapshot.Version)
```

### Steps to test and verify

See `TestAggregateStore_TakeSnapshot_no_additional_events_after_snapshot_was_saved`

1. Create an aggregate
2. Set a snapshot policy to store every 3 events
3. Add 3 events to aggregate (same number than policy or a multiple of it)
4. Save snapshot
5. Load aggregate from Snapshot
6. Aggregate version will be 0

