### PR TITLE
Fix global registry test panics with -count>1

### DIFF
--- a/aggregate.go
+++ b/aggregate.go
@@ -195,5 +195,20 @@ func CreateAggregate(aggregateType AggregateType, id uuid.UUID) (Aggregate, erro
 	return nil, ErrAggregateNotRegistered
 }
 
+func UnregisterAggregate(aggregateType AggregateType) {
+	if aggregateType == AggregateType("") {
+		panic("eventhorizon: attempt to unregister empty aggregate type")
+	}
+
+	aggregatesMu.Lock()
+	defer aggregatesMu.Unlock()
+
+	if _, ok := aggregates[aggregateType]; !ok {
+		panic(fmt.Sprintf("eventhorizon: unregister of non-registered type %q", aggregateType))
+	}
+
+	delete(aggregates, aggregateType)
+}
+
 var aggregates = make(map[AggregateType]func(uuid.UUID) Aggregate)
 var aggregatesMu sync.RWMutex

--- a/aggregate_test.go
+++ b/aggregate_test.go
@@ -33,6 +33,7 @@ func TestCreateAggregate(t *testing.T) {
 	RegisterAggregate(func(id uuid.UUID) Aggregate {
 		return &TestAggregateRegister{id: id}
 	})
+	defer UnregisterAggregate(TestAggregateRegisterType)
 
 	aggregate, err := CreateAggregate(TestAggregateRegisterType, id)
 	if err != nil {
@@ -69,6 +70,7 @@ func TestRegisterAggregateNil(t *testing.T) {
 }
 
 func TestRegisterAggregateTwice(t *testing.T) {
+	defer UnregisterAggregate(TestAggregateRegisterTwiceType)
 	defer func() {
 		if r := recover(); r == nil || r != "eventhorizon: registering duplicate types for \"TestAggregateRegisterTwice\"" {
 			t.Error("there should have been a panic:", r)

--- a/command_test.go
+++ b/command_test.go
@@ -59,6 +59,7 @@ func TestRegisterCommandNil(t *testing.T) {
 }
 
 func TestRegisterCommandTwice(t *testing.T) {
+	defer UnregisterCommand(TestCommandRegisterTwiceType)
 	defer func() {
 		if r := recover(); r == nil || r != "eventhorizon: registering duplicate types for \"TestCommandRegisterTwice\"" {
 			t.Error("there should have been a panic:", r)

--- a/context_test.go
+++ b/context_test.go
@@ -20,6 +20,13 @@ import (
 )
 
 func TestContextMarshaler(t *testing.T) {
+	savedLen := len(contextMarshalFuncs)
+	defer func() {
+		contextMarshalFuncsMu.Lock()
+		contextMarshalFuncs = contextMarshalFuncs[:savedLen]
+		contextMarshalFuncsMu.Unlock()
+	}()
+
 	if len(contextMarshalFuncs) != 1 {
 		t.Error("there should be one context marshaler")
 	}
@@ -50,6 +57,13 @@ func TestContextMarshaler(t *testing.T) {
 }
 
 func TestContextUnmarshaler(t *testing.T) {
+	savedLen := len(contextUnmarshalFuncs)
+	defer func() {
+		contextUnmarshalFuncsMu.Lock()
+		contextUnmarshalFuncs = contextUnmarshalFuncs[:savedLen]
+		contextUnmarshalFuncsMu.Unlock()
+	}()
+
 	if len(contextUnmarshalFuncs) != 1 {
 		t.Error("there should be one context marshaler")
 	}
@@ -82,13 +96,28 @@ func TestContextUnmarshaler(t *testing.T) {
 }
 
 func TestCopyContext(t *testing.T) {
-	if len(contextMarshalFuncs) != 2 {
-		t.Error("there should be two context marshalers")
-	}
+	marshalSavedLen := len(contextMarshalFuncs)
+	unmarshalSavedLen := len(contextUnmarshalFuncs)
+	defer func() {
+		contextMarshalFuncsMu.Lock()
+		contextMarshalFuncs = contextMarshalFuncs[:marshalSavedLen]
+		contextMarshalFuncsMu.Unlock()
+		contextUnmarshalFuncsMu.Lock()
+		contextUnmarshalFuncs = contextUnmarshalFuncs[:unmarshalSavedLen]
+		contextUnmarshalFuncsMu.Unlock()
+	}()
 
-	if len(contextUnmarshalFuncs) != 2 {
-		t.Error("there should be two context unmarshalers")
-	}
+	RegisterContextMarshaler(func(ctx context.Context, vals map[string]interface{}) {
+		if val, ok := ContextTestOne(ctx); ok {
+			vals[contextTestKeyOneStr] = val
+		}
+	})
+	RegisterContextUnmarshaler(func(ctx context.Context, vals map[string]interface{}) context.Context {
+		if val, ok := vals[contextTestKeyOneStr].(string); ok {
+			return WithContextTestOne(ctx, val)
+		}
+		return ctx
+	})
 
 	from := WithContextTestOne(context.Background(), "testval")
 

--- a/event_test.go
+++ b/event_test.go
@@ -135,6 +135,7 @@ func TestRegisterEventEmptyName(t *testing.T) {
 }
 
 func TestRegisterEventTwice(t *testing.T) {
+	defer UnregisterEventData(TestEventRegisterTwiceType)
 	defer func() {
 		if r := recover(); r == nil || r != "eventhorizon: registering duplicate types for \"TestEventRegisterTwice\"" {
 			t.Error("there should have been a panic:", r)


### PR DESCRIPTION
### Description

Running `go test -count=20` panics because test functions register types into global registries without cleanup. On the second iteration the registry rejects duplicates with a panic.

### Affected Components

- Aggregate registry
- Command registry
- Event data registry
- Context marshaler/unmarshaler registries

### Related Issues

None

### Solution and Design

- Add `UnregisterAggregate` following the existing pattern of `UnregisterCommand` and `UnregisterEventData`
- Add `defer` cleanup in tests that register into global registries (`aggregate_test.go`, `command_test.go`, `event_test.go`)
- For context marshalers/unmarshalers (append-only slices with no unregister API), save and restore slice length via defer
- Make `TestCopyContext` self-contained instead of relying on side effects from prior tests

### Steps to test and verify

1. `go test -race -count=20 .` — all iterations pass without panics