### PR TITLE
ci(release-please): add workflow_dispatch manual trigger

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
Adds a `workflow_dispatch` trigger to the Release Please workflow so it can be run manually from the GitHub Actions UI, in addition to the existing push-to-main trigger.