### PR TITLE
fix(ci): update to up/download-artifact v4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
           make test_cover
 
       - name: Store coverage
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: coverage
           path: unit.coverprofile
@@ -51,7 +51,7 @@ jobs:
           make test_integration_cover
 
       - name: Store coverage
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: coverage
           path: integration.coverprofile
@@ -69,7 +69,7 @@ jobs:
           go-version: 1.16
 
       - name: Load coverage
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: coverage
 

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ test_loadtest:
 
 .PHONY: test_all_docker
 test_all_docker:
-	docker-compose up --build --force-recreate eventhorizon-test
+	docker compose up --build --force-recreate eventhorizon-test
 
 .PHONY: merge_coverage
 merge_coverage:
@@ -42,31 +42,31 @@ upload_coverage:
 
 .PHONY: run
 run:
-	docker-compose up -d mongodb gpubsub kafka redis nats
+	docker compose up -d mongodb gpubsub kafka redis nats
 
 .PHONY: run_mongodb
 run_mongodb:
-	docker-compose up -d mongodb
+	docker compose up -d mongodb
 
 .PHONY: run_gpubsub
 run_gpubsub:
-	docker-compose up -d gpubsub
+	docker compose up -d gpubsub
 
 .PHONY: run_kafka
 run_kafka:
-	docker-compose up -d kafka
+	docker compose up -d kafka
 
 .PHONY: run_redis
 run_redis:
-	docker-compose up -d redis
+	docker compose up -d redis
 
 .PHONY: run_nats
 run_nats:
-	docker-compose up -d nats
+	docker compose up -d nats
 
 .PHONY: stop
 stop:
-	docker-compose down
+	docker compose down
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
### Description

Updates to use version 4 of the `upload-artifact` and `download-artifact` actions.
See https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/ for details of the deprecation.

Also updates to Compose v2 as the latest Ubuntu image needs that.
See https://docs.docker.com/compose/releases/migrate/ for more details.

### Affected Components

- CI

### Related Issues

### Solution and Design

### Steps to test and verify
