### PR TITLE
fix(ci): use multiple artifacts for code coverage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Store coverage
         uses: actions/upload-artifact@v4
         with:
-          name: coverage
+          name: unit_coverage
           path: unit.coverprofile
 
   integration:
@@ -53,7 +53,7 @@ jobs:
       - name: Store coverage
         uses: actions/upload-artifact@v4
         with:
-          name: coverage
+          name: integration_coverage
           path: integration.coverprofile
 
   finish:
@@ -68,10 +68,15 @@ jobs:
         with:
           go-version: 1.16
 
-      - name: Load coverage
+      - name: Load unit coverage
         uses: actions/download-artifact@v4
         with:
-          name: coverage
+          name: unit_coverage
+
+      - name: Load integration coverage
+        uses: actions/download-artifact@v4
+        with:
+          name: integration_coverage
 
       - name: Merge coverage
         shell: bash


### PR DESCRIPTION
### Description

Due to a breaking change in upload-artifacts v4 multiple artifacts is needed. See https://github.com/actions/upload-artifact?tab=readme-ov-file#breaking-changes for more details.

### Affected Components

- CI

### Related Issues

### Solution and Design

### Steps to test and verify
