### PR TITLE
fix(eventbus/gcp): migrate to cloud.google.com/go/pubsub/v2

### DIFF
--- a/context_test.go
+++ b/context_test.go
@@ -107,12 +107,12 @@ func TestCopyContext(t *testing.T) {
 		contextUnmarshalFuncsMu.Unlock()
 	}()
 
-	RegisterContextMarshaler(func(ctx context.Context, vals map[string]interface{}) {
+	RegisterContextMarshaler(func(ctx context.Context, vals map[string]any) {
 		if val, ok := ContextTestOne(ctx); ok {
 			vals[contextTestKeyOneStr] = val
 		}
 	})
-	RegisterContextUnmarshaler(func(ctx context.Context, vals map[string]interface{}) context.Context {
+	RegisterContextUnmarshaler(func(ctx context.Context, vals map[string]any) context.Context {
 		if val, ok := vals[contextTestKeyOneStr].(string); ok {
 			return WithContextTestOne(ctx, val)
 		}

--- a/eventbus/gcp/eventbus.go
+++ b/eventbus/gcp/eventbus.go
@@ -22,8 +22,13 @@ import (
 	"sync"
 	"time"
 
-	"cloud.google.com/go/pubsub"
+	"cloud.google.com/go/pubsub/v2"
+	pubsubpb "cloud.google.com/go/pubsub/v2/apiv1/pubsubpb"
 	"google.golang.org/api/option"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/durationpb"
 
 	eh "github.com/looplab/eventhorizon"
 	"github.com/looplab/eventhorizon/codec/json"
@@ -33,10 +38,12 @@ import (
 // to all matching registered handlers, in order of registration.
 type EventBus struct {
 	appID        string
+	projectID    string
 	client       *pubsub.Client
 	clientOpts   []option.ClientOption
-	topic        *pubsub.Topic
-	topicConfig  *pubsub.TopicConfig
+	publisher    *pubsub.Publisher
+	topicName    string
+	topicConfig  *pubsubpb.Topic
 	registered   map[eh.EventHandlerType]struct{}
 	registeredMu sync.RWMutex
 	errCh        chan error
@@ -52,6 +59,7 @@ func NewEventBus(projectID, appID string, options ...Option) (*EventBus, error) 
 
 	b := &EventBus{
 		appID:      appID,
+		projectID:  projectID,
 		registered: map[eh.EventHandlerType]struct{}{},
 		errCh:      make(chan error, 100),
 		cctx:       ctx,
@@ -79,24 +87,30 @@ func NewEventBus(projectID, appID string, options ...Option) (*EventBus, error) 
 	}
 
 	// Get or create the topic.
-	name := appID + "_events"
-	b.topic = b.client.Topic(name)
+	b.topicName = fmt.Sprintf("projects/%s/topics/%s_events", projectID, appID)
 
-	if ok, err := b.topic.Exists(b.cctx); err != nil {
-		return nil, err
-	} else if !ok {
+	if _, err := b.client.TopicAdminClient.GetTopic(b.cctx, &pubsubpb.GetTopicRequest{Topic: b.topicName}); err != nil {
+		if status.Code(err) != codes.NotFound {
+			return nil, err
+		}
+
+		topic := &pubsubpb.Topic{}
 		if b.topicConfig != nil {
-			if b.topic, err = b.client.CreateTopicWithConfig(b.cctx, name, b.topicConfig); err != nil {
-				return nil, err
+			clone, ok := proto.Clone(b.topicConfig).(*pubsubpb.Topic)
+			if !ok {
+				return nil, fmt.Errorf("unexpected topic config type: %T", clone)
 			}
-		} else {
-			if b.topic, err = b.client.CreateTopic(b.cctx, name); err != nil {
-				return nil, err
-			}
+			topic = clone
+		}
+		topic.Name = b.topicName
+
+		if _, err := b.client.TopicAdminClient.CreateTopic(b.cctx, topic); err != nil {
+			return nil, err
 		}
 	}
 
-	b.topic.EnableMessageOrdering = true
+	b.publisher = b.client.Publisher(b.topicName)
+	b.publisher.EnableMessageOrdering = true
 
 	return b, nil
 }
@@ -122,9 +136,9 @@ func WithPubSubOptions(opts ...option.ClientOption) Option {
 	}
 }
 
-// WithTopicOptions adds the options to the pubsub.TopicConfig.
+// WithTopicOptions adds the options to the pubsubpb.Topic used on creation.
 // This allows control over the Topic creation, including message retention.
-func WithTopicOptions(topicConfig *pubsub.TopicConfig) Option {
+func WithTopicOptions(topicConfig *pubsubpb.Topic) Option {
 	return func(b *EventBus) error {
 		b.topicConfig = topicConfig
 
@@ -149,7 +163,7 @@ func (b *EventBus) HandleEvent(ctx context.Context, event eh.Event) error {
 		return fmt.Errorf("could not marshal event: %w", err)
 	}
 
-	res := b.topic.Publish(ctx, &pubsub.Message{
+	res := b.publisher.Publish(ctx, &pubsub.Message{
 		Data: data,
 		Attributes: map[string]string{
 			aggregateTypeAttribute:     event.AggregateType().String(),
@@ -191,36 +205,35 @@ func (b *EventBus) AddHandler(ctx context.Context, m eh.EventMatcher, h eh.Event
 
 	// Get or create the subscription.
 	subscriptionID := b.appID + "_" + h.HandlerType().String()
-	sub := b.client.Subscription(subscriptionID)
+	subName := fmt.Sprintf("projects/%s/subscriptions/%s", b.projectID, subscriptionID)
 
-	if ok, err := sub.Exists(ctx); err != nil {
-		return fmt.Errorf("could not check existing subscription: %w", err)
-	} else if !ok {
-		if sub, err = b.client.CreateSubscription(ctx, subscriptionID,
-			pubsub.SubscriptionConfig{
-				Topic:                 b.topic,
-				AckDeadline:           60 * time.Second,
-				Filter:                filter,
-				EnableMessageOrdering: true,
-				RetryPolicy: &pubsub.RetryPolicy{
-					MinimumBackoff: 3 * time.Second,
-				},
+	if cfg, err := b.client.SubscriptionAdminClient.GetSubscription(ctx, &pubsubpb.GetSubscriptionRequest{Subscription: subName}); err != nil {
+		if status.Code(err) != codes.NotFound {
+			return fmt.Errorf("could not check existing subscription: %w", err)
+		}
+
+		if _, err := b.client.SubscriptionAdminClient.CreateSubscription(ctx, &pubsubpb.Subscription{
+			Name:                  subName,
+			Topic:                 b.topicName,
+			AckDeadlineSeconds:    60,
+			Filter:                filter,
+			EnableMessageOrdering: true,
+			RetryPolicy: &pubsubpb.RetryPolicy{
+				MinimumBackoff: durationpb.New(3 * time.Second),
 			},
-		); err != nil {
+		}); err != nil {
 			return fmt.Errorf("could not create subscription: %w", err)
 		}
-	} else if ok {
-		cfg, err := sub.Config(ctx)
-		if err != nil {
-			return fmt.Errorf("could not get subscription config: %w", err)
-		}
-		if cfg.Filter != filter {
+	} else {
+		if cfg.GetFilter() != filter {
 			return fmt.Errorf("the existing filter for '%s' differs, please remove to recreate", h.HandlerType())
 		}
-		if !cfg.EnableMessageOrdering {
+		if !cfg.GetEnableMessageOrdering() {
 			return fmt.Errorf("message ordering not enabled for subscription '%s', please remove to recreate", h.HandlerType())
 		}
 	}
+
+	sub := b.client.Subscriber(subName)
 
 	// Register handler.
 	b.registered[h.HandlerType()] = struct{}{}
@@ -241,7 +254,7 @@ func (b *EventBus) Errors() <-chan error {
 // Close implements the Close method of the eventhorizon.EventBus interface.
 func (b *EventBus) Close() error {
 	// Stop publishing.
-	b.topic.Stop()
+	b.publisher.Stop()
 
 	// Stop handling.
 	b.cancel()
@@ -251,7 +264,7 @@ func (b *EventBus) Close() error {
 }
 
 // Handles all events coming in on the channel.
-func (b *EventBus) handle(m eh.EventMatcher, h eh.EventHandler, sub *pubsub.Subscription) {
+func (b *EventBus) handle(m eh.EventMatcher, h eh.EventHandler, sub *pubsub.Subscriber) {
 	defer b.wg.Done()
 
 	for {

--- a/eventbus/gcp/eventbus_test.go
+++ b/eventbus/gcp/eventbus_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 	"time"
 
-	"cloud.google.com/go/pubsub"
+	pubsubpb "cloud.google.com/go/pubsub/v2/apiv1/pubsubpb"
 	eh "github.com/looplab/eventhorizon"
 	"github.com/looplab/eventhorizon/eventbus"
 )
@@ -147,8 +147,8 @@ func newTestEventBusWithTopicConfig(appID string) (eh.EventBus, string, error) {
 	}
 
 	// Create an empty config. The emulator doesn't support configurable message retention.
-	topicConfig := &pubsub.TopicConfig{
-		// RetentionDuration: 7 * 24 * time.Hour,
+	topicConfig := &pubsubpb.Topic{
+		// MessageRetentionDuration: durationpb.New(7 * 24 * time.Hour),
 	}
 	bus, err := NewEventBus("project_id", appID, WithTopicOptions(topicConfig))
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/looplab/eventhorizon
 go 1.25.6
 
 require (
-	cloud.google.com/go/pubsub v1.50.1
+	cloud.google.com/go/pubsub/v2 v2.0.0
 	github.com/go-redis/redis/v8 v8.11.5
 	github.com/google/uuid v1.6.0
 	github.com/gorhill/cronexpr v0.0.0-20180427100037-88b0669f7d75
@@ -20,6 +20,8 @@ require (
 	github.com/uber/jaeger-client-go v2.29.1+incompatible
 	go.mongodb.org/mongo-driver/v2 v2.5.0
 	google.golang.org/api v0.273.0
+	google.golang.org/grpc v1.79.3
+	google.golang.org/protobuf v1.36.11
 )
 
 require (
@@ -28,7 +30,6 @@ require (
 	cloud.google.com/go/auth/oauth2adapt v0.2.8 // indirect
 	cloud.google.com/go/compute/metadata v0.9.0 // indirect
 	cloud.google.com/go/iam v1.5.3 // indirect
-	cloud.google.com/go/pubsub/v2 v2.0.0 // indirect
 	dario.cat/mergo v1.0.2 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c // indirect
 	github.com/HdrHistogram/hdrhistogram-go v1.1.2 // indirect
@@ -86,6 +87,7 @@ require (
 	github.com/xdg-go/stringprep v1.0.4 // indirect
 	github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
+	go.einride.tech/aip v0.73.0 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.61.0 // indirect
@@ -104,7 +106,5 @@ require (
 	google.golang.org/genproto v0.0.0-20260316180232-0b37fe3546d5 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260316180232-0b37fe3546d5 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260319201613-d00831a3d3e7 // indirect
-	google.golang.org/grpc v1.79.3 // indirect
-	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -9,12 +9,6 @@ cloud.google.com/go/compute/metadata v0.9.0 h1:pDUj4QMoPejqq20dK0Pg2N4yG9zIkYGdB
 cloud.google.com/go/compute/metadata v0.9.0/go.mod h1:E0bWwX5wTnLPedCKqk3pJmVgCBSM6qQI1yTBdEb3C10=
 cloud.google.com/go/iam v1.5.3 h1:+vMINPiDF2ognBJ97ABAYYwRgsaqxPbQDlMnbHMjolc=
 cloud.google.com/go/iam v1.5.3/go.mod h1:MR3v9oLkZCTlaqljW6Eb2d3HGDGK5/bDv93jhfISFvU=
-cloud.google.com/go/kms v1.26.0 h1:cK9mN2cf+9V63D3H1f6koxTatWy39aTI/hCjz1I+adU=
-cloud.google.com/go/kms v1.26.0/go.mod h1:pHKOdFJm63hxBsiPkYtowZPltu9dW0MWvBa6IA4HM58=
-cloud.google.com/go/longrunning v0.8.0 h1:LiKK77J3bx5gDLi4SMViHixjD2ohlkwBi+mKA7EhfW8=
-cloud.google.com/go/longrunning v0.8.0/go.mod h1:UmErU2Onzi+fKDg2gR7dusz11Pe26aknR4kHmJJqIfk=
-cloud.google.com/go/pubsub v1.50.1 h1:fzbXpPyJnSGvWXF1jabhQeXyxdbCIkXTpjXHy7xviBM=
-cloud.google.com/go/pubsub v1.50.1/go.mod h1:6YVJv3MzWJUVdvQXG081sFvS0dWQOdnV+oTo++q/xFk=
 cloud.google.com/go/pubsub/v2 v2.0.0 h1:0qS6mRJ41gD1lNmM/vdm6bR7DQu6coQcVwD+VPf0Bz0=
 cloud.google.com/go/pubsub/v2 v2.0.0/go.mod h1:0aztFxNzVQIRSZ8vUr79uH2bS3jwLebwK6q1sgEub+E=
 dario.cat/mergo v1.0.2 h1:85+piFYR1tMbRrLcDwR18y4UKJ3aH1Tbzi24VRW1TK8=


### PR DESCRIPTION
## Summary
Fixes `SA1019: "cloud.google.com/go/pubsub" is deprecated` by migrating the GCP event bus to `cloud.google.com/go/pubsub/v2`.

## Changes
- **`eventbus.go`**
  - Topic get/create via `TopicAdminClient.GetTopic` (NotFound check) + `CreateTopic` with `pubsubpb.Topic`.
  - Subscription get/create via `SubscriptionAdminClient` with `pubsubpb.Subscription` (full resource names, `AckDeadlineSeconds`, `durationpb` retry backoff).
  - Publishing via `*pubsub.Publisher` (`client.Publisher`), receiving via `*pubsub.Subscriber` (`client.Subscriber`).
  - Message ordering moved from topic to `Publisher.EnableMessageOrdering`.
  - `WithTopicOptions` now takes `*pubsubpb.Topic` instead of `*pubsub.TopicConfig`.
- **`eventbus_test.go`**: topic config type updated to `*pubsubpb.Topic`.
- **`go.mod`**: `pubsub/v2` promoted to direct, v1 dropped.

## Notes
- ⚠️ Breaking: `WithTopicOptions` signature changed (`*pubsub.TopicConfig` → `*pubsubpb.Topic`).

## Testing
- `go build` ✅
- `go vet` ✅
- `staticcheck` — SA1019 cleared ✅
- Integration tests require the pubsub emulator and were not run.