### PR TITLE
Use generics to deduplicate internal patterns

### DIFF
--- a/aggregate.go
+++ b/aggregate.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"sync"
 	"time"
 
 	"github.com/looplab/eventhorizon/uuid"
@@ -159,36 +158,18 @@ func (e *AggregateError) Cause() error {
 //
 //	RegisterAggregate(func(id UUID) Aggregate { return &MyAggregate{id} })
 func RegisterAggregate(factory func(uuid.UUID) Aggregate) {
-	// Check that the created aggregate matches the registered type.
-	// TODO: Explore the use of reflect/gob for creating concrete types without
-	// a factory func.
 	aggregate := factory(uuid.New())
 	if aggregate == nil {
 		panic("eventhorizon: created aggregate is nil")
 	}
 
-	aggregateType := aggregate.AggregateType()
-	if aggregateType == AggregateType("") {
-		panic("eventhorizon: attempt to register empty aggregate type")
-	}
-
-	aggregatesMu.Lock()
-	defer aggregatesMu.Unlock()
-
-	if _, ok := aggregates[aggregateType]; ok {
-		panic(fmt.Sprintf("eventhorizon: registering duplicate types for %q", aggregateType))
-	}
-
-	aggregates[aggregateType] = factory
+	aggregates.register(aggregate.AggregateType(), factory)
 }
 
 // CreateAggregate creates an aggregate of a type with an ID using the factory
 // registered with RegisterAggregate.
 func CreateAggregate(aggregateType AggregateType, id uuid.UUID) (Aggregate, error) {
-	aggregatesMu.RLock()
-	defer aggregatesMu.RUnlock()
-
-	if factory, ok := aggregates[aggregateType]; ok {
+	if factory, ok := aggregates.get(aggregateType); ok {
 		return factory(id), nil
 	}
 
@@ -196,19 +177,7 @@ func CreateAggregate(aggregateType AggregateType, id uuid.UUID) (Aggregate, erro
 }
 
 func UnregisterAggregate(aggregateType AggregateType) {
-	if aggregateType == AggregateType("") {
-		panic("eventhorizon: attempt to unregister empty aggregate type")
-	}
-
-	aggregatesMu.Lock()
-	defer aggregatesMu.Unlock()
-
-	if _, ok := aggregates[aggregateType]; !ok {
-		panic(fmt.Sprintf("eventhorizon: unregister of non-registered type %q", aggregateType))
-	}
-
-	delete(aggregates, aggregateType)
+	aggregates.unregister(aggregateType)
 }
 
-var aggregates = make(map[AggregateType]func(uuid.UUID) Aggregate)
-var aggregatesMu sync.RWMutex
+var aggregates = newTypeRegistry[AggregateType, func(uuid.UUID) Aggregate]("aggregate")

--- a/command.go
+++ b/command.go
@@ -73,6 +73,22 @@ func RegisterCommand(factory func() Command) {
 	commands.register(cmd.CommandType(), factory)
 }
 
+// RegisterCommandType registers a command type using generics. The type
+// parameter T must be a struct whose pointer implements Command.
+//
+// An example would be:
+//
+//	RegisterCommandType[MyCommand]()
+func RegisterCommandType[T any, PT interface {
+	*T
+	Command
+}]() {
+	factory := func() Command { return PT(new(T)) }
+	cmd := factory()
+
+	commands.register(cmd.CommandType(), factory)
+}
+
 // UnregisterCommand removes the registration of the command factory for
 // a type. This is mainly useful in mainenance situations where the command type
 // needs to be switched at runtime.

--- a/command.go
+++ b/command.go
@@ -16,9 +16,6 @@ package eventhorizon
 
 import (
 	"errors"
-	"fmt"
-	"maps"
-	"sync"
 
 	"github.com/looplab/eventhorizon/uuid"
 )
@@ -68,70 +65,34 @@ var ErrCommandNotRegistered = errors.New("command not registered")
 //
 //	RegisterCommand(func() Command { return &MyCommand{} })
 func RegisterCommand(factory func() Command) {
-	// Check that the created command matches the type registered.
-	// TODO: Explore the use of reflect/gob for creating concrete types without
-	// a factory func.
 	cmd := factory()
 	if cmd == nil {
 		panic("eventhorizon: created command is nil")
 	}
 
-	commandType := cmd.CommandType()
-	if commandType == CommandType("") {
-		panic("eventhorizon: attempt to register empty command type")
-	}
-
-	commandsMu.Lock()
-	defer commandsMu.Unlock()
-
-	if _, ok := commands[commandType]; ok {
-		panic(fmt.Sprintf("eventhorizon: registering duplicate types for %q", commandType))
-	}
-
-	commands[commandType] = factory
+	commands.register(cmd.CommandType(), factory)
 }
 
 // UnregisterCommand removes the registration of the command factory for
 // a type. This is mainly useful in mainenance situations where the command type
 // needs to be switched at runtime.
 func UnregisterCommand(commandType CommandType) {
-	if commandType == CommandType("") {
-		panic("eventhorizon: attempt to unregister empty command type")
-	}
-
-	commandsMu.Lock()
-	defer commandsMu.Unlock()
-
-	if _, ok := commands[commandType]; !ok {
-		panic(fmt.Sprintf("eventhorizon: unregister of non-registered type %q", commandType))
-	}
-
-	delete(commands, commandType)
+	commands.unregister(commandType)
 }
 
 // CreateCommand creates an command of a type with an ID using the factory
 // registered with RegisterCommand.
 func CreateCommand(commandType CommandType) (Command, error) {
-	commandsMu.RLock()
-	defer commandsMu.RUnlock()
-
-	if factory, ok := commands[commandType]; ok {
+	if factory, ok := commands.get(commandType); ok {
 		return factory(), nil
 	}
 
 	return nil, ErrCommandNotRegistered
 }
 
-// ListCommands returns a list of all registered command types.
+// RegisteredCommands returns a list of all registered command types.
 func RegisteredCommands() map[CommandType]func() Command {
-	commandsMu.Lock()
-	defer commandsMu.Unlock()
-
-	mapCopy := make(map[CommandType]func() Command)
-	maps.Copy(mapCopy, commands)
-
-	return mapCopy
+	return commands.all()
 }
 
-var commands = make(map[CommandType]func() Command)
-var commandsMu sync.RWMutex
+var commands = newTypeRegistry[CommandType, func() Command]("command")

--- a/command_test.go
+++ b/command_test.go
@@ -90,7 +90,7 @@ func TestUnregisterCommandTwice(t *testing.T) {
 }
 
 func TestRegisteredCommands(t *testing.T) {
-	commands = make(map[CommandType]func() Command)
+	commands.reset()
 	RegisterCommand(func() Command { return &TestCommandRegister{} })
 	defer UnregisterCommand(TestCommandRegisterType)
 

--- a/command_test.go
+++ b/command_test.go
@@ -89,6 +89,20 @@ func TestUnregisterCommandTwice(t *testing.T) {
 	UnregisterCommand(TestCommandUnregisterTwiceType)
 }
 
+func TestRegisterCommandType(t *testing.T) {
+	RegisterCommandType[TestCommandRegisterGeneric]()
+	defer UnregisterCommand(TestCommandRegisterGenericType)
+
+	cmd, err := CreateCommand(TestCommandRegisterGenericType)
+	if err != nil {
+		t.Error("there should be no error:", err)
+	}
+
+	if cmd.CommandType() != TestCommandRegisterGenericType {
+		t.Error("the command type should be correct:", cmd.CommandType())
+	}
+}
+
 func TestRegisteredCommands(t *testing.T) {
 	commands.reset()
 	RegisterCommand(func() Command { return &TestCommandRegister{} })
@@ -101,6 +115,7 @@ func TestRegisteredCommands(t *testing.T) {
 }
 
 const (
+	TestCommandRegisterGenericType CommandType = "TestCommandRegisterGeneric"
 	TestCommandRegisterType        CommandType = "TestCommandRegister"
 	TestCommandRegisterEmptyType   CommandType = ""
 	TestCommandRegisterTwiceType   CommandType = "TestCommandRegisterTwice"
@@ -133,6 +148,16 @@ var _ = Command(TestCommandRegisterTwice{})
 func (a TestCommandRegisterTwice) AggregateID() uuid.UUID       { return uuid.Nil }
 func (a TestCommandRegisterTwice) AggregateType() AggregateType { return TestAggregateType }
 func (a TestCommandRegisterTwice) CommandType() CommandType     { return TestCommandRegisterTwiceType }
+
+type TestCommandRegisterGeneric struct{}
+
+var _ = Command(&TestCommandRegisterGeneric{})
+
+func (a *TestCommandRegisterGeneric) AggregateID() uuid.UUID       { return uuid.Nil }
+func (a *TestCommandRegisterGeneric) AggregateType() AggregateType { return TestAggregateType }
+func (a *TestCommandRegisterGeneric) CommandType() CommandType {
+	return TestCommandRegisterGenericType
+}
 
 type TestCommandUnregisterTwice struct{}
 

--- a/context.go
+++ b/context.go
@@ -77,23 +77,23 @@ const (
 
 // AggregateIDFromContext return the command type from the context.
 func AggregateIDFromContext(ctx context.Context) (uuid.UUID, bool) {
-	aggregateID, ok := ctx.Value(aggregateIDKey).(uuid.UUID)
-
-	return aggregateID, ok
+	return fromContext[uuid.UUID](ctx, aggregateIDKey)
 }
 
 // AggregateTypeFromContext return the command type from the context.
 func AggregateTypeFromContext(ctx context.Context) (AggregateType, bool) {
-	aggregateType, ok := ctx.Value(aggregateTypeKey).(AggregateType)
-
-	return aggregateType, ok
+	return fromContext[AggregateType](ctx, aggregateTypeKey)
 }
 
 // CommandTypeFromContext return the command type from the context.
 func CommandTypeFromContext(ctx context.Context) (CommandType, bool) {
-	commandType, ok := ctx.Value(commandTypeKey).(CommandType)
+	return fromContext[CommandType](ctx, commandTypeKey)
+}
 
-	return commandType, ok
+func fromContext[T any](ctx context.Context, key contextKey) (T, bool) {
+	val, ok := ctx.Value(key).(T)
+
+	return val, ok
 }
 
 // NewContextWithAggregateID adds a aggregate ID on the context.

--- a/event.go
+++ b/event.go
@@ -218,6 +218,15 @@ func RegisterEventData(eventType EventType, factory func() EventData) {
 	eventDataFactories.register(eventType, factory)
 }
 
+// RegisterEventDataType registers an event data type using generics.
+//
+// An example would be:
+//
+//	RegisterEventDataType[MyEventData](MyEventType)
+func RegisterEventDataType[T any](eventType EventType) {
+	eventDataFactories.register(eventType, func() EventData { return new(T) })
+}
+
 // UnregisterEventData removes the registration of the event data factory for
 // a type. This is mainly useful in mainenance situations where the event data
 // needs to be switched in a migrations.

--- a/event.go
+++ b/event.go
@@ -18,7 +18,6 @@ import (
 	"errors"
 	"fmt"
 	"maps"
-	"sync"
 	"time"
 
 	"github.com/looplab/eventhorizon/uuid"
@@ -140,7 +139,8 @@ func NewEvent(eventType EventType, data EventData, timestamp time.Time, options 
 // timestamp. It also sets the aggregate data on it.
 // DEPRECATED, use NewEvent() with the WithAggregate() option instead.
 func NewEventForAggregate(eventType EventType, data EventData, timestamp time.Time,
-	aggregateType AggregateType, aggregateID uuid.UUID, version int, options ...EventOption) Event {
+	aggregateType AggregateType, aggregateID uuid.UUID, version int, options ...EventOption,
+) Event {
 	options = append(options, ForAggregate(aggregateType, aggregateID, version))
 
 	return NewEvent(eventType, data, timestamp, options...)
@@ -215,52 +215,24 @@ var ErrEventDataNotRegistered = errors.New("event data not registered")
 //
 //	RegisterEventData(MyEventType, func() Event { return &MyEventData{} })
 func RegisterEventData(eventType EventType, factory func() EventData) {
-	if eventType == EventType("") {
-		panic("eventhorizon: attempt to register empty event type")
-	}
-
-	eventDataFactoriesMu.Lock()
-	defer eventDataFactoriesMu.Unlock()
-
-	// TODO: Explore the use of reflect/gob for creating concrete types without
-	// a factory func.
-	if _, ok := eventDataFactories[eventType]; ok {
-		panic(fmt.Sprintf("eventhorizon: registering duplicate types for %q", eventType))
-	}
-
-	eventDataFactories[eventType] = factory
+	eventDataFactories.register(eventType, factory)
 }
 
 // UnregisterEventData removes the registration of the event data factory for
 // a type. This is mainly useful in mainenance situations where the event data
 // needs to be switched in a migrations.
 func UnregisterEventData(eventType EventType) {
-	if eventType == EventType("") {
-		panic("eventhorizon: attempt to unregister empty event type")
-	}
-
-	eventDataFactoriesMu.Lock()
-	defer eventDataFactoriesMu.Unlock()
-
-	if _, ok := eventDataFactories[eventType]; !ok {
-		panic(fmt.Sprintf("eventhorizon: unregister of non-registered type %q", eventType))
-	}
-
-	delete(eventDataFactories, eventType)
+	eventDataFactories.unregister(eventType)
 }
 
 // CreateEventData creates an event data of a type using the factory registered
 // with RegisterEventData.
 func CreateEventData(eventType EventType) (EventData, error) {
-	eventDataFactoriesMu.RLock()
-	defer eventDataFactoriesMu.RUnlock()
-
-	if factory, ok := eventDataFactories[eventType]; ok {
+	if factory, ok := eventDataFactories.get(eventType); ok {
 		return factory(), nil
 	}
 
 	return nil, ErrEventDataNotRegistered
 }
 
-var eventDataFactories = make(map[EventType]func() EventData)
-var eventDataFactoriesMu sync.RWMutex
+var eventDataFactories = newTypeRegistry[EventType, func() EventData]("event")

--- a/middleware.go
+++ b/middleware.go
@@ -20,13 +20,7 @@ type CommandHandlerMiddleware func(CommandHandler) CommandHandler
 
 // UseCommandHandlerMiddleware wraps a CommandHandler in one or more middleware.
 func UseCommandHandlerMiddleware(h CommandHandler, middleware ...CommandHandlerMiddleware) CommandHandler {
-	// Apply in reverse order.
-	for i := len(middleware) - 1; i >= 0; i-- {
-		m := middleware[i]
-		h = m(h)
-	}
-
-	return h
+	return applyMiddleware(h, middleware)
 }
 
 // EventHandlerMiddleware is a function that middlewares can implement to be
@@ -46,10 +40,12 @@ type EventHandlerChain interface {
 
 // UseEventHandlerMiddleware wraps a EventHandler in one or more middleware.
 func UseEventHandlerMiddleware(h EventHandler, middleware ...EventHandlerMiddleware) EventHandler {
-	// Apply in reverse order.
+	return applyMiddleware(h, middleware)
+}
+
+func applyMiddleware[H any, M ~func(H) H](h H, middleware []M) H {
 	for i := len(middleware) - 1; i >= 0; i-- {
-		m := middleware[i]
-		h = m(h)
+		h = middleware[i](h)
 	}
 
 	return h

--- a/registry.go
+++ b/registry.go
@@ -1,0 +1,89 @@
+// Copyright (c) 2014 - The Event Horizon authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package eventhorizon
+
+import (
+	"fmt"
+	"maps"
+	"sync"
+)
+
+type typeRegistry[K comparable, F any] struct {
+	mu    sync.RWMutex
+	items map[K]F
+	name  string
+}
+
+func newTypeRegistry[K comparable, F any](name string) *typeRegistry[K, F] {
+	return &typeRegistry[K, F]{
+		items: make(map[K]F),
+		name:  name,
+	}
+}
+
+func (r *typeRegistry[K, F]) register(key K, factory F) {
+	var zero K
+	if key == zero {
+		panic(fmt.Sprintf("eventhorizon: attempt to register empty %s type", r.name))
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if _, ok := r.items[key]; ok {
+		panic(fmt.Sprintf("eventhorizon: registering duplicate types for %q", any(key)))
+	}
+
+	r.items[key] = factory
+}
+
+func (r *typeRegistry[K, F]) unregister(key K) {
+	var zero K
+	if key == zero {
+		panic(fmt.Sprintf("eventhorizon: attempt to unregister empty %s type", r.name))
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if _, ok := r.items[key]; !ok {
+		panic(fmt.Sprintf("eventhorizon: unregister of non-registered type %q", any(key)))
+	}
+
+	delete(r.items, key)
+}
+
+func (r *typeRegistry[K, F]) get(key K) (F, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	f, ok := r.items[key]
+
+	return f, ok
+}
+
+func (r *typeRegistry[K, F]) reset() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.items = make(map[K]F)
+}
+
+func (r *typeRegistry[K, F]) all() map[K]F {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	return maps.Clone(r.items)
+}

--- a/repo.go
+++ b/repo.go
@@ -21,6 +21,18 @@ import (
 	"github.com/looplab/eventhorizon/uuid"
 )
 
+func IntoRepo[T any](ctx context.Context, repo ReadRepo) *T {
+	if repo == nil {
+		return nil
+	}
+
+	if r, ok := any(repo).(*T); ok {
+		return r
+	}
+
+	return IntoRepo[T](ctx, repo.InnerRepo(ctx))
+}
+
 // ReadRepo is a read repository for entities.
 type ReadRepo interface {
 	// InnerRepo returns the inner read repository, if there is one.

--- a/repo/cache/repo.go
+++ b/repo/cache/repo.go
@@ -50,15 +50,7 @@ func (r *Repo) InnerRepo(ctx context.Context) eh.ReadRepo {
 // IntoRepo tries to convert a eh.ReadRepo into a Repo by recursively looking at
 // inner repos. Returns nil if none was found.
 func IntoRepo(ctx context.Context, repo eh.ReadRepo) *Repo {
-	if repo == nil {
-		return nil
-	}
-
-	if r, ok := repo.(*Repo); ok {
-		return r
-	}
-
-	return IntoRepo(ctx, repo.InnerRepo(ctx))
+	return eh.IntoRepo[Repo](ctx, repo)
 }
 
 // HandlerType implements the HandlerType method of the eventhorizon.EventHandler interface.

--- a/repo/version/repo.go
+++ b/repo/version/repo.go
@@ -45,15 +45,7 @@ func (r *Repo) InnerRepo(ctx context.Context) eh.ReadRepo {
 // IntoRepo tries to convert a eh.ReadRepo into a Repo by recursively looking at
 // inner repos. Returns nil if none was found.
 func IntoRepo(ctx context.Context, repo eh.ReadRepo) *Repo {
-	if repo == nil {
-		return nil
-	}
-
-	if r, ok := repo.(*Repo); ok {
-		return r
-	}
-
-	return IntoRepo(ctx, repo.InnerRepo(ctx))
+	return eh.IntoRepo[Repo](ctx, repo)
 }
 
 // Find implements the Find method of the eventhorizon.ReadModel interface.

--- a/snapshot.go
+++ b/snapshot.go
@@ -16,8 +16,6 @@ package eventhorizon
 
 import (
 	"errors"
-	"fmt"
-	"sync"
 	"time"
 
 	"github.com/looplab/eventhorizon/uuid"
@@ -37,11 +35,7 @@ type Snapshot struct {
 	State         any
 }
 
-var snapshotDataFactories = make(map[AggregateType]func(uuid2 uuid.UUID) SnapshotData)
-
 type SnapshotData any
-
-var snapshotDataFactoriesMu sync.RWMutex
 
 var ErrSnapshotDataNotRegistered = errors.New("snapshot data not registered")
 
@@ -52,28 +46,16 @@ var ErrSnapshotDataNotRegistered = errors.New("snapshot data not registered")
 //
 //	RegisterSnapshotData("aggregateType1", func() SnapshotData { return &MySnapshotData{} })
 func RegisterSnapshotData(aggregateType AggregateType, factory func(id uuid.UUID) SnapshotData) {
-	if aggregateType == AggregateType("") {
-		panic("eventhorizon: attempt to register empty aggregate type")
-	}
-
-	snapshotDataFactoriesMu.Lock()
-	defer snapshotDataFactoriesMu.Unlock()
-
-	if _, ok := snapshotDataFactories[aggregateType]; ok {
-		panic(fmt.Sprintf("eventhorizon: registering duplicate types for %q", aggregateType))
-	}
-
-	snapshotDataFactories[aggregateType] = factory
+	snapshotDataFactories.register(aggregateType, factory)
 }
 
 // CreateSnapshotData create a concrete instance using the registered snapshot factories.
 func CreateSnapshotData(aggregateID uuid.UUID, aggregateType AggregateType) (SnapshotData, error) {
-	snapshotDataFactoriesMu.RLock()
-	defer snapshotDataFactoriesMu.RUnlock()
-
-	if factory, ok := snapshotDataFactories[aggregateType]; ok {
+	if factory, ok := snapshotDataFactories.get(aggregateType); ok {
 		return factory(aggregateID), nil
 	}
 
 	return nil, ErrSnapshotDataNotRegistered
 }
+
+var snapshotDataFactories = newTypeRegistry[AggregateType, func(uuid.UUID) SnapshotData]("aggregate")

--- a/tracing/repo.go
+++ b/tracing/repo.go
@@ -45,15 +45,7 @@ func (r *Repo) InnerRepo(ctx context.Context) eh.ReadRepo {
 // IntoRepo tries to convert a eh.ReadRepo into a Repo by recursively looking at
 // inner repos. Returns nil if none was found.
 func IntoRepo(ctx context.Context, repo eh.ReadRepo) *Repo {
-	if repo == nil {
-		return nil
-	}
-
-	if r, ok := repo.(*Repo); ok {
-		return r
-	}
-
-	return IntoRepo(ctx, repo.InnerRepo(ctx))
+	return eh.IntoRepo[Repo](ctx, repo)
 }
 
 // Find implements the Find method of the eventhorizon.ReadModel interface.


### PR DESCRIPTION
### Description

Use Go generics to deduplicate four near-identical internal patterns while keeping all public API signatures unchanged. Also adds generic registration alternatives for commands and event data.

### Affected Components

- Command registry
- Event data registry
- Aggregate registry
- Snapshot registry
- Middleware chaining
- Context value extraction
- Repo unwrapping (cache, version, tracing)

### Related Issues

None

### Solution and Design

- A generic `typeRegistry[K, F]` replaces four copy-pasted mutex/map/panic registry implementations in `command.go`, `event.go`, `aggregate.go`, and `snapshot.go`.
- A generic `applyMiddleware[H, M]` deduplicates `UseCommandHandlerMiddleware` and `UseEventHandlerMiddleware`.
- A generic `fromContext[T]` simplifies context value extraction to one-liners.
- A generic `IntoRepo[T]` eliminates recursive repo unwrapping duplication across `repo/cache`, `repo/version`, and `tracing`.
- New `RegisterCommandType[T]()` and `RegisterEventDataType[T](eventType)` provide generic alternatives that eliminate factory closures (types below are from `examples/todomvc/backend/domains/todo`):
  ```go
  // Before:
  eh.RegisterCommand(func() eh.Command { return &Create{} })
  eh.RegisterEventData(ItemAdded, func() eh.EventData { return &ItemAddedData{} })

  // After:
  eh.RegisterCommandType[Create]()
  eh.RegisterEventDataType[ItemAddedData](ItemAdded)
  ```
  The existing factory-based functions remain unchanged for backward compatibility. Aggregates still require the factory approach due to UUID-dependent construction.

All internal changes are backward compatible. No exported type signatures changed.

### Steps to test and verify

1. `go build ./...` — all packages compile
2. `go vet ./...` — no new issues
3. `go test ./...` — all existing tests pass, new generic registration tests included

Closes #405
